### PR TITLE
[DONTMERGE] return Frs instead of G1Points in GetCommitmentsAlongPath

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -34,10 +34,10 @@ import (
 	"github.com/protolambda/go-kzg/bls"
 )
 
-func calcR(cs []*bls.G1Point, indices []*bls.Fr, ys []*bls.Fr, modulus *big.Int) bls.Fr {
+func calcR(cs []*bls.Fr, indices []*bls.Fr, ys []*bls.Fr, modulus *big.Int) bls.Fr {
 	digest := sha256.New()
 	for _, c := range cs {
-		h := sha256.Sum256(bls.ToCompressedG1(c))
+		h := bls.FrTo32(c)
 		digest.Write(h[:])
 	}
 	for _, idx := range indices {
@@ -180,7 +180,7 @@ func MakeVerkleProofOneLeaf(root VerkleNode, key []byte) (d *bls.G1Point, y *bls
 	return
 }
 
-func VerifyVerkleProof(ks *kzg.KZGSettings, d, sigma *bls.G1Point, y *bls.Fr, commitments []*bls.G1Point, zis, yis []*bls.Fr, tc *TreeConfig) bool {
+func VerifyVerkleProof(ks *kzg.KZGSettings, d, sigma *bls.G1Point, y *bls.Fr, commitments []*bls.Fr, zis, yis []*bls.Fr, tc *TreeConfig) bool {
 	r := calcR(commitments, zis, yis, tc.modulus)
 	t := calcT(&r, d, tc.modulus)
 
@@ -199,7 +199,8 @@ func VerifyVerkleProof(ks *kzg.KZGSettings, d, sigma *bls.G1Point, y *bls.Fr, co
 
 		// E
 		var eTmp bls.G1Point
-		bls.MulG1(&eTmp, commitments[i], &rDivZi)
+		bls.MulG1(&eTmp, &bls.GenG1, commitments[i])
+		bls.MulG1(&eTmp, &eTmp, &rDivZi)
 		bls.AddG1(&e, &e, &eTmp)
 
 		// rⁱ⁺¹ = r ⨯ rⁱ

--- a/proof_test.go
+++ b/proof_test.go
@@ -54,13 +54,13 @@ func TestProofGenerationTwoLeaves(t *testing.T) {
 		t.Fatalf("invalid D commitment, expected %x, got %x", expectedD, bls.ToCompressedG1(d))
 	}
 
-	expectedY := "25260028056023728885062014257735876297522899925584752069345287414141735924126"
+	expectedY := "29842264055476368474381550200659803489591910572458223684866711009200423180479"
 	gotY := bls.FrStr(y)
 	if expectedY != gotY {
 		t.Fatalf("invalid y, expected %s != %s", expectedY, gotY)
 	}
 
-	expectedSigma := common.Hex2Bytes("ae8993d2fa20729db5b9c725921fc6f746cd52996a69ba44a63bc5be070134c1e94d529528441d1012e45f0bb54f67b5")
+	expectedSigma := common.Hex2Bytes("8a87e2392a409916844ae98625b39de4d3fc3b79cd5f9c5a09c13afa1ea9aeda0c71f2c087b4fbceff5217dcda8f1698")
 	if !bytes.Equal(expectedSigma, bls.ToCompressedG1(sigma)) {
 		t.Fatalf("invalid sigma, expected %x, got %x", expectedSigma, bls.ToCompressedG1(sigma))
 	}


### PR DESCRIPTION
This was an experiment destined to match more closely the behavior in `compute_commitment_root`, which returns an `int` representing a field element.

This PR has an issue in the calculation of `E` in the verification code: the commitments aren't directly accessible, so `E` can not be calculated by the verifier.

This is a tracking issue to remind me to ensure that the EIP doesn't have this same problem.