### PR TITLE
Export node types

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -110,24 +110,24 @@ type (
 		treeConfig *TreeConfig
 	}
 
-	hashedNode struct {
+	HashedNode struct {
 		hash       common.Hash
 		commitment *bls.G1Point
 	}
 
-	leafNode struct {
+	LeafNode struct {
 		key   []byte
 		value []byte
 	}
 
-	empty struct{}
+	Empty struct{}
 )
 
 func newInternalNode(depth int, tc *TreeConfig) VerkleNode {
 	node := new(InternalNode)
 	node.children = make([]VerkleNode, tc.nodeWidth)
 	for idx := range node.children {
-		node.children[idx] = empty(struct{}{})
+		node.children[idx] = Empty(struct{}{})
 	}
 	node.depth = depth
 	node.treeConfig = tc
@@ -174,6 +174,18 @@ func offset2KeyTenBits(key []byte, offset int) uint {
 	return ret
 }
 
+func (n *InternalNode) Children() []VerkleNode {
+	return n.children
+}
+
+func (n *InternalNode) SetChild(i int, c VerkleNode) error {
+	if i >= n.treeConfig.nodeWidth-1 {
+		return errors.New("child index higher than node width")
+	}
+	n.children[i] = c
+	return nil
+}
+
 func (n *InternalNode) Insert(key []byte, value []byte) error {
 	// Clear cached commitment on modification
 	if n.commitment != nil {
@@ -183,11 +195,11 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 	nChild := offset2Key(key, n.depth, n.treeConfig.width)
 
 	switch child := n.children[nChild].(type) {
-	case empty:
-		n.children[nChild] = &leafNode{key: key, value: value}
-	case *hashedNode:
+	case Empty:
+		n.children[nChild] = &LeafNode{key: key, value: value}
+	case *HashedNode:
 		return errInsertIntoHash
-	case *leafNode:
+	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.
 		// Otherwise, just update the key.
@@ -208,7 +220,7 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 			if nextWordInInsertedKey != nextWordInExistingKey {
 				// Next word differs, so this was the last level.
 				// Insert it directly into its final slot.
-				newBranch.children[nextWordInInsertedKey] = &leafNode{key: key, value: value}
+				newBranch.children[nextWordInInsertedKey] = &LeafNode{key: key, value: value}
 			} else {
 				newBranch.Insert(key, value)
 			}
@@ -228,22 +240,22 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush chan Flusha
 	nChild := offset2Key(key, n.depth, n.treeConfig.width)
 
 	switch child := n.children[nChild].(type) {
-	case empty:
+	case Empty:
 		// Insert into a new subtrie, which means that the
 		// subtree directly preceding this new one, can
 		// safely be calculated.
 		for i := int(nChild) - 1; i >= 0; i-- {
 			switch n.children[i].(type) {
-			case empty:
+			case Empty:
 				continue
-			case *leafNode:
+			case *LeafNode:
 				childHash := n.children[i].Hash()
 				if flush != nil {
 					flush <- FlushableNode{childHash, n.children[i]}
 				}
-				n.children[i] = &hashedNode{hash: childHash}
+				n.children[i] = &HashedNode{hash: childHash}
 				break
-			case *hashedNode:
+			case *HashedNode:
 				break
 			default:
 				comm := n.children[i].ComputeCommitment()
@@ -252,15 +264,15 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush chan Flusha
 				if flush != nil {
 					n.children[i].(*InternalNode).Flush(flush)
 				}
-				n.children[i] = &hashedNode{hash: h, commitment: comm}
+				n.children[i] = &HashedNode{hash: h, commitment: comm}
 				break
 			}
 		}
 
-		n.children[nChild] = &leafNode{key: key, value: value}
-	case *hashedNode:
+		n.children[nChild] = &LeafNode{key: key, value: value}
+	case *HashedNode:
 		return errInsertIntoHash
-	case *leafNode:
+	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.
 		// Otherwise, just update the key.
@@ -288,10 +300,10 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush chan Flusha
 				if flush != nil {
 					flush <- FlushableNode{h, child}
 				}
-				newBranch.children[nextWordInExistingKey] = &hashedNode{hash: h, commitment: comm}
+				newBranch.children[nextWordInExistingKey] = &HashedNode{hash: h, commitment: comm}
 				// Next word differs, so this was the last level.
 				// Insert it directly into its final slot.
-				newBranch.children[nextWordInInsertedKey] = &leafNode{key: key, value: value}
+				newBranch.children[nextWordInInsertedKey] = &LeafNode{key: key, value: value}
 			} else {
 				// Reinsert the leaf in order to recurse
 				newBranch.children[nextWordInExistingKey] = child
@@ -305,16 +317,16 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush chan Flusha
 }
 
 // Flush hashes the children of an internal node and replaces them
-// with hashedNode. It also sends the current node on the flush channel.
+// with HashedNode. It also sends the current node on the flush channel.
 func (n *InternalNode) Flush(flush chan FlushableNode) {
 	for i, child := range n.children {
 		if c, ok := child.(*InternalNode); ok {
 			c.Flush(flush)
-			n.children[i] = &hashedNode{c.Hash(), c.commitment}
-		} else if c, ok := child.(*leafNode); ok {
+			n.children[i] = &HashedNode{c.Hash(), c.commitment}
+		} else if c, ok := child.(*LeafNode); ok {
 			childHash := c.Hash()
 			flush <- FlushableNode{childHash, c}
-			n.children[i] = &hashedNode{hash: childHash}
+			n.children[i] = &HashedNode{hash: childHash}
 		}
 	}
 	flush <- FlushableNode{n.Hash(), n}
@@ -324,7 +336,7 @@ func (n *InternalNode) Get(k []byte) ([]byte, error) {
 	nChild := offset2Key(k, n.depth, n.treeConfig.width)
 
 	switch child := n.children[nChild].(type) {
-	case empty, *hashedNode, nil:
+	case Empty, *HashedNode, nil:
 		return nil, errors.New("trying to read from an invalid child")
 	default:
 		return child.Get(k)
@@ -377,9 +389,9 @@ func (n *InternalNode) ComputeCommitment() *bls.G1Point {
 	poly := make([]bls.Fr, n.treeConfig.nodeWidth)
 	for idx, childC := range n.children {
 		switch child := childC.(type) {
-		case empty:
+		case Empty:
 			emptyChildren++
-		case *leafNode, *hashedNode:
+		case *LeafNode, *HashedNode:
 			hashToFr(&poly[idx], child.Hash(), n.treeConfig.modulus)
 		default:
 			compressed := bls.ToCompressedG1(childC.ComputeCommitment())
@@ -430,7 +442,7 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 	var bitlist [128]uint8
 	children := make([]byte, 0, n.treeConfig.nodeWidth*32)
 	for i, c := range n.children {
-		if _, ok := c.(empty); !ok {
+		if _, ok := c.(Empty); !ok {
 			setBit(bitlist[:], i)
 			children = append(children, c.Hash().Bytes()...)
 		}
@@ -438,13 +450,13 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 	return rlp.EncodeToBytes([]interface{}{bitlist, children})
 }
 
-func (n *leafNode) Insert(k []byte, value []byte) error {
+func (n *LeafNode) Insert(k []byte, value []byte) error {
 	n.key = k
 	n.value = value
 	return nil
 }
 
-func (n *leafNode) InsertOrdered(key []byte, value []byte, flush chan FlushableNode) error {
+func (n *LeafNode) InsertOrdered(key []byte, value []byte, flush chan FlushableNode) error {
 	err := n.Insert(key, value)
 	if err != nil && flush != nil {
 		flush <- FlushableNode{n.Hash(), n}
@@ -452,53 +464,53 @@ func (n *leafNode) InsertOrdered(key []byte, value []byte, flush chan FlushableN
 	return err
 }
 
-func (n *leafNode) Get(k []byte) ([]byte, error) {
+func (n *LeafNode) Get(k []byte) ([]byte, error) {
 	if !bytes.Equal(k, n.key) {
 		return nil, errValueNotPresent
 	}
 	return n.value, nil
 }
 
-func (n *leafNode) ComputeCommitment() *bls.G1Point {
+func (n *LeafNode) ComputeCommitment() *bls.G1Point {
 	panic("can't compute the commitment directly")
 }
 
-func (n *leafNode) GetCommitment() *bls.G1Point {
+func (n *LeafNode) GetCommitment() *bls.G1Point {
 	panic("can't get the commitment directly")
 }
 
-func (n *leafNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
+func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
 	return nil, nil, nil, nil
 }
 
-func (n *leafNode) Hash() common.Hash {
+func (n *LeafNode) Hash() common.Hash {
 	digest := sha256.New()
 	digest.Write(n.key)
 	digest.Write(n.value)
 	return common.BytesToHash(digest.Sum(nil))
 }
 
-func (n *leafNode) Serialize() ([]byte, error) {
+func (n *LeafNode) Serialize() ([]byte, error) {
 	return rlp.EncodeToBytes([][]byte{n.key, n.value})
 }
 
-func (n *hashedNode) Insert(k []byte, value []byte) error {
+func (n *HashedNode) Insert(k []byte, value []byte) error {
 	return errInsertIntoHash
 }
 
-func (n *hashedNode) InsertOrdered(key []byte, value []byte, _ chan FlushableNode) error {
+func (n *HashedNode) InsertOrdered(key []byte, value []byte, _ chan FlushableNode) error {
 	return errInsertIntoHash
 }
 
-func (n *hashedNode) Get(k []byte) ([]byte, error) {
+func (n *HashedNode) Get(k []byte) ([]byte, error) {
 	return nil, errors.New("can not read from a hash node")
 }
 
-func (n *hashedNode) Hash() common.Hash {
+func (n *HashedNode) Hash() common.Hash {
 	return n.hash
 }
 
-func (n *hashedNode) ComputeCommitment() *bls.G1Point {
+func (n *HashedNode) ComputeCommitment() *bls.G1Point {
 	if n.commitment == nil {
 		var hashAsFr bls.Fr
 		hashToFr(&hashAsFr, n.hash, big.NewInt(0))
@@ -508,47 +520,47 @@ func (n *hashedNode) ComputeCommitment() *bls.G1Point {
 	return n.commitment
 }
 
-func (n *hashedNode) GetCommitment() *bls.G1Point {
+func (n *HashedNode) GetCommitment() *bls.G1Point {
 	return n.commitment
 }
 
-func (n *hashedNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
+func (n *HashedNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
 	panic("can not get the full path, and there is no proof of absence")
 }
 
-func (n *hashedNode) Serialize() ([]byte, error) {
+func (n *HashedNode) Serialize() ([]byte, error) {
 	return rlp.EncodeToBytes([][]byte{n.hash[:]})
 }
 
-func (e empty) Insert(k []byte, value []byte) error {
+func (e Empty) Insert(k []byte, value []byte) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
 
-func (e empty) InsertOrdered(key []byte, value []byte, _ chan FlushableNode) error {
+func (e Empty) InsertOrdered(key []byte, value []byte, _ chan FlushableNode) error {
 	return e.Insert(key, value)
 }
 
-func (e empty) Get(k []byte) ([]byte, error) {
+func (e Empty) Get(k []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func (e empty) Hash() common.Hash {
+func (e Empty) Hash() common.Hash {
 	return zeroHash
 }
 
-func (e empty) ComputeCommitment() *bls.G1Point {
+func (e Empty) ComputeCommitment() *bls.G1Point {
 	return &bls.ZeroG1
 }
 
-func (e empty) GetCommitment() *bls.G1Point {
+func (e Empty) GetCommitment() *bls.G1Point {
 	return &bls.ZeroG1
 }
 
-func (e empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
+func (e Empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
 	panic("trying to produce a commitment for an empty subtree")
 }
 
-func (e empty) Serialize() ([]byte, error) {
+func (e Empty) Serialize() ([]byte, error) {
 	return nil, errors.New("can't encode empty node to RLP")
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -57,7 +57,7 @@ func TestInsertIntoRoot(t *testing.T) {
 		t.Fatalf("error inserting: %v", err)
 	}
 
-	leaf, ok := root.(*InternalNode).children[0].(*leafNode)
+	leaf, ok := root.(*InternalNode).children[0].(*LeafNode)
 	if !ok {
 		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[0])
 	}
@@ -72,12 +72,12 @@ func TestInsertTwoLeaves(t *testing.T) {
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	leaf0, ok := root.(*InternalNode).children[0].(*leafNode)
+	leaf0, ok := root.(*InternalNode).children[0].(*LeafNode)
 	if !ok {
 		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[0])
 	}
 
-	leaff, ok := root.(*InternalNode).children[1023].(*leafNode)
+	leaff, ok := root.(*InternalNode).children[1023].(*LeafNode)
 	if !ok {
 		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[1023])
 	}
@@ -203,7 +203,7 @@ func TestComputeRootCommitmentOnlineThreeLeavesFlush(t *testing.T) {
 
 	count := 0
 	for f := range flush {
-		_, isLeaf := f.Node.(*leafNode)
+		_, isLeaf := f.Node.(*LeafNode)
 		_, isInternal := f.Node.(*InternalNode)
 		if !isLeaf && !isInternal {
 			t.Fatal("invalid node type received, expected leaf")
@@ -332,7 +332,7 @@ func TestFlush1kLeaves(t *testing.T) {
 	count := 0
 	leaves := 0
 	for f := range flush {
-		_, isLeaf := f.Node.(*leafNode)
+		_, isLeaf := f.Node.(*LeafNode)
 		_, isInternal := f.Node.(*InternalNode)
 		if !isLeaf && !isInternal {
 			t.Fatal("invalid node type received, expected leaf")


### PR DESCRIPTION
I had made these changes for the purposes of resolving nodes from the database, but I just realized if we want to move encoding out of this repo then we'll need to make the fields also public. Wdyt?