### PR TITLE
Naive multiproof implementation

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -90,7 +90,7 @@ func ComputeKZGProof(tc *TreeConfig, poly []bls.Fr, z, y *bls.Fr) *bls.G1Point {
 	return kzg.CommitToEvalPoly(tc.lg1, oq)
 }
 
-func MakeVerkleProofOneLeaf(root VerkleNode, key []byte) (d *bls.G1Point, y *bls.Fr, sigma *bls.G1Point) {
+func MakeVerkleProof(root VerkleNode, keys [][]byte) (d *bls.G1Point, y *bls.Fr, sigma *bls.G1Point) {
 	var tc *TreeConfig
 	if root, ok := root.(*InternalNode); !ok {
 		panic("no tree config")
@@ -99,7 +99,7 @@ func MakeVerkleProofOneLeaf(root VerkleNode, key []byte) (d *bls.G1Point, y *bls
 	}
 
 	var fis [][]bls.Fr
-	commitments, zis, yis, fis := root.GetCommitmentsAlongPath(key)
+	commitments, zis, yis, fis := root.GetCommitmentsAlongPaths(keys)
 
 	// Construct g(x)
 	r := calcR(commitments, zis, yis, tc.modulus)

--- a/proof_test.go
+++ b/proof_test.go
@@ -46,7 +46,7 @@ func TestProofGenerationTwoLeaves(t *testing.T) {
 
 	var s bls.Fr
 	bls.SetFr(&s, "1927409816240961209460912649124")
-	d, y, sigma := MakeVerkleProofOneLeaf(root, zeroKeyTest)
+	d, y, sigma := MakeVerkleProof(root, [][]byte{zeroKeyTest})
 
 	expectedD := common.Hex2Bytes("af768e1ff778c322455f0c4159d99f516cb944c6e87da099fa8c402cfda53001bd6417a185a179f2012d2e3ba780ca1b")
 
@@ -89,9 +89,9 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 	// Calculate all commitments
 	root.ComputeCommitment()
 
-	d, y, sigma := MakeVerkleProofOneLeaf(root, zeroKeyTest)
+	d, y, sigma := MakeVerkleProof(root, [][]byte{zeroKeyTest})
 
-	comms, zis, yis, _ := root.GetCommitmentsAlongPath(zeroKeyTest)
+	comms, zis, yis, _ := root.GetCommitmentsAlongPaths([][]byte{zeroKeyTest})
 	if !VerifyVerkleProof(ks, d, sigma, y, comms, zis, yis, tc) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -125,7 +125,7 @@ func BenchmarkProofCalculation(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		MakeVerkleProofOneLeaf(root, keys[len(keys)/2])
+		MakeVerkleProof(root, [][]byte{keys[len(keys)/2]})
 	}
 }
 
@@ -160,8 +160,8 @@ func BenchmarkProofVerification(b *testing.B) {
 	// Calculate all commitments
 	root.ComputeCommitment()
 
-	comms, zis, yis, _ := root.GetCommitmentsAlongPath(keys[len(keys)/2])
-	d, y, sigma := MakeVerkleProofOneLeaf(root, keys[len(keys)/2])
+	comms, zis, yis, _ := root.GetCommitmentsAlongPaths(keys[len(keys)/2 : len(keys)/2+1])
+	d, y, sigma := MakeVerkleProof(root, [][]byte{keys[len(keys)/2]})
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/tree_test.go
+++ b/tree_test.go
@@ -434,7 +434,7 @@ func TestClearCache(t *testing.T) {
 		t.Error("internal child's cached commitment should have been cleared")
 	}
 }
-  
+
 func TestGetCommitmentAlongPathS(t *testing.T) {
 	value := []byte("value")
 	key1 := common.Hex2Bytes("0105000000000000000000000000000000000000000000000000000000000000")

--- a/tree_test.go
+++ b/tree_test.go
@@ -449,8 +449,8 @@ func TestGetCommitmentAlongPathS(t *testing.T) {
 	tree.ComputeCommitment()
 
 	cs, zs, ys, fs := tree.GetCommitmentsAlongPaths([][]byte{key3, key4})
-	if len(cs) != 2 {
-		t.Fatalf("invalid number of commitments 2 != %d", len(cs))
+	if len(cs) != 4 {
+		t.Fatalf("invalid number of commitments 4 != %d", len(cs))
 	}
 	if len(zs) != 4 {
 		t.Fatalf("invalid number of zis 4 != %d", len(zs))

--- a/tree_test.go
+++ b/tree_test.go
@@ -381,6 +381,34 @@ func TestCachedCommitment(t *testing.T) {
 	}
 }
 
+func TestGetCommitmentAlongPathS(t *testing.T) {
+	value := []byte("value")
+	key1 := common.Hex2Bytes("0105000000000000000000000000000000000000000000000000000000000000")
+	key2 := common.Hex2Bytes("0107000000000000000000000000000000000000000000000000000000000000")
+	key3 := common.Hex2Bytes("0405000000000000000000000000000000000000000000000000000000000000")
+	key4 := common.Hex2Bytes("0407000000000000000000000000000000000000000000000000000000000000")
+	tree := New(8)
+	tree.Insert(key1, value)
+	tree.Insert(key2, value)
+	tree.Insert(key3, value)
+	tree.Insert(key4, value)
+	tree.ComputeCommitment()
+
+	cs, zs, ys, fs := tree.GetCommitmentsAlongPaths([][]byte{key3, key4})
+	if len(cs) != 2 {
+		t.Fatalf("invalid number of commitments 2 != %d", len(cs))
+	}
+	if len(zs) != 4 {
+		t.Fatalf("invalid number of zis 4 != %d", len(zs))
+	}
+	if len(ys) != 4 {
+		t.Fatalf("invalid number of yis 4 != %d", len(ys))
+	}
+	if len(fs) != 4 {
+		t.Fatalf("invalid number of fis 4 != %d", len(fs))
+	}
+}
+
 func BenchmarkCommitLeaves(b *testing.B) {
 	benchmarkCommitNLeaves(b, 1000, 10)
 	benchmarkCommitNLeaves(b, 10000, 10)


### PR DESCRIPTION
Change function signatures to accept multiple keys. The proof elements for each key are calculated independently, and then these results are naively concatenated.

In the implementation, only the  root will have multiple keys as an argument, and then each subtree will receive an array containing only one value, thus duplicating values for nodes having more than one child in the proof.