### PR TITLE
Add node decoding support

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,90 @@
+package verkle
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const ErrInvalidNodeEncoding = "invalid node encoding"
+
+func ParseNode(serialized []byte, tc *TreeConfig) (VerkleNode, error) {
+	elems, _, err := rlp.SplitList(serialized)
+	if err != nil {
+		return nil, err
+	}
+	c, err := rlp.CountValues(elems)
+	if err != nil {
+		return nil, err
+	}
+
+	if c == 1 {
+		// HashedNode
+		hash, _, err := rlp.SplitString(elems)
+		if err != nil {
+			return nil, err
+		}
+		return &HashedNode{hash: common.BytesToHash(hash)}, nil
+	} else if c == 2 {
+		// either leaf or internal
+		kind, first, rest, err := rlp.Split(elems)
+		if err != nil {
+			return nil, err
+		}
+		if kind != rlp.String {
+			return nil, errors.New(ErrInvalidNodeEncoding)
+		}
+
+		if len(first) == 32 {
+			// leaf
+			value, _, err := rlp.SplitString(rest)
+			if err != nil {
+				return nil, err
+			}
+			return &LeafNode{key: first, value: value}, nil
+		} else if len(first) == 128 {
+			// internal
+			children, _, err := rlp.SplitString(rest)
+			if err != nil {
+				return nil, err
+			}
+			return createInternalNode(first, children, tc)
+		} else {
+			return nil, errors.New(ErrInvalidNodeEncoding)
+		}
+	} else {
+		return nil, errors.New(ErrInvalidNodeEncoding)
+	}
+	panic("unreachable")
+}
+
+func createInternalNode(bitlist []byte, raw []byte, tc *TreeConfig) (*InternalNode, error) {
+	// TODO: fix depth
+	n := (newInternalNode(0, tc)).(*InternalNode)
+	indices := indicesFromBitlist(bitlist)
+	if len(raw)/32 != len(indices) {
+		return nil, errors.New(ErrInvalidNodeEncoding)
+	}
+	for i, index := range indices {
+		n.children[index] = &HashedNode{hash: common.BytesToHash(raw[i*32 : (i+1)*32])}
+	}
+	return n, nil
+}
+
+func indicesFromBitlist(bitlist []byte) []int {
+	indices := make([]int, 0)
+	for i, b := range bitlist {
+		if b&0xff == 0x00 {
+			continue
+		}
+		for j := 0; j < 8; j++ {
+			mask := byte(1 << j)
+			if b&mask == mask {
+				index := i*8 + j
+				indices = append(indices, index)
+			}
+		}
+	}
+	return indices
+}

--- a/encoding.go
+++ b/encoding.go
@@ -21,11 +21,7 @@ func ParseNode(serialized []byte, tc *TreeConfig) (VerkleNode, error) {
 
 	if c == 1 {
 		// HashedNode
-		hash, _, err := rlp.SplitString(elems)
-		if err != nil {
-			return nil, err
-		}
-		return &HashedNode{hash: common.BytesToHash(hash)}, nil
+		panic("parsing hashed node is unsupported")
 	} else if c == 2 {
 		// either leaf or internal
 		kind, first, rest, err := rlp.Split(elems)

--- a/encoding.go
+++ b/encoding.go
@@ -56,7 +56,6 @@ func ParseNode(serialized []byte, tc *TreeConfig) (VerkleNode, error) {
 	} else {
 		return nil, errors.New(ErrInvalidNodeEncoding)
 	}
-	panic("unreachable")
 }
 
 func createInternalNode(bitlist []byte, raw []byte, tc *TreeConfig) (*InternalNode, error) {

--- a/encoding.go
+++ b/encoding.go
@@ -70,7 +70,7 @@ func createInternalNode(bitlist []byte, raw []byte, tc *TreeConfig) (*InternalNo
 func indicesFromBitlist(bitlist []byte) []int {
 	indices := make([]int, 0)
 	for i, b := range bitlist {
-		if b&0xff == 0x00 {
+		if b == 0 {
 			continue
 		}
 		for j := 0; j < 8; j++ {

--- a/tree.go
+++ b/tree.go
@@ -501,6 +501,16 @@ func (n *InternalNode) clearCache() {
 	n.commitment = nil
 }
 
+func (n *InternalNode) nonEmptyIndices() []int {
+	indices := make([]int, 0)
+	for i, c := range n.children {
+		if _, ok := c.(Empty); !ok {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
 func (n *LeafNode) Insert(k []byte, value []byte) error {
 	n.key = k
 	n.value = value

--- a/tree_test.go
+++ b/tree_test.go
@@ -589,7 +589,7 @@ func TestNodeSerde(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	res, err := ParseNode(rs, tc)
+	res, err := ParseNode(rs, 0, tc)
 	if err != nil {
 		t.Error(err)
 	}
@@ -602,7 +602,7 @@ func TestNodeSerde(t *testing.T) {
 		t.Error(err)
 	}
 
-	res, err = ParseNode(ls, tc)
+	res, err = ParseNode(ls, 1, tc)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Distinguishes between RLP-serialized node types and decodes them into their respective objects. I'm planning to move encoding logic from this repo to go-ethereum soon.