### PR TITLE
Add bench for inserting 10k values in tree with 1M values

### DIFF
--- a/benchs/main.go
+++ b/benchs/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/gballet/go-verkle"
+	"github.com/protolambda/go-kzg"
+	"github.com/protolambda/go-kzg/bls"
+)
+
+var s1, lg1 []bls.G1Point
+var s2 []bls.G2Point
+var ks *kzg.KZGSettings
+
+// GenerateTestingSetupWithLagrange creates a setup of n values from the given secret,
+// along with the  **for testing purposes only**
+func GenerateTestingSetupWithLagrange(secret string, n uint64, fftCfg *kzg.FFTSettings) ([]bls.G1Point, []bls.G2Point, []bls.G1Point, error) {
+	var s bls.Fr
+	bls.SetFr(&s, secret)
+
+	var sPow bls.Fr
+	bls.CopyFr(&sPow, &bls.ONE)
+
+	s1Out := make([]bls.G1Point, n, n)
+	s2Out := make([]bls.G2Point, n, n)
+	for i := uint64(0); i < n; i++ {
+		bls.MulG1(&s1Out[i], &bls.GenG1, &sPow)
+		bls.MulG2(&s2Out[i], &bls.GenG2, &sPow)
+		var tmp bls.Fr
+		bls.CopyFr(&tmp, &sPow)
+		bls.MulModFr(&sPow, &tmp, &s)
+	}
+
+	s1Lagrange, err := fftCfg.FFTG1(s1Out, true)
+
+	return s1Out, s2Out, s1Lagrange, err
+}
+
+func main() {
+	var err error
+	fftCfg := kzg.NewFFTSettings(10)
+	s1, s2, lg1, err = GenerateTestingSetupWithLagrange("1927409816240961209460912649124", 1024, fftCfg)
+	if err != nil {
+		panic(err)
+	}
+	ks = kzg.NewKZGSettings(fftCfg, s1, s2)
+
+	benchmarkInsertInExisting()
+}
+
+func benchmarkInsertInExisting() {
+	// Number of existing leaves in tree
+	n := 1000000
+	// Leaves to be inserted afterwards
+	toInsert := 10000
+	total := n + toInsert
+
+	type kv struct {
+		k []byte
+		v []byte
+	}
+	kvs := make([]kv, toInsert)
+	rand.Seed(time.Now().UnixNano())
+
+	for i := 0; i < 10; i++ {
+		root := verkle.New()
+		for i := 0; i < total; i++ {
+			key := make([]byte, 32)
+			val := make([]byte, 32)
+			rand.Read(key)
+			rand.Read(val)
+			if i < n {
+				root.Insert(key, val)
+			} else {
+				kvs[i-n] = kv{k: key, v: val}
+			}
+		}
+		root.ComputeCommitment(ks, lg1)
+
+		start := time.Now()
+		for _, el := range kvs {
+			if err := root.Insert(el.k, el.v); err != nil {
+				panic(err)
+			}
+		}
+		root.ComputeCommitment(ks, lg1)
+		elapsed := time.Since(start)
+		fmt.Printf("Took %v to insert and commit %d leaves\n", elapsed, toInsert)
+	}
+}


### PR DESCRIPTION
The result of 10 runs is as follows. Note we're not using LinCombG1 (i.e. manually reverted #3) and bignum lib is hbls.

```
Took 88.370121ms to insert and commit 10000 leaves
Took 1.000353643s to insert and commit 10000 leaves
Took 89.519466ms to insert and commit 10000 leaves
Took 167.110938ms to insert and commit 10000 leaves
Took 94.143657ms to insert and commit 10000 leaves
Took 74.528575ms to insert and commit 10000 leaves
Took 31.913447ms to insert and commit 10000 leaves
Took 81.51628ms to insert and commit 10000 leaves
```