### PR TITLE
tree: apply mod 2^255 in hashToFr

### DIFF
--- a/goerli_test.go
+++ b/goerli_test.go
@@ -33,12 +33,13 @@ import (
 	"github.com/protolambda/go-kzg/bls"
 )
 
+// Check a use case in which the hash is above the fields' order
 func TestGoerliInsertBug(t *testing.T) {
 	root := New(10)
 	root.InsertOrdered(common.Hex2Bytes("000c9f87eb59996c38b587bb3a5a49b85a64b8b6bb7dd76e87125fe1370071a2"), common.Hex2Bytes("f84b018701d7c17cd98200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9506198b51956083dabde9b3c5c0c4251b56ea4741396ce02631c4be379"), common.Hex2Bytes("f84b018701d7b0b950b200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9538ed7e9a5688464cc41c8c5f20af324c76ea78360abe7d57185c23834"), common.Hex2Bytes("f8440180a01a67cc51538c651f63e8d55094b0ae7bca7f623f05a9ff77ca815dd44d5c8322a010b37de11f39e0a372615c70e1d4d7c613937e8f61823d59be9bea62112e175c"), nil)
-	expected := common.Hex2Bytes("a4195c94ee2ecb3f2d978be1133be9abb54f1e86aacdfceca1e8e9833b30a92ee544e78cfbe803f30263f5d93b54c005")
+	expected := common.Hex2Bytes("b94fed4a30dbba3df2ca718c3c63022c6a3adfb07b2c8ebb2999f2c630cfeeda775b10abe3b7de6dcd59170cc516105c")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)

--- a/proof_test.go
+++ b/proof_test.go
@@ -54,13 +54,13 @@ func TestProofGenerationTwoLeaves(t *testing.T) {
 		t.Fatalf("invalid D commitment, expected %x, got %x", expectedD, bls.ToCompressedG1(d))
 	}
 
-	expectedY := "29538444433028619980967897141357016680422322190427848339183478815792394204807"
+	expectedY := "21306146820571925953472288604371653231632928908819047628407230609299841830732"
 	gotY := bls.FrStr(y)
 	if expectedY != gotY {
 		t.Fatalf("invalid y, expected %s != %s", expectedY, gotY)
 	}
 
-	expectedSigma := common.Hex2Bytes("a28c6ff3c7856e5fd2cdf32630935bcfceacd80e00f2e49633839bfa9e2f20057215efc6391a8006ef9f699eb8b18a1a")
+	expectedSigma := common.Hex2Bytes("a28912f8d55541111654f42a0bde30833ff7e4e795a5f79146f92600369d43540f52c19e6ca33dce80101d8f59c4cb29")
 	if !bytes.Equal(expectedSigma, bls.ToCompressedG1(sigma)) {
 		t.Fatalf("invalid sigma, expected %x, got %x", expectedSigma, bls.ToCompressedG1(sigma))
 	}

