### PR TITLE
Benchmark for committing a tree with 1000 leaves

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -32,7 +32,6 @@ import (
 	"github.com/protolambda/go-kzg/bls"
 )
 
-
 func calcR(cs []*bls.G1Point, indices []*bls.Fr, ys []*bls.Fr) bls.Fr {
 	digest := sha256.New()
 	for _, c := range cs {

--- a/tree_test.go
+++ b/tree_test.go
@@ -253,7 +253,14 @@ func TestHashToFrTrailingZeroBytes(t *testing.T) {
 }
 
 func BenchmarkCommit1kLeaves(b *testing.B) {
-	n := 1000
+    benchmarkCommitNLeaves(b, 1000)
+}
+
+func BenchmarkCommit10kLeaves(b *testing.B) {
+    benchmarkCommitNLeaves(b, 10000)
+}
+
+func benchmarkCommitNLeaves(b *testing.B, n int) {
 	type kv struct {
 		k []byte
 		v []byte


### PR DESCRIPTION
(Comment updated with more comprehensive results, see below)

The result I'm getting:

```bash
❯ go test -v -run=BenchmarkCommit1kLeaves -tags bignum_hbls -bench=.
...
BenchmarkCommit1kLeaves/insert-8                       1        1451244411 ns/op        14297256 B/op      11412 allocs/op
BenchmarkCommit1kLeaves/insertOrdered-8                1        1486191367 ns/op        14445392 B/op      14381 allocs/op
```

And:

```bash
❯ go test -v -run=BenchmarkCommit1kLeaves -tags bignum_kilic -bench=.
BenchmarkCommit1kLeaves/insert-8                       2         705902770 ns/op        81831024 B/op     561279 allocs/op
BenchmarkCommit1kLeaves/insertOrdered-8                2         742656540 ns/op        84141580 B/op     576989 allocs/op
PASS
```

---

 UPDATE: We noticed that using LinCombG1 as per #3 vs the previous [implementation](https://github.com/gballet/go-verkle/blob/32361a96839c506fd794bf2565e94de53960923e/tree.go#L318-L328) (let's call it baseline) has a significant performance difference, with baseline often showing a speed-up of 2-3x. The main slowdown in LinCombG1 seems to stem from empty nodes. As suggested by @gballet I then benchmarked committing to one full node with 1024 children (i.e. no empty nodes) and there LinCombG1 does indeed perform better. Therefore the results include committing to a tree with 1000, 10000, and 100000 leaves, as well as a full node with 1024 leaves. Since runtime of the `Insert` and `InsertOrdered` approaches are similar I only include `Insert` results.:
 
|  | 1k kilic | 1k hbls | 10k kilic | 10k hbls | 100k kilic | 100k hbls | FullNode kilic | FullNode hbls |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| LinCombG1 (s) | 0.7  | 1.45 | 4 | 7 | 20 | 36 | 0.02 | 0.04 |
| Baseline (s)  | 0.14 | 0.12 | 1.3 | 1 | 13 | 9 | 0.11 | 0.08 |