### PR TITLE
match geth's behavior: return nil on non-existing key

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -107,8 +107,11 @@ func TestGetTwoLeaves(t *testing.T) {
 	}
 
 	val, err = root.Get(oneKeyTest)
-	if err != errValueNotPresent {
-		t.Fatalf("wrong error type, expected %v, got %v", errValueNotPresent, err)
+	if err != nil {
+		t.Fatalf("wrong error type, expected %v, got %v", nil, err)
+	}
+	if val != nil {
+		t.Fatalf("Get returned value %x for a non-existing key", val)
 	}
 
 	if val != nil {


### PR DESCRIPTION
In Geth, the `SecureTrie` will return `nil` when one tries to `Get` a value that is absent from the trie. This PR makes Verkle trees adopt the same behavior.