--- a/tree.go
+++ b/tree.go
@@ -444,7 +444,9 @@ func (n *InternalNode) Hash() common.Hash {
 // This piece of code is really ugly, and probably a performance hog, it
 // needs to be rewritten more efficiently.
 func hashToFr(out *bls.Fr, h [32]byte, modulus *big.Int) {
-	// reverse endianness
+	h[31] &= 0x7F // mod 2^255
+
+	// reverse endianness (little -> big)
 	for i := 0; i < len(h)/2; i++ {
 		t := h[i]
 		h[i] = h[len(h)-i-1]

--- a/tree_test.go
+++ b/tree_test.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/protolambda/go-kzg/bls"
 )
 
@@ -134,7 +133,7 @@ func TestComputeRootCommitmentThreeLeaves(t *testing.T) {
 	root.Insert(fourtyKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := []byte{137, 46, 141, 157, 55, 243, 191, 123, 197, 83, 9, 229, 155, 145, 185, 155, 171, 133, 195, 118, 100, 193, 107, 202, 170, 6, 51, 189, 99, 62, 244, 70, 199, 253, 80, 218, 171, 68, 89, 136, 222, 166, 5, 209, 92, 255, 140, 164}
+	expected := common.Hex2Bytes("a8284375e58dee2a57fd7dc4ffd47c15fb49909f726e8b13c53e3c37d0da16febea38542d70135cb2bc04c0fc23785d4")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -154,7 +153,7 @@ func TestComputeRootCommitmentOnlineThreeLeaves(t *testing.T) {
 	// commitment is calculated.
 	comm := root.ComputeCommitment()
 
-	expected := []byte{137, 46, 141, 157, 55, 243, 191, 123, 197, 83, 9, 229, 155, 145, 185, 155, 171, 133, 195, 118, 100, 193, 107, 202, 170, 6, 51, 189, 99, 62, 244, 70, 199, 253, 80, 218, 171, 68, 89, 136, 222, 166, 5, 209, 92, 255, 140, 164}
+	expected := common.Hex2Bytes("a8284375e58dee2a57fd7dc4ffd47c15fb49909f726e8b13c53e3c37d0da16febea38542d70135cb2bc04c0fc23785d4")
 
 	got := bls.ToCompressedG1(comm)
 
@@ -169,7 +168,7 @@ func TestComputeRootCommitmentThreeLeavesDeep(t *testing.T) {
 	root.Insert(oneKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := []byte{180, 224, 116, 69, 8, 16, 10, 46, 12, 87, 199, 139, 17, 157, 123, 95, 113, 9, 180, 227, 72, 13, 125, 20, 35, 52, 98, 119, 121, 181, 253, 151, 253, 0, 62, 206, 64, 49, 8, 93, 140, 128, 232, 208, 102, 248, 81, 206}
+	expected := common.Hex2Bytes("95550bf1eef11d0fefb102845c4612c96a18c62aa854a324fc3375c56609509e153acc60180644c0878f0f7e2166de16")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -185,7 +184,7 @@ func TestComputeRootCommitmentOnlineThreeLeavesDeep(t *testing.T) {
 	root.InsertOrdered(oneKeyTest, testValue, nil)
 	root.InsertOrdered(ffx32KeyTest, testValue, nil)
 
-	expected := []byte{180, 224, 116, 69, 8, 16, 10, 46, 12, 87, 199, 139, 17, 157, 123, 95, 113, 9, 180, 227, 72, 13, 125, 20, 35, 52, 98, 119, 121, 181, 253, 151, 253, 0, 62, 206, 64, 49, 8, 93, 140, 128, 232, 208, 102, 248, 81, 206}
+	expected := common.Hex2Bytes("95550bf1eef11d0fefb102845c4612c96a18c62aa854a324fc3375c56609509e153acc60180644c0878f0f7e2166de16")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -521,55 +520,55 @@ type Account struct {
 	CodeHash []byte
 }
 
-func TestDevnet0PostMortem(t *testing.T) {
-	addr1 := common.Hex2Bytes("3e47cd08ea12b4dfcf5210e3ef3827471994d49b")
-	addr2 := common.Hex2Bytes("617661d148a52bef51a268c728b3a21b58f94306")
-	balance1, _ := big.NewInt(0).SetString("100000000000000000000", 10)
-	balance2, _ := big.NewInt(0).SetString("1000003506000000000000000000", 10)
-	account1 := Account{
-		Nonce:    0,
-		Balance:  balance1,
-		Root:     emptyRootHash,
-		CodeHash: emptyCodeHash,
-	}
-	account2 := Account{
-		Nonce:    1,
-		Balance:  balance2,
-		Root:     emptyRootHash,
-		CodeHash: emptyCodeHash,
-	}
+//func TestDevnet0PostMortem(t *testing.T) {
+//addr1 := common.Hex2Bytes("3e47cd08ea12b4dfcf5210e3ef3827471994d49b")
+//addr2 := common.Hex2Bytes("617661d148a52bef51a268c728b3a21b58f94306")
+//balance1, _ := big.NewInt(0).SetString("100000000000000000000", 10)
+//balance2, _ := big.NewInt(0).SetString("1000003506000000000000000000", 10)
+//account1 := Account{
+//Nonce:    0,
+//Balance:  balance1,
+//Root:     emptyRootHash,
+//CodeHash: emptyCodeHash,
+//}
+//account2 := Account{
+//Nonce:    1,
+//Balance:  balance2,
+//Root:     emptyRootHash,
+//CodeHash: emptyCodeHash,
+//}
 
-	var buf1, buf2 bytes.Buffer
-	tree := New(8)
-	rlp.Encode(&buf1, &account1)
-	tree.Insert(addr1, buf1.Bytes())
-	rlp.Encode(&buf2, &account2)
-	tree.Insert(addr2, buf2.Bytes())
+//var buf1, buf2 bytes.Buffer
+//tree := New(8)
+//rlp.Encode(&buf1, &account1)
+//tree.Insert(addr1, buf1.Bytes())
+//rlp.Encode(&buf2, &account2)
+//tree.Insert(addr2, buf2.Bytes())
 
-	tree.ComputeCommitment()
+//tree.ComputeCommitment()
 
-	block1803Hash := tree.Hash()
-	if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
-		t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
-	}
+//block1803Hash := tree.Hash()
+//if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
+//t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
+//}
 
-	buf1.Reset()
-	account1.Balance.SetString("199000000000000000000", 10)
-	rlp.Encode(&buf1, &account1)
-	tree.Insert(addr1, buf1.Bytes())
-	buf2.Reset()
-	account2.Nonce = 4
-	account2.Balance.SetString("1000003587000000000000000000", 10)
-	rlp.Encode(&buf2, &account2)
-	tree.Insert(addr2, buf2.Bytes())
+//buf1.Reset()
+//account1.Balance.SetString("199000000000000000000", 10)
+//rlp.Encode(&buf1, &account1)
+//tree.Insert(addr1, buf1.Bytes())
+//buf2.Reset()
+//account2.Nonce = 4
+//account2.Balance.SetString("1000003587000000000000000000", 10)
+//rlp.Encode(&buf2, &account2)
+//tree.Insert(addr2, buf2.Bytes())
 
-	tree.ComputeCommitment()
+//tree.ComputeCommitment()
 
-	block1893Hash := tree.Hash()
-	if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
-		t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
-	}
-}
+//block1893Hash := tree.Hash()
+//if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
+//t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
+//}
+//}
 
 func TestConcurrentTrees(t *testing.T) {
 	value := []byte("value")
@@ -806,7 +805,7 @@ func TestMainnetStart(t *testing.T) {
 
 	h := tree.Hash()
 
-	if !bytes.Equal(h[:], common.Hex2Bytes("83fd7664ae16de3d3deb70897ecacfcbcd851bde2e6d4aad98b6c9c2ba903568")) {
+	if !bytes.Equal(h[:], common.Hex2Bytes("d4bca0d22e7dbd08521a362692c4696358796d844ede242055dad54eeb402a88")) {
 		t.Fatalf("invalid hash: %x", h)
 	}
 }


### PR DESCRIPTION
The more modest version of #62 : apply the `2^255` modulus before applying that of the field.

Deactivate one test that is no longer valid, to be replaced with the data from the next devnet run.