### PR TITLE
Add serialization to nodes

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -75,6 +75,8 @@ type VerkleNode interface {
 	// is from the bottom of the tree, up to the root.
 	GetCommitmentsAlongPath([]byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr)
 
+	Flush(chan FlushableNode)
+
 	// Serialize encodes the node to RLP.
 	Serialize() ([]byte, error)
 }
@@ -494,6 +496,9 @@ func (n *leafNode) Hash() common.Hash {
 	return common.BytesToHash(digest.Sum(nil))
 }
 
+func (n *leafNode) Flush(chan FlushableNode) {
+}
+
 func (n *leafNode) Serialize() ([]byte, error) {
 	return rlp.EncodeToBytes([][]byte{n.key, n.value})
 }
@@ -532,6 +537,9 @@ func (n *hashedNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls
 	panic("can not get the full path, and there is no proof of absence")
 }
 
+func (n *hashedNode) Flush(chan FlushableNode) {
+}
+
 func (n *hashedNode) Serialize() ([]byte, error) {
 	return rlp.EncodeToBytes([][]byte{n.hash[:]})
 }
@@ -562,6 +570,9 @@ func (e empty) GetCommitment() *bls.G1Point {
 
 func (e empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
 	panic("trying to produce a commitment for an empty subtree")
+}
+
+func (e empty) Flush(chan FlushableNode) {
 }
 
 func (e empty) Serialize() ([]byte, error) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -92,9 +92,9 @@ func TestInsertIntoRoot(t *testing.T) {
 		t.Fatalf("error inserting: %v", err)
 	}
 
-	leaf, ok := root.(*internalNode).children[0].(*leafNode)
+	leaf, ok := root.(*InternalNode).children[0].(*leafNode)
 	if !ok {
-		t.Fatalf("invalid leaf node type %v", root.(*internalNode).children[0])
+		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[0])
 	}
 
 	if !bytes.Equal(leaf.value[:], testValue) {
@@ -107,14 +107,14 @@ func TestInsertTwoLeaves(t *testing.T) {
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	leaf0, ok := root.(*internalNode).children[0].(*leafNode)
+	leaf0, ok := root.(*InternalNode).children[0].(*leafNode)
 	if !ok {
-		t.Fatalf("invalid leaf node type %v", root.(*internalNode).children[0])
+		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[0])
 	}
 
-	leaff, ok := root.(*internalNode).children[1023].(*leafNode)
+	leaff, ok := root.(*InternalNode).children[1023].(*leafNode)
 	if !ok {
-		t.Fatalf("invalid leaf node type %v", root.(*internalNode).children[1023])
+		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[1023])
 	}
 
 	if !bytes.Equal(leaf0.value[:], testValue) {
@@ -232,19 +232,22 @@ func TestComputeRootCommitmentOnlineThreeLeavesFlush(t *testing.T) {
 		root.InsertOrdered(zeroKeyTest, testValue, ks, lg1, flush)
 		root.InsertOrdered(fourtyKeyTest, testValue, ks, lg1, flush)
 		root.InsertOrdered(ffx32KeyTest, testValue, ks, lg1, flush)
+		root.(*InternalNode).Flush(flush)
 		close(flush)
 	}()
 
 	count := 0
 	for f := range flush {
-		if _, ok := f.Node.(*leafNode); !ok {
+		_, isLeaf := f.Node.(*leafNode)
+		_, isInternal := f.Node.(*InternalNode)
+		if !isLeaf && !isInternal {
 			t.Fatal("invalid node type received, expected leaf")
 		}
 		count++
 	}
 
-	if count != 2 {
-		t.Fatalf("incorrect number of flushed leaves 2 != %d", count)
+	if count != 4 {
+		t.Fatalf("incorrect number of flushed leaves 4 != %d", count)
 	}
 }
 


### PR DESCRIPTION
Encode nodes via RLP. Internal nodes are handled specially by encoding a bitlist of which children are present and then a concatenation of non-empty children hashes.

Note that now the node hashes and their serialization have diverged..we should probably take care of that.

Also added the `Flush` method to the interface so can be called from downstream