### PR TITLE
Add a method to copy trees

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -551,6 +551,8 @@ func (n *LeafNode) Serialize() ([]byte, error) {
 
 func (n *LeafNode) Copy() VerkleNode {
 	l := &LeafNode{}
+	l.key = make([]byte, len(n.key))
+	l.value = make([]byte, len(n.value))
 	copy(l.key, n.key)
 	copy(l.value, n.value)
 

--- a/tree.go
+++ b/tree.go
@@ -76,6 +76,9 @@ type VerkleNode interface {
 
 	// Serialize encodes the node to RLP.
 	Serialize() ([]byte, error)
+
+	// Copy a node and its children
+	Copy() VerkleNode
 }
 
 const (
@@ -566,6 +569,16 @@ func (n *HashedNode) Serialize() ([]byte, error) {
 	return rlp.EncodeToBytes([][]byte{n.hash[:]})
 }
 
+func (n *hashedNode) Copy() VerkleNode {
+	h := &hashedNode{
+		commitment: new(bls.G1Point),
+	}
+	copy(h.hash[:], n.hash[:])
+	bls.CopyG1(h.commitment, n.commitment)
+
+	return h
+}
+
 func (e Empty) Insert(k []byte, value []byte) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
@@ -596,6 +609,10 @@ func (e Empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, [
 
 func (e Empty) Serialize() ([]byte, error) {
 	return nil, errors.New("can't encode empty node to RLP")
+}
+
+func (e Empty) Copy() VerkleNode {
+	return empty(struct{}{})
 }
 
 func setBit(bitlist []uint8, index int) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -367,8 +367,9 @@ func TestCopy(t *testing.T) {
 	tree.ComputeCommitment()
 
 	copied := tree.Copy()
+	copied.(*InternalNode).clearCache()
 
-	if !bytes.Equal(bls.ToCompressedG1(copied.GetCommitment()), bls.ToCompressedG1(tree.GetCommitment())) {
+	if !bytes.Equal(bls.ToCompressedG1(copied.ComputeCommitment()), bls.ToCompressedG1(tree.ComputeCommitment())) {
 		t.Fatal("error copying commitments")
 	}
 	if copied.Hash() != tree.Hash() {

--- a/tree_test.go
+++ b/tree_test.go
@@ -355,6 +355,32 @@ func TestFlush1kLeaves(t *testing.T) {
 	}
 }
 
+func TestCopy(t *testing.T) {
+	value := []byte("value")
+	key1 := common.Hex2Bytes("0105000000000000000000000000000000000000000000000000000000000000")
+	key2 := common.Hex2Bytes("0107000000000000000000000000000000000000000000000000000000000000")
+	key3 := common.Hex2Bytes("0405000000000000000000000000000000000000000000000000000000000000")
+	tree := New(8)
+	tree.Insert(key1, value)
+	tree.Insert(key2, value)
+	tree.Insert(key3, value)
+	tree.ComputeCommitment()
+
+	copied := tree.Copy()
+
+	if !bytes.Equal(bls.ToCompressedG1(copied.GetCommitment()), bls.ToCompressedG1(tree.GetCommitment())) {
+		t.Fatal("error copying commitments")
+	}
+	if copied.Hash() != tree.Hash() {
+		t.Fatal("error copying commitments")
+	}
+	tree.Insert(key2, []byte("changed"))
+	tree.ComputeCommitment()
+	if bytes.Equal(bls.ToCompressedG1(copied.GetCommitment()), bls.ToCompressedG1(tree.GetCommitment())) {
+		t.Fatal("error tree and its copy should have a different commitment after the update")
+	}
+}
+
 func TestCachedCommitment(t *testing.T) {
 	value := []byte("value")
 	key1 := common.Hex2Bytes("0105000000000000000000000000000000000000000000000000000000000000")


### PR DESCRIPTION
`geth` is making copies of the tree every time a new transaction is executed, in the event that it is reverted. Introduce the `Copy()` helper function, that does this.