### PR TITLE
optimized modulus in hashToFr

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -50,7 +50,7 @@ func calcR(cs []*bls.G1Point, indices []*bls.Fr, ys []*bls.Fr, modulus *big.Int)
 	}
 
 	var tmp bls.Fr
-	hashToFr(&tmp, common.BytesToHash(digest.Sum(nil)), modulus)
+	hashToFr(&tmp, common.BytesToHash(digest.Sum(nil)))
 	return tmp
 
 }
@@ -64,7 +64,7 @@ func calcT(r *bls.Fr, d *bls.G1Point, modulus *big.Int) bls.Fr {
 	digest.Write(tmpBytes[:])
 
 	var tmp bls.Fr
-	hashToFr(&tmp, common.BytesToHash(digest.Sum(nil)), modulus)
+	hashToFr(&tmp, common.BytesToHash(digest.Sum(nil)))
 	return tmp
 }
 
@@ -81,7 +81,7 @@ func calcQ(e, d *bls.G1Point, y, w *bls.Fr, modulus *big.Int) bls.Fr {
 	digest.Write(tmpBytes[:])
 
 	var tmp bls.Fr
-	hashToFr(&tmp, common.BytesToHash(digest.Sum(nil)), modulus)
+	hashToFr(&tmp, common.BytesToHash(digest.Sum(nil)))
 	return tmp
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -236,14 +236,9 @@ func TestComputeRootCommitmentTwoLeaves(t *testing.T) {
 }
 
 func TestHashToFrTrailingZeroBytes(t *testing.T) {
-	modulus, ok := big.NewInt(0).SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
-	if !ok {
-		panic("could not get modulus")
-	}
-
 	h := common.HexToHash("c79e576e0f534a5bbed66b32e5022a9d624b4415779b369a62b2e7a6c3d8e000")
 	var out bls.Fr
-	hashToFr(&out, h, modulus)
+	hashToFr(&out, h)
 
 	h2 := common.HexToHash("c79e576e0f534a5bbed66b32e5022a9d624b4415779b369a62b2e7a6c3d8e000")
 	var expected bls.Fr


### PR DESCRIPTION
An optimized version of `hashToFr` that doesn't require going through the `big.Int` shebang.