### PR TITLE
Implement the merge of accounts + storage tries

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -439,6 +439,13 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 }
 
 func (n *leafNode) Insert(k []byte, value []byte) error {
+	// The parent insert is expected to ensure that this
+	// situation doesn't occur. This check will catch an
+	// invalid situation while the library stabilizes.
+	if !bytes.Equal(k, n.key) {
+		return errors.New("inserting invalid key into key")
+	}
+
 	n.key = k
 	n.value = value
 	return nil


### PR DESCRIPTION
This is the go-verkle part of #16. It adds a new `accountLeaf` node that holds account data. `leafNode` is now used to represent storage slots and has to be 32-byte long.

Account nodes can't be written directly, they have to be created through the `CreateAccount` methods.