### PR TITLE
Implement the last-level node scheme

### DIFF
--- a/config.go
+++ b/config.go
@@ -176,3 +176,22 @@ func (tc *TreeConfig) outerQuotients(f []bls.Fr, z, y *bls.Fr) []bls.Fr {
 
 	return q[:]
 }
+
+// Evaluate a polynomial in the lagrange basis
+func (tc *TreeConfig) evalPoly(poly []bls.Fr, emptyChildren int) *bls.G1Point {
+	if tc.nodeWidth-emptyChildren >= tc.multiExpThreshold {
+		return bls.LinCombG1(tc.lg1, poly[:])
+	} else {
+		var comm bls.G1Point
+		bls.CopyG1(&comm, &bls.ZERO_G1)
+		for i := range poly {
+			if !bls.EqualZero(&poly[i]) {
+				var tmpG1, eval bls.G1Point
+				bls.MulG1(&eval, &tc.lg1[i], &poly[i])
+				bls.CopyG1(&tmpG1, &comm)
+				bls.AddG1(&comm, &tmpG1, &eval)
+			}
+		}
+		return &comm
+	}
+}

--- a/encoding.go
+++ b/encoding.go
@@ -65,7 +65,7 @@ func ParseNode(serialized []byte, depth, width int) (VerkleNode, error) {
 			return nil, err
 		}
 		var values [][]byte
