### PR TITLE
Fix deletion pruning

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -360,6 +360,9 @@ func (n *InternalNode) Delete(key []byte) error {
 		return nil
 	default:
 		child.Delete(key)
+		if len(child.(*InternalNode).nonEmptyIndices()) == 0 {
+			n.children[nChild] = Empty{}
+		}
 	}
 	return nil
 }

--- a/tree.go
+++ b/tree.go
@@ -360,8 +360,14 @@ func (n *InternalNode) Delete(key []byte) error {
 		return nil
 	default:
 		child.Delete(key)
-		if len(child.(*InternalNode).nonEmptyIndices()) == 0 {
+		// Prune child if necessary
+		nonEmpty := child.(*InternalNode).nonEmptyIndices()
+		switch len(nonEmpty) {
+		case 0:
 			n.children[nChild] = Empty{}
+		case 1:
+			n.children[nChild] = child.(*InternalNode).children[nonEmpty[0]]
+		default:
 		}
 	}
 	return nil

--- a/tree_test.go
+++ b/tree_test.go
@@ -476,6 +476,32 @@ func TestDeleteNonExistent(t *testing.T) {
 	}
 }
 
+func TestDeletePrune(t *testing.T) {
+	value := []byte("value")
+	key1 := common.Hex2Bytes("0105000000000000000000000000000000000000000000000000000000000000")
+	key2 := common.Hex2Bytes("0107000000000000000000000000000000000000000000000000000000000000")
+	key3 := common.Hex2Bytes("0405000000000000000000000000000000000000000000000000000000000000")
+	key4 := common.Hex2Bytes("0407000000000000000000000000000000000000000000000000000000000000")
+	tree := New(8)
+	tree.Insert(key1, value)
+	tree.Insert(key2, value)
+	hash := tree.Hash()
+
+	tree.Insert(key3, value)
+	tree.Insert(key4, value)
+	if err := tree.Delete(key3); err != nil {
+		t.Error(err)
+	}
+	if err := tree.Delete(key4); err != nil {
+		t.Error(err)
+	}
+
+	postHash := tree.Hash()
+	if !bytes.Equal(hash.Bytes(), postHash.Bytes()) {
+		t.Error("deleting leaf resulted in unexpected tree")
+	}
+}
+
 func BenchmarkCommitLeaves(b *testing.B) {
 	benchmarkCommitNLeaves(b, 1000, 10)
 	benchmarkCommitNLeaves(b, 10000, 10)

--- a/tree_test.go
+++ b/tree_test.go
@@ -485,19 +485,25 @@ func TestDeletePrune(t *testing.T) {
 	tree := New(8)
 	tree.Insert(key1, value)
 	tree.Insert(key2, value)
-	hash := tree.Hash()
 
+	hash1 := tree.Hash()
 	tree.Insert(key3, value)
+	hash2 := tree.Hash()
 	tree.Insert(key4, value)
-	if err := tree.Delete(key3); err != nil {
-		t.Error(err)
-	}
+
 	if err := tree.Delete(key4); err != nil {
 		t.Error(err)
 	}
-
 	postHash := tree.Hash()
-	if !bytes.Equal(hash.Bytes(), postHash.Bytes()) {
+	if !bytes.Equal(hash2.Bytes(), postHash.Bytes()) {
+		t.Error("deleting leaf resulted in unexpected tree")
+	}
+
+	if err := tree.Delete(key3); err != nil {
+		t.Error(err)
+	}
+	postHash = tree.Hash()
+	if !bytes.Equal(hash1.Bytes(), postHash.Bytes()) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 }


### PR DESCRIPTION
Handles the cases where after deletion an internal node becomes empty and can be itself deleted, and the case where an internal node will have one remaining node which will in turn replace its parent.