### PR TITLE
Produce the expected y

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -73,11 +73,17 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 
 	var s bls.Fr
 	bls.SetFr(&s, "1927409816240961209460912649124")
-	d, _, _ := MakeVerkleProofOneLeaf(root, zeroKeyTest, lg1)
+	d, y, _ := MakeVerkleProofOneLeaf(root, zeroKeyTest, lg1)
 
 	expectedD := common.Hex2Bytes("af768e1ff778c322455f0c4159d99f516cb944c6e87da099fa8c402cfda53001bd6417a185a179f2012d2e3ba780ca1b")
 
 	if !bytes.Equal(expectedD, bls.ToCompressedG1(d)) {
 		t.Fatalf("invalid D commitment, expected %x, got %x", expectedD, bls.ToCompressedG1(d))
+	}
+
+	expectedY := "29538444433028619980967897141357016680422322190427848339183478815792394204807"
+	gotY := bls.FrStr(y)
+	if expectedY != gotY {
+		t.Fatalf("invalid y, expected %s != %s", expectedY, gotY)
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -129,6 +129,7 @@ type (
 var modulus *big.Int
 var omegaIs [InternalNodeNumChildren]bls.Fr
 var inverses [InternalNodeNumChildren]bls.Fr
+var nodeWidthInversed bls.Fr
 
 func init() {
 	// Calculate the lagrangian evaluation basis.
@@ -152,6 +153,9 @@ func init() {
 		bls.SubModFr(&tmp, &bls.ONE, &omegaIs[i])
 		bls.DivModFr(&inverses[i], &bls.ONE, &tmp)
 	}
+
+	bls.AsFr(&nodeWidthInversed, InternalNodeNumChildren)
+	bls.InvModFr(&nodeWidthInversed, &nodeWidthInversed)
 }
 
 func newInternalNode(depth uint) VerkleNode {


### PR DESCRIPTION
Using `bls.EvalPoly` will evaluate `h` and `h` in coefficient form. They have to be evaluated in evaluation form.