### PR TITLE
guard configuration with a mutex

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ package verkle
 
 import (
 	"math/big"
+	"sync"
 
 	"github.com/protolambda/go-kzg"
 	"github.com/protolambda/go-kzg/bls"
@@ -42,13 +43,19 @@ type TreeConfig struct {
 	lg1               []bls.G1Point
 }
 
-var configs map[int]*TreeConfig
+var (
+	configs   map[int]*TreeConfig
+	configMtx sync.Mutex
+)
 
 func init() {
 	configs = make(map[int]*TreeConfig)
 }
 
 func GetTreeConfig(width int) *TreeConfig {
+	configMtx.Lock()
+	defer configMtx.Unlock()
+
 	if cfg, ok := configs[width]; ok {
 		return cfg
 	}


### PR DESCRIPTION
Addresses #51 : Add a mutex in `GetTreeConfig` in order to avoid the thread-safety problems of kilic