### PR TITLE
Encoding fixes

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -9,7 +9,7 @@ import (
 
 const ErrInvalidNodeEncoding = "invalid node encoding"
 
-func ParseNode(serialized []byte, depth int, tc *TreeConfig) (VerkleNode, error) {
+func ParseNode(serialized []byte, depth, width int) (VerkleNode, error) {
 	elems, _, err := rlp.SplitList(serialized)
 	if err != nil {
 		return nil, err
@@ -47,13 +47,16 @@ func ParseNode(serialized []byte, depth int, tc *TreeConfig) (VerkleNode, error)
 		if err != nil {
 			return nil, err
 		}
-		return createInternalNode(first, children, depth, tc)
+		return createInternalNode(first, children, depth, width)
 	default:
 		return nil, errors.New(ErrInvalidNodeEncoding)
 	}
 }
 
-func createInternalNode(bitlist []byte, raw []byte, depth int, tc *TreeConfig) (*InternalNode, error) {
+func createInternalNode(bitlist []byte, raw []byte, depth, width int) (*InternalNode, error) {
+	// GetTreeConfig caches computation result, hence
+	// this op has low overhead
+	tc := GetTreeConfig(width)
 	n := (newInternalNode(depth, tc)).(*InternalNode)
 	indices := indicesFromBitlist(bitlist)
 	if len(raw)/32 != len(indices) {

--- a/tree.go
+++ b/tree.go
@@ -86,6 +86,11 @@ const (
 	// computing commitment. Number refers to non-zero
 	// children in a node.
 	multiExpThreshold = 110
+
+	// These types will distinguish internal
+	// and leaf nodes when decoding from RLP.
+	internalRLPType byte = 1
+	leafRLPType     byte = 2
 )
 
 var (
@@ -467,7 +472,7 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 			children = append(children, c.Hash().Bytes()...)
 		}
 	}
-	return rlp.EncodeToBytes([]interface{}{bitlist, children})
+	return rlp.EncodeToBytes([]interface{}{internalRLPType, bitlist, children})
 }
 
 func (n *InternalNode) Copy() VerkleNode {
@@ -556,7 +561,7 @@ func (n *LeafNode) Hash() common.Hash {
 }
 
 func (n *LeafNode) Serialize() ([]byte, error) {
-	return rlp.EncodeToBytes([][]byte{n.key, n.value})
+	return rlp.EncodeToBytes([]interface{}{leafRLPType, n.key, n.value})
 }
 
 func (n *LeafNode) Copy() VerkleNode {

--- a/tree_test.go
+++ b/tree_test.go
@@ -579,11 +579,11 @@ func randomKeysSorted(n int) [][]byte {
 }
 
 func TestNodeSerde(t *testing.T) {
-	tree := New(10)
+	width := 10
+	tree := New(width)
 	tree.Insert(zeroKeyTest, testValue)
 	tree.Insert(fourtyKeyTest, testValue)
 	root := tree.(*InternalNode)
-	tc := root.treeConfig
 
 	// Serialize all the nodes
 	leaf0 := (root.children[0]).(*LeafNode)
@@ -604,19 +604,19 @@ func TestNodeSerde(t *testing.T) {
 	}
 
 	// Now deserialize and re-construct tree
-	res, err := ParseNode(ls0, 1, tc)
+	res, err := ParseNode(ls0, 1, width)
 	if err != nil {
 		t.Error(err)
 	}
 	resLeaf0 := res.(*LeafNode)
 
-	res, err = ParseNode(ls256, 1, tc)
+	res, err = ParseNode(ls256, 1, width)
 	if err != nil {
 		t.Error(err)
 	}
 	resLeaf256 := res.(*LeafNode)
 
-	res, err = ParseNode(rs, 0, tc)
+	res, err = ParseNode(rs, 0, width)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
* Pass width as parameter to `ParseNode` instead of tree config
* Add type to the serialization of leaf and internal nodes