-		if err := rlp.DecodeBytes(rest, values); err != nil {
+		if err := rlp.DecodeBytes(rest, &values); err != nil {
 			return nil, err
 		}
 		tc := GetTreeConfig(width)

--- a/encoding.go
+++ b/encoding.go
@@ -27,6 +27,7 @@ package verkle
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -69,6 +70,9 @@ func ParseNode(serialized []byte, depth, width int) (VerkleNode, error) {
 			return nil, err
 		}
 		tc := GetTreeConfig(width)
+		if tc.nodeWidth != len(values) {
+			return nil, fmt.Errorf("invalid number of nodes in decoded child expected %d, got %d", tc.nodeWidth, len(values))
+		}
 		ln := &LeafNode{
 			key:        key,
 			values:     values,

--- a/encoding.go
+++ b/encoding.go
@@ -64,11 +64,17 @@ func ParseNode(serialized []byte, depth, width int) (VerkleNode, error) {
 		if err != nil {
 			return nil, err
 		}
-		value, _, err := rlp.SplitString(rest)
-		if err != nil {
+		var values [][]byte
+		if err := rlp.DecodeBytes(rest, values); err != nil {
 			return nil, err
 		}
-		return &LeafNode{key: key, value: value}, nil
+		tc := GetTreeConfig(width)
+		ln := &LeafNode{
+			key:        key,
+			values:     values,
+			treeConfig: tc,
+		}
+		return ln, nil
 	case internalRLPType:
 		bitlist, rest, err := rlp.SplitString(rest)
 		if err != nil {

--- a/goerli_test.go
+++ b/goerli_test.go
@@ -38,7 +38,7 @@ func TestGoerliInsertBug(t *testing.T) {
 	root.InsertOrdered(common.Hex2Bytes("000c9f87eb59996c38b587bb3a5a49b85a64b8b6bb7dd76e87125fe1370071a2"), common.Hex2Bytes("f84b018701d7c17cd98200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9506198b51956083dabde9b3c5c0c4251b56ea4741396ce02631c4be379"), common.Hex2Bytes("f84b018701d7b0b950b200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9538ed7e9a5688464cc41c8c5f20af324c76ea78360abe7d57185c23834"), common.Hex2Bytes("f8440180a01a67cc51538c651f63e8d55094b0ae7bca7f623f05a9ff77ca815dd44d5c8322a010b37de11f39e0a372615c70e1d4d7c613937e8f61823d59be9bea62112e175c"), nil)
-	expected := common.Hex2Bytes("a4195c94ee2ecb3f2d978be1133be9abb54f1e86aacdfceca1e8e9833b30a92ee544e78cfbe803f30263f5d93b54c005")
+	expected := common.Hex2Bytes("ab3b4a83d6edf4cf52c5556e76096e42f99aaa318d50419ad1f78a43eba4f577a44b88a819b4108936e5d180b8f31934")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)

--- a/goerli_test.go
+++ b/goerli_test.go
@@ -38,7 +38,7 @@ func TestGoerliInsertBug(t *testing.T) {
 	root.InsertOrdered(common.Hex2Bytes("000c9f87eb59996c38b587bb3a5a49b85a64b8b6bb7dd76e87125fe1370071a2"), common.Hex2Bytes("f84b018701d7c17cd98200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9506198b51956083dabde9b3c5c0c4251b56ea4741396ce02631c4be379"), common.Hex2Bytes("f84b018701d7b0b950b200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9538ed7e9a5688464cc41c8c5f20af324c76ea78360abe7d57185c23834"), common.Hex2Bytes("f8440180a01a67cc51538c651f63e8d55094b0ae7bca7f623f05a9ff77ca815dd44d5c8322a010b37de11f39e0a372615c70e1d4d7c613937e8f61823d59be9bea62112e175c"), nil)
-	expected := common.Hex2Bytes("a52fa7f1571e2de4a65cda9c3a29089690bbd845ac615d87c7832f82cdc18a1aba308afeb399c7c6eb29a5c44e8b78b8")
+	expected := common.Hex2Bytes("ab0b8ab714ecfc0097427fe1b603b2c300e9af50ee3f3951245b00d76727e9401ae3ef4bcf4ac1f5595ba7379f43b5f2")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)

--- a/goerli_test.go
+++ b/goerli_test.go
@@ -38,7 +38,7 @@ func TestGoerliInsertBug(t *testing.T) {
 	root.InsertOrdered(common.Hex2Bytes("000c9f87eb59996c38b587bb3a5a49b85a64b8b6bb7dd76e87125fe1370071a2"), common.Hex2Bytes("f84b018701d7c17cd98200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9506198b51956083dabde9b3c5c0c4251b56ea4741396ce02631c4be379"), common.Hex2Bytes("f84b018701d7b0b950b200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9538ed7e9a5688464cc41c8c5f20af324c76ea78360abe7d57185c23834"), common.Hex2Bytes("f8440180a01a67cc51538c651f63e8d55094b0ae7bca7f623f05a9ff77ca815dd44d5c8322a010b37de11f39e0a372615c70e1d4d7c613937e8f61823d59be9bea62112e175c"), nil)
-	expected := common.Hex2Bytes("ab3b4a83d6edf4cf52c5556e76096e42f99aaa318d50419ad1f78a43eba4f577a44b88a819b4108936e5d180b8f31934")
+	expected := common.Hex2Bytes("a52fa7f1571e2de4a65cda9c3a29089690bbd845ac615d87c7832f82cdc18a1aba308afeb399c7c6eb29a5c44e8b78b8")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)

--- a/proof_test.go
+++ b/proof_test.go
@@ -48,19 +48,19 @@ func TestProofGenerationTwoLeaves(t *testing.T) {
 	bls.SetFr(&s, "1927409816240961209460912649124")
 	d, y, sigma := MakeVerkleProofOneLeaf(root, zeroKeyTest)
 
-	expectedD := common.Hex2Bytes("af768e1ff778c322455f0c4159d99f516cb944c6e87da099fa8c402cfda53001bd6417a185a179f2012d2e3ba780ca1b")
+	expectedD := common.Hex2Bytes("8493875baa657f5e2a1311a630871d82247b6fe5942b40c82bcd2268d24ac2d62f60afc9f5e88c57e5827ff45346870a")
 
 	if !bytes.Equal(expectedD, bls.ToCompressedG1(d)) {
 		t.Fatalf("invalid D commitment, expected %x, got %x", expectedD, bls.ToCompressedG1(d))
 	}
 
-	expectedY := "29538444433028619980967897141357016680422322190427848339183478815792394204807"
+	expectedY := "8096084263422272718807005968668363109664482123946219710813691556037464862898"
 	gotY := bls.FrStr(y)
 	if expectedY != gotY {
 		t.Fatalf("invalid y, expected %s != %s", expectedY, gotY)
 	}
 
-	expectedSigma := common.Hex2Bytes("a28c6ff3c7856e5fd2cdf32630935bcfceacd80e00f2e49633839bfa9e2f20057215efc6391a8006ef9f699eb8b18a1a")
+	expectedSigma := common.Hex2Bytes("9337491d6d5703c130b7205f19a92be4ccd159f09829b7536f9383b3048dfc4b63ec89409e87ec033e08c8be7d5fb2c2")
 	if !bytes.Equal(expectedSigma, bls.ToCompressedG1(sigma)) {
 		t.Fatalf("invalid sigma, expected %x, got %x", expectedSigma, bls.ToCompressedG1(sigma))
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -48,19 +48,19 @@ func TestProofGenerationTwoLeaves(t *testing.T) {
 	bls.SetFr(&s, "1927409816240961209460912649124")
 	d, y, sigma := MakeVerkleProofOneLeaf(root, zeroKeyTest)
 
-	expectedD := common.Hex2Bytes("8493875baa657f5e2a1311a630871d82247b6fe5942b40c82bcd2268d24ac2d62f60afc9f5e88c57e5827ff45346870a")
+	expectedD := common.Hex2Bytes("b7ca56efcfc1cdce7aa39256f67c09e613d391e2c05809f5cda72c35a5f1c98c6bc650ccdf740d941016b406a898bf71")
 
 	if !bytes.Equal(expectedD, bls.ToCompressedG1(d)) {
 		t.Fatalf("invalid D commitment, expected %x, got %x", expectedD, bls.ToCompressedG1(d))
 	}
 
-	expectedY := "8096084263422272718807005968668363109664482123946219710813691556037464862898"
+	expectedY := "17663118220047903379229751096530013328154658399432450351097659240718099189429"
 	gotY := bls.FrStr(y)
 	if expectedY != gotY {
 		t.Fatalf("invalid y, expected %s != %s", expectedY, gotY)
 	}
 
-	expectedSigma := common.Hex2Bytes("9337491d6d5703c130b7205f19a92be4ccd159f09829b7536f9383b3048dfc4b63ec89409e87ec033e08c8be7d5fb2c2")
+	expectedSigma := common.Hex2Bytes("8fa4814f68ed8e39df578fe065a71475ce8d87780a86c95006267d533ac39b2691762b03d14dda1dd2bf00eb2cf075a1")
 	if !bytes.Equal(expectedSigma, bls.ToCompressedG1(sigma)) {
 		t.Fatalf("invalid sigma, expected %x, got %x", expectedSigma, bls.ToCompressedG1(sigma))
 	}

--- a/tree.go
+++ b/tree.go
@@ -382,7 +382,20 @@ func (n *InternalNode) Delete(key []byte) error {
 		if !bytes.Equal(child.key[:31], key[:31]) {
 			return errDeleteNonExistent
 		}
-		// overwrite empty if the last level node exists
+		n.commitment = nil
+		if err := child.Delete(key); err != nil {
+			return err
+		}
+		// Prune child if necessary
+		usedCount := 0
+		for _, v := range child.values {
+			if v != nil {
+				usedCount++
+				if usedCount >= 1 {
+					return nil
+				}
+			}
+		}
 		n.children[nChild] = Empty{}
 		return nil
 	default:

--- a/tree.go
+++ b/tree.go
@@ -532,23 +532,7 @@ func (n *InternalNode) ComputeCommitment() *bls.G1Point {
 		}
 	}
 
-	var commP *bls.G1Point
-	if n.treeConfig.nodeWidth-emptyChildren >= n.treeConfig.multiExpThreshold {
-		commP = bls.LinCombG1(n.treeConfig.lg1, poly[:])
-	} else {
-		var comm bls.G1Point
-		bls.CopyG1(&comm, &bls.ZERO_G1)
-		for i := range poly {
-			if !bls.EqualZero(&poly[i]) {
-				var tmpG1, eval bls.G1Point
-				bls.MulG1(&eval, &n.treeConfig.lg1[i], &poly[i])
-				bls.CopyG1(&tmpG1, &comm)
-				bls.AddG1(&comm, &tmpG1, &eval)
-			}
-		}
-		commP = &comm
-	}
-	n.commitment = commP
+	n.commitment = n.treeConfig.evalPoly(poly, emptyChildren)
 	return n.commitment
 }
 
@@ -671,23 +655,7 @@ func (n *LeafNode) ComputeCommitment() *bls.G1Point {
 		hashToFr(&poly[idx], h, n.treeConfig.modulus)
 	}
 
-	var commP *bls.G1Point
-	if n.treeConfig.nodeWidth-emptyChildren >= n.treeConfig.multiExpThreshold {
-		commP = bls.LinCombG1(n.treeConfig.lg1, poly[:])
-	} else {
-		var comm bls.G1Point
-		bls.CopyG1(&comm, &bls.ZERO_G1)
-		for i := range poly {
-			if !bls.EqualZero(&poly[i]) {
-				var tmpG1, eval bls.G1Point
-				bls.MulG1(&eval, &n.treeConfig.lg1[i], &poly[i])
-				bls.CopyG1(&tmpG1, &comm)
-				bls.AddG1(&comm, &tmpG1, &eval)
-			}
-		}
-		commP = &comm
-	}
-	n.commitment = commP
+	n.commitment = n.treeConfig.evalPoly(poly, emptyChildren)
 	return n.commitment
 }
 

--- a/tree.go
+++ b/tree.go
@@ -126,8 +126,11 @@ type (
 	}
 
 	LeafNode struct {
-		key   []byte
-		value []byte
+		key    []byte
+		values [][]byte
+
+		commitment *bls.G1Point
+		treeConfig *TreeConfig
 	}
 
 	Empty struct{}
@@ -218,15 +221,21 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 
 	switch child := n.children[nChild].(type) {
 	case Empty:
-		n.children[nChild] = &LeafNode{key: key, value: value}
+		lastNode := &LeafNode{
+			key:        key,
+			values:     make([][]byte, n.treeConfig.nodeWidth),
+			treeConfig: n.treeConfig,
+		}
+		lastNode.values[key[31]] = value
+		n.children[nChild] = lastNode
 	case *HashedNode:
 		return errInsertIntoHash
 	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.
 		// Otherwise, just update the key.
-		if bytes.Equal(child.key, key) {
-			child.value = value
+		if bytes.Equal(child.key[:31], key[:31]) {
+			child.Insert(key, value)
 		} else {
 			width := n.treeConfig.width
 
@@ -242,7 +251,13 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 			if nextWordInInsertedKey != nextWordInExistingKey {
 				// Next word differs, so this was the last level.
 				// Insert it directly into its final slot.
-				newBranch.children[nextWordInInsertedKey] = &LeafNode{key: key, value: value}
+				lastNode := &LeafNode{
+					key:        key,
+					values:     make([][]byte, n.treeConfig.nodeWidth),
+					treeConfig: n.treeConfig,
+				}
+				lastNode.values[key[31]] = value
+				newBranch.children[nextWordInInsertedKey] = lastNode
 			} else {
 				newBranch.Insert(key, value)
 			}
@@ -291,15 +306,21 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush chan Flusha
 			}
 		}
 
-		n.children[nChild] = &LeafNode{key: key, value: value}
+		lastNode := &LeafNode{
+			key:        key,
+			values:     make([][]byte, n.treeConfig.nodeWidth),
+			treeConfig: n.treeConfig,
+		}
+		lastNode.values[key[31]] = value
+		n.children[nChild] = lastNode
 	case *HashedNode:
 		return errInsertIntoHash
 	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.
 		// Otherwise, just update the key.
-		if bytes.Equal(child.key, key) {
-			child.value = value
+		if bytes.Equal(child.key[:31], key[:31]) {
+			child.values[key[31]] = value
 		} else {
 			width := n.treeConfig.width
 
@@ -325,7 +346,13 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush chan Flusha
 				newBranch.children[nextWordInExistingKey] = &HashedNode{hash: h, commitment: comm}
 				// Next word differs, so this was the last level.
 				// Insert it directly into its final slot.
-				newBranch.children[nextWordInInsertedKey] = &LeafNode{key: key, value: value}
+				lastNode := &LeafNode{
+					key:        key,
+					values:     make([][]byte, n.treeConfig.nodeWidth),
+					treeConfig: n.treeConfig,
+				}
+				lastNode.values[key[31]] = value
+				newBranch.children[nextWordInInsertedKey] = lastNode
 			} else {
 				// Reinsert the leaf in order to recurse
 				newBranch.children[nextWordInExistingKey] = child
@@ -575,40 +602,85 @@ func (n *InternalNode) clearCache() {
 }
 
 func (n *LeafNode) Insert(k []byte, value []byte) error {
-	n.key = k
-	n.value = value
+	// Sanity check: ensure the key header is the same:
+	if bytes.Compare(k[:31], n.key[:31]) != 0 {
+		return errors.New("split should not happen here")
+	}
+	n.values[k[31]] = value
 	return nil
 }
 
 func (n *LeafNode) InsertOrdered(key []byte, value []byte, flush chan FlushableNode) error {
-	err := n.Insert(key, value)
-	if err != nil && flush != nil {
-		flush <- FlushableNode{n.Hash(), n}
-	}
-	return err
+	// In the previous version, this value used to be flushed on insert.
+	// This is no longer the case, as all values at the last level get
+	// flushed at the same time.
+	return n.Insert(key, value)
 }
 
 func (n *LeafNode) Delete(k []byte) error {
-	return errors.New("cant delete a leaf in-place")
+	// Sanity check: ensure the key header is the same:
+	if bytes.Compare(k[:31], n.key[:31]) != 0 {
+		return errors.New("trying to delete a non-existing key")
+	}
+
+	n.values[k[31]] = nil
+	return nil
 }
 
 func (n *LeafNode) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
-	if !bytes.Equal(k, n.key) {
+	if !bytes.Equal(k[:31], n.key[:31]) {
 		// If keys differ, return nil in order to
 		// signal that the key isn't present in the
 		// tree. Do not return an error, thus matching
 		// the behavior of Geth's SecureTrie.
 		return nil, nil
 	}
-	return n.value, nil
+	// value can be nil, as expected by geth
+	return n.values[k[31]], nil
 }
 
 func (n *LeafNode) ComputeCommitment() *bls.G1Point {
-	panic("can't compute the commitment directly")
+	if n.commitment != nil {
+		return n.commitment
+	}
+
+	emptyChildren := 0
+	poly := make([]bls.Fr, n.treeConfig.nodeWidth)
+	for idx, val := range n.values {
+		if val == nil {
+			emptyChildren++
+		}
+		hasher := sha256.New()
+		hasher.Write(n.key[:31])
+		hasher.Write([]byte{byte(idx)})
+		hasher.Write(val)
+		var h [32]byte
+		copy(h[:], hasher.Sum(nil))
+		hashToFr(&poly[idx], h, n.treeConfig.modulus)
+	}
+
+	var commP *bls.G1Point
+	if n.treeConfig.nodeWidth-emptyChildren >= n.treeConfig.multiExpThreshold {
+		commP = bls.LinCombG1(n.treeConfig.lg1, poly[:])
+	} else {
+		var comm bls.G1Point
+		bls.CopyG1(&comm, &bls.ZERO_G1)
+		for i := range poly {
+			if !bls.EqualZero(&poly[i]) {
+				var tmpG1, eval bls.G1Point
+				bls.MulG1(&eval, &n.treeConfig.lg1[i], &poly[i])
+				bls.CopyG1(&tmpG1, &comm)
+				bls.AddG1(&comm, &tmpG1, &eval)
+			}
+		}
+		commP = &comm
+	}
+	n.commitment = commP
+	return n.commitment
 }
 
 func (n *LeafNode) GetCommitment() *bls.G1Point {
-	panic("can't get the commitment directly")
+	return n.commitment
 }
 
 func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
@@ -616,32 +688,27 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.F
 }
 
 func (n *LeafNode) Hash() common.Hash {
-	digest := sha256.New()
-	digest.Write(n.key)
-	digest.Write(n.value)
-	return common.BytesToHash(digest.Sum(nil))
+	comm := n.ComputeCommitment()
+	h := sha256.Sum256(bls.ToCompressedG1(comm))
+	return common.BytesToHash(h[:])
 }
 
 func (n *LeafNode) Serialize() ([]byte, error) {
-	return rlp.EncodeToBytes([]interface{}{leafRLPType, n.key, n.value})
+	return rlp.EncodeToBytes([]interface{}{leafRLPType, n.key, n.values})
 }
 
 func (n *LeafNode) Copy() VerkleNode {
 	l := &LeafNode{}
 	l.key = make([]byte, len(n.key))
-	l.value = make([]byte, len(n.value))
+	l.values = make([][]byte, len(n.values))
+	l.treeConfig = n.treeConfig
 	copy(l.key, n.key)
-	copy(l.value, n.value)
+	for i, v := range n.values {
+		l.values[i] = make([]byte, len(v))
+		copy(l.values[i], v)
+	}
 
 	return l
-}
-
-func (n *LeafNode) Key() []byte {
-	return n.key
-}
-
-func (n *LeafNode) Value() []byte {
-	return n.value
 }
 
 func (n *HashedNode) Insert(k []byte, value []byte) error {

--- a/tree.go
+++ b/tree.go
@@ -609,6 +609,7 @@ func (n *LeafNode) Insert(k []byte, value []byte) error {
 		return errors.New("split should not happen here")
 	}
 	n.values[k[31]] = value
+	n.commitment = nil
 	return nil
 }
 
@@ -704,6 +705,9 @@ func (n *LeafNode) Copy() VerkleNode {
 	for i, v := range n.values {
 		l.values[i] = make([]byte, len(v))
 		copy(l.values[i], v)
+	}
+	if n.commitment != nil {
+		l.commitment = n.commitment
 	}
 
 	return l

--- a/tree_test.go
+++ b/tree_test.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/protolambda/go-kzg/bls"
 )
 
@@ -87,7 +88,7 @@ func TestInsertTwoLeaves(t *testing.T) {
 		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf0.values[zeroKeyTest[31]][:])
 	}
 
-	if !bytes.Equal(leaff.values[ffx32KeyTest[31]][:], testValue) {
+	if !bytes.Equal(leaff.values[1008][:], testValue) {
 		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaff.values[ffx32KeyTest[31]][:])
 	}
 }
@@ -133,7 +134,7 @@ func TestComputeRootCommitmentThreeLeaves(t *testing.T) {
 	root.Insert(fourtyKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := common.Hex2Bytes("9574a0859c26e8fd5e0d605869ebf78b3c5071ec76970ebc888b686bb17eab6d5b2ef73abc85169918403e17fcd1e975")
+	expected := common.Hex2Bytes("8e348cb9637770d51d56f9f479f9f73c033347b7493679842f1f3abf525263fd252fca4c3220f848cf0730657af9af5d")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -153,7 +154,7 @@ func TestComputeRootCommitmentOnlineThreeLeaves(t *testing.T) {
 	// commitment is calculated.
 	comm := root.ComputeCommitment()
 
-	expected := common.Hex2Bytes("9574a0859c26e8fd5e0d605869ebf78b3c5071ec76970ebc888b686bb17eab6d5b2ef73abc85169918403e17fcd1e975")
+	expected := common.Hex2Bytes("8e348cb9637770d51d56f9f479f9f73c033347b7493679842f1f3abf525263fd252fca4c3220f848cf0730657af9af5d")
 
 	got := bls.ToCompressedG1(comm)
 
@@ -168,7 +169,7 @@ func TestComputeRootCommitmentThreeLeavesDeep(t *testing.T) {
 	root.Insert(oneKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := common.Hex2Bytes("8e369e78ab97ae134748557d932514ed590eaab88472575289bb5787566b39288b0749d55c6ae9bcf9f4a30d693b1961")
+	expected := common.Hex2Bytes("9615d051ca886322b0a8f9c6d3f701788567a2387e12883a053d3d03dc537a7c48d538dd612645765f58868b97047c55")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -184,7 +185,7 @@ func TestComputeRootCommitmentOnlineThreeLeavesDeep(t *testing.T) {
 	root.InsertOrdered(oneKeyTest, testValue, nil)
 	root.InsertOrdered(ffx32KeyTest, testValue, nil)
 
-	expected := common.Hex2Bytes("8e369e78ab97ae134748557d932514ed590eaab88472575289bb5787566b39288b0749d55c6ae9bcf9f4a30d693b1961")
+	expected := common.Hex2Bytes("9615d051ca886322b0a8f9c6d3f701788567a2387e12883a053d3d03dc537a7c48d538dd612645765f58868b97047c55")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -224,7 +225,7 @@ func TestComputeRootCommitmentTwoLeaves(t *testing.T) {
 	root := New(10)
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
-	expected := common.Hex2Bytes("86c1ec564b1dca759fae2a0a5534dae74ec52c0be2c7ba1e91892b4a4e081bd9acc5031c02b257a95a0080c29ffad767")
+	expected := common.Hex2Bytes("a52cc2a035a9eae8798c6c3e6b547648c057caba0f56a48196573ed570f4ca9efd05ba4af15eeaf2fb4505b6bc06fa6c")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -806,7 +807,7 @@ func TestMainnetStart(t *testing.T) {
 
 	h := tree.Hash()
 
-	if !bytes.Equal(h[:], common.Hex2Bytes("0e4c372a5ee50c6bbeb570c4d958569336f3bf887f68d9b41eceef20577b01de")) {
+	if !bytes.Equal(h[:], common.Hex2Bytes("ec62b1cb08295478a77a92f8fa9d368dd8783900ab53b2f3a3bf0da686ff8cc1")) {
 		t.Fatalf("invalid hash: %x", h)
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/protolambda/go-kzg/bls"
 )
 
@@ -134,7 +133,7 @@ func TestComputeRootCommitmentThreeLeaves(t *testing.T) {
 	root.Insert(fourtyKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := []byte{137, 46, 141, 157, 55, 243, 191, 123, 197, 83, 9, 229, 155, 145, 185, 155, 171, 133, 195, 118, 100, 193, 107, 202, 170, 6, 51, 189, 99, 62, 244, 70, 199, 253, 80, 218, 171, 68, 89, 136, 222, 166, 5, 209, 92, 255, 140, 164}
+	expected := common.Hex2Bytes("9574a0859c26e8fd5e0d605869ebf78b3c5071ec76970ebc888b686bb17eab6d5b2ef73abc85169918403e17fcd1e975")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -154,7 +153,7 @@ func TestComputeRootCommitmentOnlineThreeLeaves(t *testing.T) {
 	// commitment is calculated.
 	comm := root.ComputeCommitment()
 
-	expected := []byte{137, 46, 141, 157, 55, 243, 191, 123, 197, 83, 9, 229, 155, 145, 185, 155, 171, 133, 195, 118, 100, 193, 107, 202, 170, 6, 51, 189, 99, 62, 244, 70, 199, 253, 80, 218, 171, 68, 89, 136, 222, 166, 5, 209, 92, 255, 140, 164}
+	expected := common.Hex2Bytes("9574a0859c26e8fd5e0d605869ebf78b3c5071ec76970ebc888b686bb17eab6d5b2ef73abc85169918403e17fcd1e975")
 
 	got := bls.ToCompressedG1(comm)
 
@@ -169,7 +168,7 @@ func TestComputeRootCommitmentThreeLeavesDeep(t *testing.T) {
 	root.Insert(oneKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := []byte{180, 224, 116, 69, 8, 16, 10, 46, 12, 87, 199, 139, 17, 157, 123, 95, 113, 9, 180, 227, 72, 13, 125, 20, 35, 52, 98, 119, 121, 181, 253, 151, 253, 0, 62, 206, 64, 49, 8, 93, 140, 128, 232, 208, 102, 248, 81, 206}
+	expected := common.Hex2Bytes("8e369e78ab97ae134748557d932514ed590eaab88472575289bb5787566b39288b0749d55c6ae9bcf9f4a30d693b1961")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -185,7 +184,7 @@ func TestComputeRootCommitmentOnlineThreeLeavesDeep(t *testing.T) {
 	root.InsertOrdered(oneKeyTest, testValue, nil)
 	root.InsertOrdered(ffx32KeyTest, testValue, nil)
 
-	expected := []byte{180, 224, 116, 69, 8, 16, 10, 46, 12, 87, 199, 139, 17, 157, 123, 95, 113, 9, 180, 227, 72, 13, 125, 20, 35, 52, 98, 119, 121, 181, 253, 151, 253, 0, 62, 206, 64, 49, 8, 93, 140, 128, 232, 208, 102, 248, 81, 206}
+	expected := common.Hex2Bytes("8e369e78ab97ae134748557d932514ed590eaab88472575289bb5787566b39288b0749d55c6ae9bcf9f4a30d693b1961")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -225,7 +224,7 @@ func TestComputeRootCommitmentTwoLeaves(t *testing.T) {
 	root := New(10)
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
-	expected := []byte{178, 195, 197, 132, 158, 141, 115, 80, 222, 187, 37, 145, 15, 184, 242, 86, 101, 164, 144, 51, 239, 90, 232, 100, 78, 178, 253, 145, 36, 168, 30, 75, 100, 185, 100, 14, 198, 48, 14, 95, 3, 252, 185, 73, 183, 195, 153, 44}
+	expected := common.Hex2Bytes("86c1ec564b1dca759fae2a0a5534dae74ec52c0be2c7ba1e91892b4a4e081bd9acc5031c02b257a95a0080c29ffad767")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -282,7 +281,7 @@ func TestComputeRootCommitmentTwoLeaves256(t *testing.T) {
 	root := New(8)
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
-	expected := common.Hex2Bytes("84c699b01f33e5af95d4dd3a09257c442606a0d812600bdfcc06f45be6eba3cc767fa837e47e5c1ac51956424c9258dd")
+	expected := common.Hex2Bytes("871f56f35eb3a58880b5895a545820e87befdd90177be2c881e109fc6ca337214d6460c28c52bdd87e1a7ae520073a5f")
 
 	comm := root.ComputeCommitment()
 	got := bls.ToCompressedG1(comm)
@@ -521,55 +520,55 @@ type Account struct {
 	CodeHash []byte
 }
 
-func TestDevnet0PostMortem(t *testing.T) {
-	addr1 := common.Hex2Bytes("3e47cd08ea12b4dfcf5210e3ef3827471994d49b")
-	addr2 := common.Hex2Bytes("617661d148a52bef51a268c728b3a21b58f94306")
-	balance1, _ := big.NewInt(0).SetString("100000000000000000000", 10)
-	balance2, _ := big.NewInt(0).SetString("1000003506000000000000000000", 10)
-	account1 := Account{
-		Nonce:    0,
-		Balance:  balance1,
-		Root:     emptyRootHash,
-		CodeHash: emptyCodeHash,
-	}
-	account2 := Account{
-		Nonce:    1,
-		Balance:  balance2,
-		Root:     emptyRootHash,
-		CodeHash: emptyCodeHash,
-	}
+//func TestDevnet0PostMortem(t *testing.T) {
+//addr1 := common.Hex2Bytes("3e47cd08ea12b4dfcf5210e3ef3827471994d49b")
+//addr2 := common.Hex2Bytes("617661d148a52bef51a268c728b3a21b58f94306")
+//balance1, _ := big.NewInt(0).SetString("100000000000000000000", 10)
+//balance2, _ := big.NewInt(0).SetString("1000003506000000000000000000", 10)
+//account1 := Account{
+//Nonce:    0,
+//Balance:  balance1,
+//Root:     emptyRootHash,
+//CodeHash: emptyCodeHash,
+//}
+//account2 := Account{
+//Nonce:    1,
+//Balance:  balance2,
+//Root:     emptyRootHash,
+//CodeHash: emptyCodeHash,
+//}
 
-	var buf1, buf2 bytes.Buffer
-	tree := New(8)
-	rlp.Encode(&buf1, &account1)
-	tree.Insert(addr1, buf1.Bytes())
-	rlp.Encode(&buf2, &account2)
-	tree.Insert(addr2, buf2.Bytes())
+//var buf1, buf2 bytes.Buffer
+//tree := New(8)
+//rlp.Encode(&buf1, &account1)
+//tree.Insert(addr1, buf1.Bytes())
+//rlp.Encode(&buf2, &account2)
+//tree.Insert(addr2, buf2.Bytes())
 
-	tree.ComputeCommitment()
+//tree.ComputeCommitment()
 
-	block1803Hash := tree.Hash()
-	if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
-		t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
-	}
+//block1803Hash := tree.Hash()
+//if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
+//t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
+//}
 
-	buf1.Reset()
-	account1.Balance.SetString("199000000000000000000", 10)
-	rlp.Encode(&buf1, &account1)
-	tree.Insert(addr1, buf1.Bytes())
-	buf2.Reset()
-	account2.Nonce = 4
-	account2.Balance.SetString("1000003587000000000000000000", 10)
-	rlp.Encode(&buf2, &account2)
-	tree.Insert(addr2, buf2.Bytes())
+//buf1.Reset()
+//account1.Balance.SetString("199000000000000000000", 10)
+//rlp.Encode(&buf1, &account1)
+//tree.Insert(addr1, buf1.Bytes())
+//buf2.Reset()
+//account2.Nonce = 4
+//account2.Balance.SetString("1000003587000000000000000000", 10)
+//rlp.Encode(&buf2, &account2)
+//tree.Insert(addr2, buf2.Bytes())
 
-	tree.ComputeCommitment()
+//tree.ComputeCommitment()
 
-	block1893Hash := tree.Hash()
-	if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
-		t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
-	}
-}
+//block1893Hash := tree.Hash()
+//if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
+//t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
+//}
+//}
 
 func TestConcurrentTrees(t *testing.T) {
 	value := []byte("value")
@@ -806,7 +805,7 @@ func TestMainnetStart(t *testing.T) {
 
 	h := tree.Hash()
 
-	if !bytes.Equal(h[:], common.Hex2Bytes("83fd7664ae16de3d3deb70897ecacfcbcd851bde2e6d4aad98b6c9c2ba903568")) {
+	if !bytes.Equal(h[:], common.Hex2Bytes("0e4c372a5ee50c6bbeb570c4d958569336f3bf887f68d9b41eceef20577b01de")) {
 		t.Fatalf("invalid hash: %x", h)
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -64,8 +64,8 @@ func TestInsertIntoRoot(t *testing.T) {
 		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[0])
 	}
 
-	if !bytes.Equal(leaf.value[:], testValue) {
-		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf.value[:])
+	if !bytes.Equal(leaf.values[zeroKeyTest[31]][:], testValue) {
+		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf.values[zeroKeyTest[31]][:])
 	}
 }
 
@@ -84,12 +84,12 @@ func TestInsertTwoLeaves(t *testing.T) {
 		t.Fatalf("invalid leaf node type %v", root.(*InternalNode).children[1023])
 	}
 
-	if !bytes.Equal(leaf0.value[:], testValue) {
-		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf0.value[:])
+	if !bytes.Equal(leaf0.values[zeroKeyTest[31]][:], testValue) {
+		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf0.values[zeroKeyTest[31]][:])
 	}
 
-	if !bytes.Equal(leaff.value[:], testValue) {
-		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaff.value[:])
+	if !bytes.Equal(leaff.values[ffx32KeyTest[31]][:], testValue) {
+		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaff.values[ffx32KeyTest[31]][:])
 	}
 }
 
@@ -906,5 +906,15 @@ func isInternalEqual(a, b *InternalNode) bool {
 }
 
 func isLeafEqual(a, b *LeafNode) bool {
-	return bytes.Equal(a.key, b.key) && bytes.Equal(a.value, b.value)
+	if !bytes.Equal(a.key, b.key) {
+		return false
+	}
+
+	for i, v := range a.values {
+		if !bytes.Equal(v, b.values[i]) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -520,55 +520,56 @@ type Account struct {
 	CodeHash []byte
 }
 
-//func TestDevnet0PostMortem(t *testing.T) {
-//addr1 := common.Hex2Bytes("3e47cd08ea12b4dfcf5210e3ef3827471994d49b")
-//addr2 := common.Hex2Bytes("617661d148a52bef51a268c728b3a21b58f94306")
-//balance1, _ := big.NewInt(0).SetString("100000000000000000000", 10)
-//balance2, _ := big.NewInt(0).SetString("1000003506000000000000000000", 10)
-//account1 := Account{
-//Nonce:    0,
-//Balance:  balance1,
-//Root:     emptyRootHash,
-//CodeHash: emptyCodeHash,
-//}
-//account2 := Account{
-//Nonce:    1,
-//Balance:  balance2,
-//Root:     emptyRootHash,
-//CodeHash: emptyCodeHash,
-//}
+func TestDevnet0PostMortem(t *testing.T) {
+	t.Skip()
+	addr1 := common.Hex2Bytes("3e47cd08ea12b4dfcf5210e3ef3827471994d49b")
+	addr2 := common.Hex2Bytes("617661d148a52bef51a268c728b3a21b58f94306")
+	balance1, _ := big.NewInt(0).SetString("100000000000000000000", 10)
+	balance2, _ := big.NewInt(0).SetString("1000003506000000000000000000", 10)
+	account1 := Account{
+		Nonce:    0,
+		Balance:  balance1,
+		Root:     emptyRootHash,
+		CodeHash: emptyCodeHash,
+	}
+	account2 := Account{
+		Nonce:    1,
+		Balance:  balance2,
+		Root:     emptyRootHash,
+		CodeHash: emptyCodeHash,
+	}
 
-//var buf1, buf2 bytes.Buffer
-//tree := New(8)
-//rlp.Encode(&buf1, &account1)
-//tree.Insert(addr1, buf1.Bytes())
-//rlp.Encode(&buf2, &account2)
-//tree.Insert(addr2, buf2.Bytes())
+	var buf1, buf2 bytes.Buffer
+	tree := New(8)
+	rlp.Encode(&buf1, &account1)
+	tree.Insert(addr1, buf1.Bytes())
+	rlp.Encode(&buf2, &account2)
+	tree.Insert(addr2, buf2.Bytes())
 
-//tree.ComputeCommitment()
+	tree.ComputeCommitment()
 
-//block1803Hash := tree.Hash()
-//if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
-//t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
-//}
+	block1803Hash := tree.Hash()
+	if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
+		t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
+	}
 
-//buf1.Reset()
-//account1.Balance.SetString("199000000000000000000", 10)
-//rlp.Encode(&buf1, &account1)
-//tree.Insert(addr1, buf1.Bytes())
-//buf2.Reset()
-//account2.Nonce = 4
-//account2.Balance.SetString("1000003587000000000000000000", 10)
-//rlp.Encode(&buf2, &account2)
-//tree.Insert(addr2, buf2.Bytes())
+	buf1.Reset()
+	account1.Balance.SetString("199000000000000000000", 10)
+	rlp.Encode(&buf1, &account1)
+	tree.Insert(addr1, buf1.Bytes())
+	buf2.Reset()
+	account2.Nonce = 4
+	account2.Balance.SetString("1000003587000000000000000000", 10)
+	rlp.Encode(&buf2, &account2)
+	tree.Insert(addr2, buf2.Bytes())
 
-//tree.ComputeCommitment()
+	tree.ComputeCommitment()
 
-//block1893Hash := tree.Hash()
-//if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
-//t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
-//}
-//}
+	block1893Hash := tree.Hash()
+	if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
+		t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
+	}
+}
 
 func TestConcurrentTrees(t *testing.T) {
 	value := []byte("value")


### PR DESCRIPTION
In preparation for the implementation of [the verkle tree eip](https://notes.ethereum.org/@vbuterin/verkle_tree_eip) in geth, change `LeafNode` to be a "last-level node" with `nodeWitdh` values instead of one (basically, replace `LeafNode` with a terminal node).

This PR deactivates the devnet 0 postmortem test, which loses its meaning in this context.