### PR TITLE
copy: only copy commitments if they have been calculated in hash/internal

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -516,7 +516,9 @@ func (n *InternalNode) Copy() VerkleNode {
 	}
 
 	copy(ret.hash[:], n.hash[:])
-	bls.CopyG1(ret.commitment, n.commitment)
+	if n.commitment != nil {
+		bls.CopyG1(ret.commitment, n.commitment)
+	}
 
 	return ret
 }
@@ -661,7 +663,9 @@ func (n *HashedNode) Copy() VerkleNode {
 		commitment: new(bls.G1Point),
 	}
 	copy(h.hash[:], n.hash[:])
-	bls.CopyG1(h.commitment, n.commitment)
+	if n.commitment != nil {
+		bls.CopyG1(h.commitment, n.commitment)
+	}
 
 	return h
 }


### PR DESCRIPTION
Check that the commitments are not `nil` and if so, copy the commitment to the destination tree.

Another option would be to error, but so far in my geth experiments it seems that it's better not to recalculate the commitments each time that the trie is updated.