### PR TITLE
[DONOTMERGE] chop off MSB in hash to field element conversion

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -449,26 +449,11 @@ func (n *InternalNode) Hash() common.Hash {
 // This piece of code is really ugly, and probably a performance hog, it
 // needs to be rewritten more efficiently.
 func hashToFr(out *bls.Fr, h [32]byte, modulus *big.Int) {
-	var h2 [32]byte
-	// reverse endianness
-	for i := range h {
-		h2[i] = h[len(h)-i-1]
-	}
+	// set first byte to 0 so as not to have to calculate the modulus
 
-	// Apply modulus
-	x := big.NewInt(0).SetBytes(h2[:])
-	x.Mod(x, modulus)
 
-	// clear the buffer in case the trailing bytes were 0
-	for i := 0; i < 32; i++ {
-		h2[i] = 0
-	}
-	copy(h2[32-len(x.Bytes()):], x.Bytes())
 
-	// back to original endianness
-	for i := range h2 {
-		h[i] = h2[len(h)-i-1]
-	}
+	h[31] = 0
 
 	if !bls.FrFrom32(out, h) {
 		panic(fmt.Sprintf("invalid Fr number %x", h))


### PR DESCRIPTION
This is part of the investigation in #37 

In order to get an idea of how much of the lack of performance of `hashFr` is due to the over-convoluted modulus calculation, and how much is due to go-kzg's `FrFrom32` implementation, I just set the most significant byte to 0, and checked the difference of performance between herumi and kilic:

Herumi:
```
goos: freebsd
goarch: amd64
pkg: github.com/gballet/go-verkle
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkCommitLeaves/insert/leaves/1000/width/10-8         	      10	 116061103 ns/op	13435892 B/op	    7376 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/1000/width/10-8  	       8	 132291504 ns/op	13545084 B/op	    9431 allocs/op
BenchmarkCommitLeaves/insert/leaves/10000/width/10-8        	       1	1152875811 ns/op	57321696 B/op	   68666 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/10000/width/10-8 	       1	1404537099 ns/op	58049520 B/op	   82938 allocs/op
BenchmarkCommitLeaves/insert/leaves/1000/width/8-8          	      12	  94608800 ns/op	 3492536 B/op	    7920 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/1000/width/8-8   	       9	 128128625 ns/op	 3595922 B/op	    9875 allocs/op
BenchmarkCommitLeaves/insert/leaves/10000/width/8-8         	       1	1033121942 ns/op	16602592 B/op	   69102 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/10000/width/8-8  	       1	1467990167 ns/op	17300160 B/op	   82853 allocs/op
BenchmarkCommitFullNode/width/10-8                          	      18	  63494421 ns/op	  188640 B/op	    4100 allocs/op
BenchmarkCommitFullNode/width/8-8                           	      78	  14020684 ns/op	   47328 B/op	    1028 allocs/op
PASS
ok  	github.com/gballet/go-verkle	17.612s
```

Kilic:
```
goos: freebsd
goarch: amd64
pkg: github.com/gballet/go-verkle
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkCommitLeaves/insert/leaves/1000/width/10-8         	       1	1250530819 ns/op	102543080 B/op	  564225 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/1000/width/10-8  	       8	 140555661 ns/op	21584363 B/op	   58251 allocs/op
BenchmarkCommitLeaves/insert/leaves/10000/width/10-8        	       1	1329969118 ns/op	144294120 B/op	  587780 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/10000/width/10-8 	       1	1578241591 ns/op	154200288 B/op	  656631 allocs/op
BenchmarkCommitLeaves/insert/leaves/1000/width/8-8          	       8	 136680641 ns/op	11941788 B/op	   59527 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/1000/width/8-8   	       7	 161843873 ns/op	14015514 B/op	   73176 allocs/op
BenchmarkCommitLeaves/insert/leaves/10000/width/8-8         	       1	1215417362 ns/op	109335352 B/op	  621375 allocs/op
BenchmarkCommitLeaves/insertOrdered/leaves/10000/width/8-8  	       1	1616026795 ns/op	118297936 B/op	  684344 allocs/op
BenchmarkCommitFullNode/width/10-8                          	      42	  24986828 ns/op	  532000 B/op	    6270 allocs/op
BenchmarkCommitFullNode/width/8-8                           	     139	   8545543 ns/op	  158048 B/op	    1680 allocs/op
PASS
ok  	github.com/gballet/go-verkle	15.483s
```

`FrFrom32` is significantly slower in its Kilic version than in its herumi version. Not that this is the only factor, a quick benchmark proves that this PR compiled with Kilic is significantly faster than the version of `hashFr` currently in `master`.