### PR TITLE
Replace point with field element in ComputeCommitment

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/protolambda/go-kzg/bls"
 )
 
 const ErrInvalidNodeEncoding = "invalid node encoding"
@@ -104,7 +105,9 @@ func createInternalNode(bitlist []byte, raw []byte, depth, width int) (*Internal
 		return nil, errors.New(ErrInvalidNodeEncoding)
 	}
 	for i, index := range indices {
-		n.children[index] = &HashedNode{hash: common.BytesToHash(raw[i*32 : (i+1)*32])}
+		hashed := &HashedNode{hash: new(bls.Fr)}
+		bls.FrFrom32(hashed.hash, common.BytesToHash(raw[i*32:(i+1)*32]))
+		n.children[index] = hashed
 	}
 	return n, nil
 }

--- a/goerli_test.go
+++ b/goerli_test.go
@@ -38,12 +38,11 @@ func TestGoerliInsertBug(t *testing.T) {
 	root.InsertOrdered(common.Hex2Bytes("000c9f87eb59996c38b587bb3a5a49b85a64b8b6bb7dd76e87125fe1370071a2"), common.Hex2Bytes("f84b018701d7c17cd98200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9506198b51956083dabde9b3c5c0c4251b56ea4741396ce02631c4be379"), common.Hex2Bytes("f84b018701d7b0b950b200a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), nil)
 	root.InsertOrdered(common.Hex2Bytes("000ca9538ed7e9a5688464cc41c8c5f20af324c76ea78360abe7d57185c23834"), common.Hex2Bytes("f8440180a01a67cc51538c651f63e8d55094b0ae7bca7f623f05a9ff77ca815dd44d5c8322a010b37de11f39e0a372615c70e1d4d7c613937e8f61823d59be9bea62112e175c"), nil)
-	expected := common.Hex2Bytes("b9b18ff277a1a17cbc2a682710bdc3cf830a434b4fed0db5c904a66c7c53c235bb2160c0adcb941b5764a25ea0b62167")
+	expected := common.Hex2Bytes("bed89f4f0d247a4ffa449cb0a085b1f44669d5ef57819d4c7a775d2c814d6958")
 
-	comm := root.ComputeCommitment()
-	got := bls.ToCompressedG1(comm)
+	got := bls.FrTo32(root.ComputeCommitment())
 
-	if !bytes.Equal(got, expected) {
+	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -175,6 +175,7 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 	// Clear cached commitment on modification
 	if n.commitment != nil {
 		n.commitment = nil
+		n.hash = nil
 	}
 
 	nChild := n.treeConfig.offset2key(key, n.depth)
@@ -239,6 +240,7 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 	// Clear cached commitment on modification
 	if n.commitment != nil {
 		n.commitment = nil
+		n.hash = nil
 	}
 
 	nChild := n.treeConfig.offset2key(key, n.depth)
@@ -329,9 +331,8 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 
 func (n *InternalNode) Delete(key []byte) error {
 	// Clear cached commitment on modification
-	if n.commitment != nil {
-		n.commitment = nil
-	}
+	n.commitment = nil
+	n.hash = nil
 
 	nChild := n.treeConfig.offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
@@ -598,6 +599,7 @@ func (n *LeafNode) Insert(k []byte, value []byte) error {
 	}
 	n.values[lastSlot(n.treeConfig.width, k)] = value
 	n.commitment = nil
+	n.hash = nil
 	return nil
 }
 
@@ -614,6 +616,8 @@ func (n *LeafNode) Delete(k []byte) error {
 		return errors.New("trying to delete a non-existing key")
 	}
 
+	n.commitment = nil
+	n.hash = nil
 	n.values[lastSlot(n.treeConfig.width, k)] = nil
 	return nil
 }

--- a/tree.go
+++ b/tree.go
@@ -55,12 +55,10 @@ type VerkleNode interface {
 	// Get value at a given key
 	Get([]byte, NodeResolverFn) ([]byte, error)
 
-	// Hash of the current node
-	Hash() common.Hash
-
 	// ComputeCommitment computes the commitment of the node
-	// The result is cached.
-	ComputeCommitment() *bls.G1Point
+	// The results (the cureve point and the field element
+	// representation of its hash) are cached.
+	ComputeCommitment() *bls.Fr
 
 	// GetCommitmentAlongPath follows the path that one key
 	// traces through the tree, and collects the various
@@ -83,10 +81,11 @@ const (
 )
 
 var (
-	errInsertIntoHash    = errors.New("trying to insert into hashed node")
-	errValueNotPresent   = errors.New("value not present in tree")
-	errDeleteNonExistent = errors.New("trying to delete non-existent leaf")
-	errReadFromInvalid   = errors.New("trying to read from an invalid child")
+	errInsertIntoHash      = errors.New("trying to insert into hashed node")
+	errValueNotPresent     = errors.New("value not present in tree")
+	errDeleteNonExistent   = errors.New("trying to delete non-existent leaf")
+	errReadFromInvalid     = errors.New("trying to read from an invalid child")
+	errSerializeHashedNode = errors.New("trying to serialized a hashed node")
 
 	zeroHash = common.HexToHash("0000000000000000000000000000000000000000000000000000000000000000")
 )
@@ -104,8 +103,9 @@ type (
 		// commitment calculations.
 		count uint
 
-		// Cache the hash of the current node
-		hash common.Hash
+		// Cache the field representation of the hash
+		// of the current node.
+		hash *bls.Fr
 
 		// Cache the commitment value
 		commitment *bls.G1Point
@@ -114,7 +114,7 @@ type (
 	}
 
 	HashedNode struct {
-		hash       common.Hash
+		hash       *bls.Fr
 		commitment *bls.G1Point
 	}
 
@@ -123,7 +123,7 @@ type (
 		values [][]byte
 
 		commitment *bls.G1Point
-		hash       common.Hash
+		hash       *bls.Fr
 		treeConfig *TreeConfig
 	}
 
@@ -231,6 +231,10 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 	return nil
 }
 
+func (n *InternalNode) toHashedNode() *HashedNode {
+	return &HashedNode{n.hash, n.commitment}
+}
+
 func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn) error {
 	// Clear cached commitment on modification
 	if n.commitment != nil {
@@ -245,27 +249,17 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 		// subtree directly preceding this new one, can
 		// safely be calculated.
 		for i := int(nChild) - 1; i >= 0; i-- {
-			switch n.children[i].(type) {
+			switch child := n.children[i].(type) {
 			case Empty:
 				continue
-			case *LeafNode:
-				comm := n.children[i].ComputeCommitment()
-				childHash := n.children[i].Hash()
-				if flush != nil {
-					flush(n.children[i])
-				}
-				n.children[i] = &HashedNode{hash: childHash, commitment: comm}
+			case *LeafNode, *HashedNode:
 				break
-			case *HashedNode:
-				break
-			default:
-				comm := n.children[i].ComputeCommitment()
-				// Don't re-compute commitment as it's cached
-				h := n.children[i].Hash()
+			case *InternalNode:
+				n.children[i].ComputeCommitment()
 				if flush != nil {
 					n.children[i].(*InternalNode).Flush(flush)
 				}
-				n.children[i] = &HashedNode{hash: h, commitment: comm}
+				n.children[i] = child.toHashedNode()
 				break
 			}
 		}
@@ -278,6 +272,7 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 		}
 		lastNode.values[lastSlot(n.treeConfig.width, key)] = value
 		n.children[nChild] = lastNode
+		n.count++
 
 		// If the node was already created, then there was at least one
 		// child. As a result, inserting this new leaf means there are
@@ -305,15 +300,11 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 			if nextWordInInsertedKey != nextWordInExistingKey {
 				// Directly hash the (left) node that was already
 				// inserted.
-				h := child.Hash()
-				comm := new(bls.G1Point)
-				var tmp bls.Fr
-				hashToFr(&tmp, h, n.treeConfig.modulus)
-				bls.MulG1(comm, &bls.GenG1, &tmp)
+				child.ComputeCommitment()
 				if flush != nil {
 					flush(child)
 				}
-				newBranch.children[nextWordInExistingKey] = &HashedNode{hash: h, commitment: comm}
+				newBranch.children[nextWordInExistingKey] = child.toHashedNode()
 				// Next word differs, so this was the last level.
 				// Insert it directly into its final slot.
 				lastNode := &LeafNode{
@@ -401,9 +392,7 @@ func (n *InternalNode) Flush(flush NodeFlushFn) {
 			c.Flush(flush)
 			n.children[i] = &HashedNode{c.Hash(), c.commitment}
 		} else if c, ok := child.(*LeafNode); ok {
-			childHash := c.Hash()
-			flush(c)
-			n.children[i] = &HashedNode{hash: childHash}
+			n.children[i] = c.toHashedNode()
 		}
 	}
 	flush(n)
@@ -425,7 +414,8 @@ func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 			return nil, errReadFromInvalid
 		}
 
-		payload, err := getter(child.hash[:])
+		commitment := bls.FrTo32(child.hash)
+		payload, err := getter(commitment[:])
 		if err != nil {
 			return nil, err
 		}
@@ -441,10 +431,6 @@ func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 	default: // InternalNode
 		return child.Get(k, getter)
 	}
-}
-
-func (n *InternalNode) Hash() common.Hash {
-	return n.hash
 }
 
 // This function takes a hash and turns it into a bls.Fr integer, making
@@ -481,10 +467,11 @@ func hashToFr(out *bls.Fr, h [32]byte, modulus *big.Int) {
 	}
 }
 
-func (n *InternalNode) ComputeCommitment() *bls.G1Point {
-	if n.commitment != nil {
-		return n.commitment
+func (n *InternalNode) ComputeCommitment() *bls.Fr {
+	if n.hash != nil {
+		return n.hash
 	}
+	n.hash = new(bls.Fr)
 
 	emptyChildren := 0
 	lastIndex := -1
@@ -497,16 +484,14 @@ func (n *InternalNode) ComputeCommitment() *bls.G1Point {
 			lastIndex = idx
 			// Store the leaf node hash in the polynomial, even if
 			// the tree is free.
-			child.ComputeCommitment()
-			hashToFr(&poly[idx], child.Hash(), n.treeConfig.modulus)
+			bls.CopyFr(&poly[idx], child.ComputeCommitment())
 		case *HashedNode:
 			lastIndex = idx
-			hashToFr(&poly[idx], child.Hash(), n.treeConfig.modulus)
+			bls.CopyFr(&poly[idx], child.ComputeCommitment())
 		default:
 			lastIndex = idx
 			childC.ComputeCommitment()
-			h := childC.Hash()
-			hashToFr(&poly[idx], h, n.treeConfig.modulus)
+			bls.CopyFr(&poly[idx], child.ComputeCommitment())
 		}
 	}
 
@@ -514,15 +499,11 @@ func (n *InternalNode) ComputeCommitment() *bls.G1Point {
 	// (1 child, which must be a LeafNode), or multiple children, which are
 	// taken as the coefficients of a polynomial.
 	if child, ok := n.children[lastIndex].(*LeafNode); ok && n.count == 1 {
-		// Idée sur laquelle je bosse: cacher le commitment lui-même,
-		// renvoyer le hash à ce niveau (ou ne rien renvoyer) et pour
-		// GetCommitmentsAlongPath on récupère ce qui a été caché (donc
-		// les fis ?)
 		digest := sha256.New()
 		digest.Write(child.key[:31]) // write only the first 31 bytes
 		tmp := bls.FrTo32(&poly[lastIndex])
 		digest.Write(tmp[:])
-		n.hash = common.BytesToHash(digest.Sum(nil))
+		hashToFr(n.hash, common.BytesToHash(digest.Sum(nil)), n.treeConfig.modulus)
 
 		// Set the commitment to nil, as there is no real commitment at this
 		// level - only the hash has significance.
@@ -530,10 +511,10 @@ func (n *InternalNode) ComputeCommitment() *bls.G1Point {
 	} else {
 		n.commitment = n.treeConfig.evalPoly(poly, emptyChildren)
 		h := sha256.Sum256(bls.ToCompressedG1(n.commitment))
-		n.hash = common.BytesToHash(h[:])
+		hashToFr(n.hash, h, n.treeConfig.modulus)
 	}
 
-	return n.commitment
+	return n.hash
 }
 
 func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
@@ -548,12 +529,12 @@ func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*b
 	bls.AsFr(&zi, uint64(childIdx))
 	fi := make([]bls.Fr, n.treeConfig.nodeWidth)
 	for i, child := range n.children {
-		hashToFr(&fi[i], child.Hash(), n.treeConfig.modulus)
+		bls.CopyFr(&fi[i], child.ComputeCommitment())
 		if i == int(childIdx) {
 			bls.CopyFr(&yi, &fi[i])
 		}
 	}
-	return append(comms, n.ComputeCommitment()), append(zis, &zi), append(yis, &yi), append(fis, fi[:])
+	return append(comms, n.commitment), append(zis, &zi), append(yis, &yi), append(fis, fi[:])
 }
 
 func (n *InternalNode) Serialize() ([]byte, error) {
@@ -562,7 +543,8 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 	for i, c := range n.children {
 		if _, ok := c.(Empty); !ok {
 			setBit(bitlist[:], i)
-			children = append(children, c.Hash().Bytes()...)
+			digits := bls.FrTo32(c.ComputeCommitment())
+			children = append(children, digits[:]...)
 		}
 	}
 	return rlp.EncodeToBytes([]interface{}{internalRLPType, bitlist, children})
@@ -581,7 +563,10 @@ func (n *InternalNode) Copy() VerkleNode {
 		ret.children[i] = child.Copy()
 	}
 
-	copy(ret.hash[:], n.hash[:])
+	if n.hash != nil {
+		ret.hash = new(bls.Fr)
+		bls.CopyFr(ret.hash, n.hash)
+	}
 	if n.commitment != nil {
 		bls.CopyG1(ret.commitment, n.commitment)
 	}
@@ -600,6 +585,10 @@ func (n *InternalNode) clearCache() {
 		in.clearCache()
 	}
 	n.commitment = nil
+}
+
+func (n *LeafNode) toHashedNode() *HashedNode {
+	return &HashedNode{n.hash, n.commitment}
 }
 
 func (n *LeafNode) Insert(k []byte, value []byte) error {
@@ -652,10 +641,11 @@ func (n *LeafNode) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
 	return n.values[lastSlot(n.treeConfig.width, k)], nil
 }
 
-func (n *LeafNode) ComputeCommitment() *bls.G1Point {
-	if n.commitment != nil {
-		return n.commitment
+func (n *LeafNode) ComputeCommitment() *bls.Fr {
+	if n.hash != nil {
+		return n.hash
 	}
+	n.hash = new(bls.Fr)
 
 	emptyChildren := 0
 	poly := make([]bls.Fr, n.treeConfig.nodeWidth)
@@ -669,17 +659,13 @@ func (n *LeafNode) ComputeCommitment() *bls.G1Point {
 	}
 
 	n.commitment = n.treeConfig.evalPoly(poly, emptyChildren)
-	n.hash = sha256.Sum256(bls.ToCompressedG1(n.commitment))
-	return n.commitment
+
+	hashToFr(n.hash, sha256.Sum256(bls.ToCompressedG1(n.commitment)), n.treeConfig.modulus)
+	return n.hash
 }
 
 func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
 	return nil, nil, nil, nil
-}
-
-func (n *LeafNode) Hash() common.Hash {
-	n.ComputeCommitment()
-	return n.hash
 }
 
 func (n *LeafNode) Serialize() ([]byte, error) {
@@ -699,7 +685,9 @@ func (n *LeafNode) Copy() VerkleNode {
 	if n.commitment != nil {
 		l.commitment = n.commitment
 	}
-	copy(l.hash[:], n.hash[:])
+	if l.hash != nil {
+		bls.CopyFr(l.hash, n.hash)
+	}
 
 	return l
 }
@@ -720,12 +708,8 @@ func (n *HashedNode) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
 	return nil, errors.New("can not read from a hash node")
 }
 
-func (n *HashedNode) Hash() common.Hash {
+func (n *HashedNode) ComputeCommitment() *bls.Fr {
 	return n.hash
-}
-
-func (n *HashedNode) ComputeCommitment() *bls.G1Point {
-	return n.commitment
 }
 
 func (n *HashedNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {
@@ -733,14 +717,16 @@ func (n *HashedNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls
 }
 
 func (n *HashedNode) Serialize() ([]byte, error) {
-	return rlp.EncodeToBytes([][]byte{n.hash[:]})
+	return nil, errSerializeHashedNode
 }
 
 func (n *HashedNode) Copy() VerkleNode {
 	h := &HashedNode{
 		commitment: new(bls.G1Point),
 	}
-	copy(h.hash[:], n.hash[:])
+	if n.hash != nil {
+		bls.CopyFr(h.hash, n.hash)
+	}
 	if n.commitment != nil {
 		bls.CopyG1(h.commitment, n.commitment)
 	}
@@ -752,7 +738,7 @@ func (e Empty) Insert(k []byte, value []byte) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
 
-func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {
+func (e Empty) InsertOrdered(key []byte, value []byte, _ chan FlushableNode) error {
 	return e.Insert(key, value)
 }
 
@@ -764,12 +750,8 @@ func (e Empty) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
 	return nil, nil
 }
 
-func (e Empty) Hash() common.Hash {
-	return zeroHash
-}
-
-func (e Empty) ComputeCommitment() *bls.G1Point {
-	return &bls.ZeroG1
+func (e Empty) ComputeCommitment() *bls.Fr {
+	return &bls.ZERO
 }
 
 func (e Empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []*bls.Fr, []*bls.Fr, [][]bls.Fr) {

--- a/tree.go
+++ b/tree.go
@@ -56,7 +56,7 @@ type VerkleNode interface {
 	Get([]byte, NodeResolverFn) ([]byte, error)
 
 	// ComputeCommitment computes the commitment of the node
-	// The results (the cureve point and the field element
+	// The results (the curve point and the field element
 	// representation of its hash) are cached.
 	ComputeCommitment() *bls.Fr
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -362,7 +362,7 @@ func TestFlush1kLeaves(t *testing.T) {
 		flushCh <- node
 	}
 	go func() {
-		root := New(10)
+		root := New(8)
 		for _, k := range keys {
 			root.InsertOrdered(k, value, flush)
 		}
@@ -385,10 +385,7 @@ func TestFlush1kLeaves(t *testing.T) {
 	}
 
 	if leaves != n {
-		t.Errorf("number of flushed leaves incorrect. Expected %d got %d\n", n, leaves)
-	}
-	if count <= n {
-		t.Errorf("number of flushed nodes incorrect. Expected %d got %d\n", n, leaves)
+		t.Fatalf("number of flushed leaves incorrect. Expected %d got %d\n", n, leaves)
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -139,24 +139,15 @@ func TestGetTwoLeaves(t *testing.T) {
 	}
 }
 
-func TestTreeHashing(t *testing.T) {
-	root := New(10)
-	root.Insert(zeroKeyTest, testValue)
-	root.Insert(ffx32KeyTest, testValue)
-
-	root.Hash()
-}
-
 func TestComputeRootCommitmentThreeLeaves(t *testing.T) {
 	root := New(10)
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(fourtyKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := common.Hex2Bytes("3438030e22ae83a47e97592801b98c9887ab143a07108ca9d7c1de5a3eaac7b0")
+	expected := common.Hex2Bytes("3438030e22ae83a47e97592801b98c9887ab143a07108ca9d7c1de5a3eaac730")
 
-	root.ComputeCommitment()
-	got := root.Hash()
+	got := bls.FrTo32(root.ComputeCommitment())
 
 	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment hash %x != %x", got, expected)
@@ -171,13 +162,11 @@ func TestComputeRootCommitmentOnlineThreeLeaves(t *testing.T) {
 
 	// This still needs to be called, so that the root
 	// commitment is calculated.
-	comm := root.ComputeCommitment()
+	got := bls.FrTo32(root.ComputeCommitment())
 
-	expected := common.Hex2Bytes("88d760b018321bf37e62dddd78568b102f5d303bfd635c667fe3abffbf0523b3d337f061f0b5359198c970a55d60cbca")
+	expected := common.Hex2Bytes("3438030e22ae83a47e97592801b98c9887ab143a07108ca9d7c1de5a3eaac730")
 
-	got := bls.ToCompressedG1(comm)
-
-	if !bytes.Equal(got, expected) {
+	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
 	}
 }
@@ -188,12 +177,11 @@ func TestComputeRootCommitmentThreeLeavesDeep(t *testing.T) {
 	root.Insert(oneKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
 
-	expected := common.Hex2Bytes("b87fb70db2808c8c28b5c724191ea4b895489d6502b6172f92a82c83fb88c110021cd16f44149083541c834d54a1da36")
+	expected := common.Hex2Bytes("338b8c0c7ebf685fabf1a8b097a7c77c0e1bd742f2c04ad22a6227f4aea16972")
 
-	comm := root.ComputeCommitment()
-	got := bls.ToCompressedG1(comm)
+	got := bls.FrTo32(root.ComputeCommitment())
 
-	if !bytes.Equal(got, expected) {
+	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
 	}
 }
@@ -201,10 +189,9 @@ func TestComputeRootCommitmentOneLeaf(t *testing.T) {
 	root := New(8)
 	root.Insert(zeroKeyTest, zeroKeyTest)
 
-	expected := common.Hex2Bytes("c754161429960718cd6eca5ac4bf74af76b5435e838b928d90632f52be4700f4")
+	expected := common.Hex2Bytes("c65416142a960718ce12cc5ac11bb75b71dda1547bb3585a48e691286ba01200")
 
-	root.ComputeCommitment()
-	got := root.Hash()
+	got := bls.FrTo32(root.ComputeCommitment())
 
 	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment hash %x != %x", got, expected)
@@ -217,12 +204,11 @@ func TestComputeRootCommitmentOnlineThreeLeavesDeep(t *testing.T) {
 	root.InsertOrdered(oneKeyTest, testValue, nil)
 	root.InsertOrdered(ffx32KeyTest, testValue, nil)
 
-	expected := common.Hex2Bytes("b87fb70db2808c8c28b5c724191ea4b895489d6502b6172f92a82c83fb88c110021cd16f44149083541c834d54a1da36")
+	expected := common.Hex2Bytes("338b8c0c7ebf685fabf1a8b097a7c77c0e1bd742f2c04ad22a6227f4aea16972")
 
-	comm := root.ComputeCommitment()
-	got := bls.ToCompressedG1(comm)
+	got := bls.FrTo32(root.ComputeCommitment())
 
-	if !bytes.Equal(got, expected) {
+	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
 	}
 }
@@ -262,8 +248,7 @@ func TestComputeRootCommitmentTwoLeaves(t *testing.T) {
 	root.Insert(ffx32KeyTest, testValue)
 	expected := common.Hex2Bytes("907f6841e2e95f350899c767213bb44a8e9d4bdfa36872a49cc2eddc05d70753")
 
-	root.ComputeCommitment()
-	got := root.Hash()
+	got := bls.FrTo32(root.ComputeCommitment())
 
 	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
@@ -275,10 +260,9 @@ func TestComputeRootCommitmentTwoLeavesLastLevel(t *testing.T) {
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(oneKeyTest, testValue)
 
-	expected := common.Hex2Bytes("0ac1acd61bf406b149bd8e6f0a6d3f858a0551955274e0bda9f4cdf2c7cce0fb")
+	expected := common.Hex2Bytes("09c1acd61cf406b14a61906f07c98131852daf8b4a9ca68a617730c97425f307")
 
-	root.ComputeCommitment()
-	got := root.Hash()
+	got := bls.FrTo32(root.ComputeCommitment())
 
 	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
@@ -332,10 +316,9 @@ func TestComputeRootCommitmentTwoLeaves256(t *testing.T) {
 	root := New(8)
 	root.Insert(zeroKeyTest, testValue)
 	root.Insert(ffx32KeyTest, testValue)
-	expected := common.Hex2Bytes("a02ce754e95dcb632009d4f11845871990c1ceece8bddc8ed571623d03af4bfc")
+	expected := common.Hex2Bytes("9f2ce754ea5dcb6321add5f115a1c9c58ae92ce3e0e5a25b8df4c413b0075e08")
 
-	root.ComputeCommitment()
-	got := root.Hash()
+	got := bls.FrTo32(root.ComputeCommitment())
 
 	if !bytes.Equal(got[:], expected) {
 		t.Fatalf("incorrect root commitment %x != %x", got, expected)
@@ -351,20 +334,20 @@ func TestInsertVsOrdered(t *testing.T) {
 	copy(sortedKeys[:], keys[:])
 	sort.Slice(sortedKeys, func(i, j int) bool { return bytes.Compare(sortedKeys[i], sortedKeys[j]) < 0 })
 
-	root1 := New(10)
+	root1 := New(8)
 	for _, k := range keys {
 		root1.Insert(k, value)
 	}
-	root2 := New(10)
+	root2 := New(8)
 	for _, k := range sortedKeys {
 		root2.InsertOrdered(k, value, nil)
 	}
 
-	h1 := root1.Hash().Bytes()
-	h2 := root2.Hash().Bytes()
+	h2 := bls.FrTo32(root2.ComputeCommitment())
+	h1 := bls.FrTo32(root1.ComputeCommitment())
 
-	if !bytes.Equal(h1, h2) {
-		t.Error("Insert and InsertOrdered produce different trees")
+	if !bytes.Equal(h1[:], h2[:]) {
+		t.Errorf("Insert and InsertOrdered produce different trees %x != %x", h1, h2)
 	}
 }
 
@@ -423,19 +406,14 @@ func TestCopy(t *testing.T) {
 	copied := tree.Copy()
 	copied.(*InternalNode).clearCache()
 
-	copied.ComputeCommitment()
-	tree.ComputeCommitment()
-	got1 := copied.Hash()
-	got2 := tree.Hash()
+	got1 := bls.FrTo32(copied.ComputeCommitment())
+	got2 := bls.FrTo32(tree.ComputeCommitment())
 	if !bytes.Equal(got1[:], got2[:]) {
 		t.Fatalf("error copying commitments %x != %x", got1, got2)
 	}
-	if copied.Hash() != tree.Hash() {
-		t.Fatal("error copying commitments")
-	}
 	tree.Insert(key2, []byte("changed"))
 	tree.ComputeCommitment()
-	got2 = tree.Hash()
+	got2 = bls.FrTo32(tree.ComputeCommitment())
 	if bytes.Equal(got1[:], got2[:]) {
 		t1, _ := tree.Get(key2, nil)
 		t2, _ := copied.Get(key2, nil)
@@ -503,15 +481,15 @@ func TestDelLeaf(t *testing.T) {
 	tree := New(8)
 	tree.Insert(key1, value)
 	tree.Insert(key2, value)
-	hash := tree.Hash()
+	hash := tree.ComputeCommitment()
 
 	tree.Insert(key3, value)
 	if err := tree.Delete(key3); err != nil {
 		t.Error(err)
 	}
 
-	postHash := tree.Hash()
-	if !bytes.Equal(hash.Bytes(), postHash.Bytes()) {
+	postHash := tree.ComputeCommitment()
+	if !bls.EqualFr(hash, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 
@@ -547,24 +525,24 @@ func TestDeletePrune(t *testing.T) {
 	tree.Insert(key1, value)
 	tree.Insert(key2, value)
 
-	hash1 := tree.Hash()
+	hash1 := tree.ComputeCommitment()
 	tree.Insert(key3, value)
-	hash2 := tree.Hash()
+	hash2 := tree.ComputeCommitment()
 	tree.Insert(key4, value)
 
 	if err := tree.Delete(key4); err != nil {
 		t.Error(err)
 	}
-	postHash := tree.Hash()
-	if !bytes.Equal(hash2.Bytes(), postHash.Bytes()) {
+	postHash := tree.ComputeCommitment()
+	if !bls.EqualFr(hash2, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 
 	if err := tree.Delete(key3); err != nil {
 		t.Error(err)
 	}
-	postHash = tree.Hash()
-	if !bytes.Equal(hash1.Bytes(), postHash.Bytes()) {
+	postHash = tree.ComputeCommitment()
+	if !bls.EqualFr(hash1, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 }
@@ -579,16 +557,16 @@ func TestDeletePruneMultipleLevels(t *testing.T) {
 	tree.Insert(key1, value)
 	tree.Insert(key2, value)
 
-	hash1 := tree.Hash()
+	hash1 := tree.ComputeCommitment()
 	tree.Insert(key3, value)
-	hash2 := tree.Hash()
+	hash2 := tree.ComputeCommitment()
 	tree.Insert(key4, value)
 
 	if err := tree.Delete(key4); err != nil {
 		t.Error(err)
 	}
-	postHash := tree.Hash()
-	if !bytes.Equal(hash2.Bytes(), postHash.Bytes()) {
+	postHash := tree.ComputeCommitment()
+	if !bls.EqualFr(hash2, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 
@@ -600,8 +578,8 @@ func TestDeletePruneMultipleLevels(t *testing.T) {
 	if err := tree.Delete(key3); err != nil {
 		t.Error(err)
 	}
-	postHash = tree.Hash()
-	if !bytes.Equal(hash1.Bytes(), postHash.Bytes()) {
+	postHash = tree.ComputeCommitment()
+	if !bls.EqualFr(hash1, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 
@@ -620,9 +598,9 @@ func TestDeletePruneExtensions(t *testing.T) {
 	tree.Insert(key1, value)
 	tree.Insert(key2, value)
 
-	hash1 := tree.Hash()
+	hash1 := tree.ComputeCommitment()
 	tree.Insert(key3, value)
-	hash2 := tree.Hash()
+	hash2 := tree.ComputeCommitment()
 	tree.Insert(key4, value)
 
 	node4 := tree.(*InternalNode).children[4]
@@ -643,8 +621,8 @@ func TestDeletePruneExtensions(t *testing.T) {
 	if err := tree.Delete(key4); err != nil {
 		t.Error(err)
 	}
-	postHash := tree.Hash()
-	if !bytes.Equal(hash2.Bytes(), postHash.Bytes()) {
+	postHash := tree.ComputeCommitment()
+	if !bls.EqualFr(hash2, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 
@@ -660,8 +638,8 @@ func TestDeletePruneExtensions(t *testing.T) {
 	if err := tree.Delete(key3); err != nil {
 		t.Error(err)
 	}
-	postHash = tree.Hash()
-	if !bytes.Equal(hash1.Bytes(), postHash.Bytes()) {
+	postHash = tree.ComputeCommitment()
+	if !bls.EqualFr(hash1, postHash) {
 		t.Error("deleting leaf resulted in unexpected tree")
 	}
 }
@@ -706,7 +684,7 @@ func TestDevnet0PostMortem(t *testing.T) {
 
 	tree.ComputeCommitment()
 
-	block1803Hash := tree.Hash()
+	block1803Hash := bls.FrTo32(tree.ComputeCommitment())
 	if !bytes.Equal(block1803Hash[:], common.Hex2Bytes("74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c")) {
 		t.Fatalf("error, got %x != 74eb37a063c4c8806716d59816487c32315861d32f5f7697a9aaef5cfe964b9c", block1803Hash)
 	}
@@ -723,7 +701,7 @@ func TestDevnet0PostMortem(t *testing.T) {
 
 	tree.ComputeCommitment()
 
-	block1893Hash := tree.Hash()
+	block1893Hash := bls.FrTo32(tree.ComputeCommitment())
 	if !bytes.Equal(block1893Hash[:], common.Hex2Bytes("55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee")) {
 		t.Fatalf("error, got %x != 55938f57d4211b306eb3a1404d4784b2e0a8fdb254f284834b3ccf74791e54ee", block1803Hash)
 	}
@@ -733,14 +711,14 @@ func TestConcurrentTrees(t *testing.T) {
 	value := []byte("value")
 	tree := New(10)
 	tree.Insert(zeroKeyTest, value)
-	expected := tree.Hash()
+	expected := tree.ComputeCommitment()
 
 	threads := 2
-	ch := make(chan common.Hash)
+	ch := make(chan *bls.Fr)
 	builder := func() {
 		tree := New(10)
 		tree.Insert(zeroKeyTest, value)
-		ch <- tree.Hash()
+		ch <- tree.ComputeCommitment()
 	}
 
 	for i := 0; i < threads; i++ {
@@ -749,7 +727,7 @@ func TestConcurrentTrees(t *testing.T) {
 
 	for i := 0; i < threads; i++ {
 		root := <-ch
-		if !bytes.Equal(root.Bytes(), expected.Bytes()) {
+		if !bls.EqualFr(root, expected) {
 			t.Error("Incorrect root")
 		}
 	}
@@ -962,10 +940,9 @@ func TestMainnetStart(t *testing.T) {
 		tree.InsertOrdered(key, value, nil)
 	}
 
-	tree.ComputeCommitment()
-	h := tree.Hash()
+	h := bls.FrTo32(tree.ComputeCommitment())
 
-	if !bytes.Equal(h[:], common.Hex2Bytes("684fb4007b172aa7b33daad14e0badb200e6b6a521a9c8ebcdeb2ca45db2d88a")) {
+	if !bytes.Equal(h[:], common.Hex2Bytes("684fb4007b172aa7b33daad14e0badb200e6b6a521a9c8ebcdeb2ca45db2d80a")) {
 		t.Fatalf("invalid hash: %x", h)
 	}
 }
@@ -1039,7 +1016,7 @@ func isInternalEqual(a, b *InternalNode) bool {
 			if !ok {
 				return false
 			}
-			if !bytes.Equal(c.(*HashedNode).hash.Bytes(), hn.hash.Bytes()) {
+			if !bls.EqualFr(c.(*HashedNode).hash, hn.hash) {
 				return false
 			}
 		case *LeafNode:

--- a/tree_test.go
+++ b/tree_test.go
@@ -535,7 +535,7 @@ func TestDeletePrune(t *testing.T) {
 	}
 	postHash := tree.ComputeCommitment()
 	if !bls.EqualFr(hash2, postHash) {
-		t.Error("deleting leaf resulted in unexpected tree")
+		t.Error("deleting leaf #4 resulted in unexpected tree")
 	}
 
 	if err := tree.Delete(key3); err != nil {
@@ -543,7 +543,7 @@ func TestDeletePrune(t *testing.T) {
 	}
 	postHash = tree.ComputeCommitment()
 	if !bls.EqualFr(hash1, postHash) {
-		t.Error("deleting leaf resulted in unexpected tree")
+		t.Error("deleting leaf #3 resulted in unexpected tree")
 	}
 }
 


### PR DESCRIPTION
Part of the EIP draft update: to match the spec, `ComputeCommitment` now returns a `bls.Fr` element, and not a `bls.G1Point`.