### PR TITLE
Don't pass the modulus as a parameter to hashToFr

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,7 +27,6 @@ package verkle
 
 import (
 	"bytes"
-	"math/big"
 	"sync"
 
 	"github.com/protolambda/go-kzg"
@@ -42,7 +41,6 @@ const (
 )
 
 type KZGConfig struct {
-	modulus           *big.Int // Field's modulus
 	omegaIs           []bls.Fr // List of the root of unity
 	inverses          []bls.Fr // List of all 1 / (1 - ωⁱ)
 	nodeWidthInversed bls.Fr   // Inverse of node witdh in prime field
@@ -104,12 +102,6 @@ func initKZGConfig(lg1 []bls.G1Point) *KZGConfig {
 	for i := 0; i < NodeWidth; i++ {
 		bls.CopyFr(&tc.omegaIs[i], &tmp)
 		bls.MulModFr(&tmp, &tmp, &bls.Scale2RootOfUnity[8])
-	}
-
-	var ok bool
-	tc.modulus, ok = big.NewInt(0).SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
-	if !ok {
-		panic("could not get modulus")
 	}
 
 	// Compute all 1 / (1 - ωⁱ)

--- a/tree.go
+++ b/tree.go
@@ -215,10 +215,8 @@ func (n *InternalNode) Insert(key []byte, value []byte) error {
 				lastNode.values[key[31]] = value
 				newBranch.children[nextWordInInsertedKey] = lastNode
 				newBranch.count++
-			} else {
-				if err := newBranch.Insert(key, value); err != nil {
-					return err
-				}
+			} else if err := newBranch.Insert(key, value); err != nil {
+				return err
 			}
 		}
 	default: // InternalNode
@@ -778,7 +776,7 @@ func (n *HashedNode) Copy() VerkleNode {
 	return h
 }
 
-func (e Empty) Insert(k []byte, value []byte) error {
+func (Empty) Insert(k []byte, value []byte) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
 
@@ -786,27 +784,27 @@ func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {
 	return e.Insert(key, value)
 }
 
-func (e Empty) Delete(k []byte) error {
+func (Empty) Delete(k []byte) error {
 	return errors.New("cant delete an empty node")
 }
 
-func (e Empty) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
+func (Empty) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
 	return nil, nil
 }
 
-func (e Empty) ComputeCommitment() *bls.Fr {
+func (Empty) ComputeCommitment() *bls.Fr {
 	return &bls.ZERO
 }
 
-func (e Empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []int, []*bls.Fr, [][]bls.Fr) {
+func (Empty) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []int, []*bls.Fr, [][]bls.Fr) {
 	panic("trying to produce a commitment for an empty subtree")
 }
 
-func (e Empty) Serialize() ([]byte, error) {
+func (Empty) Serialize() ([]byte, error) {
 	return nil, errors.New("can't encode empty node to RLP")
 }
 
-func (e Empty) Copy() VerkleNode {
+func (Empty) Copy() VerkleNode {
 	return Empty(struct{}{})
 }
 

--- a/tree.go
+++ b/tree.go
@@ -258,7 +258,7 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 				if flush != nil {
 					flush(child)
 				}
-				hashToFr(child.hash, common.BytesToHash(digest.Sum(nil)), n.treeConfig.modulus)
+				hashToFr(child.hash, common.BytesToHash(digest.Sum(nil)))
 				n.children[i] = child.toHashedNode()
 				break searchFirstNonEmptyChild
 			case *HashedNode:
@@ -314,7 +314,7 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 				if flush != nil {
 					flush(child)
 				}
-				hashToFr(child.hash, common.BytesToHash(digest.Sum(nil)), n.treeConfig.modulus)
+				hashToFr(child.hash, common.BytesToHash(digest.Sum(nil)))
 				newBranch.children[nextWordInExistingKey] = child.toHashedNode()
 				// Next word differs, so this was the last level.
 				// Insert it directly into its final slot.
@@ -446,11 +446,22 @@ func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 	}
 }
 
+var modulus *big.Int
+
+func init() {
+	var ok bool
+	modulus, ok = big.NewInt(0).SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
+	if !ok {
+		panic("could not get modulus")
+	}
+
+}
+
 // This function takes a hash and turns it into a bls.Fr integer, making
 // sure that this doesn't overflow the modulus.
 // This piece of code is really ugly, and probably a performance hog, it
 // needs to be rewritten more efficiently.
-func hashToFr(out *bls.Fr, h [32]byte, modulus *big.Int) {
+func hashToFr(out *bls.Fr, h [32]byte) {
 	h[31] &= 0x7F // mod 2^255
 
 	// reverse endianness (little -> big)
@@ -502,13 +513,13 @@ func (n *InternalNode) ComputeCommitment() *bls.Fr {
 			// special case: only one leaf node - then ignore the top
 			// branch node.
 			if n.count == 1 && n.depth == 0 {
-				hashToFr(n.hash, common.BytesToHash(digest.Sum(nil)), n.treeConfig.modulus)
+				hashToFr(n.hash, common.BytesToHash(digest.Sum(nil)))
 				// Set the commitment to nil, as there is no real commitment at this
 				// level - only the hash has significance.
 				n.commitment = nil
 				return n.hash
 			}
-			hashToFr(&poly[idx], common.BytesToHash(digest.Sum(nil)), n.treeConfig.modulus)
+			hashToFr(&poly[idx], common.BytesToHash(digest.Sum(nil)))
 		case *HashedNode:
 			bls.CopyFr(&poly[idx], child.ComputeCommitment())
 		default:
@@ -522,7 +533,7 @@ func (n *InternalNode) ComputeCommitment() *bls.Fr {
 	n.commitment = evalPoly(poly, n.treeConfig.lg1, emptyChildren)
 	serialized := bls.ToCompressedG1(n.commitment)
 	h := sha256.Sum256(serialized)
-	hashToFr(n.hash, h, n.treeConfig.modulus)
+	hashToFr(n.hash, h)
 
 	return n.hash
 }
@@ -545,7 +556,7 @@ func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []in
 			digest.Write(c.key[:31]) // Write the stem
 			tmp := bls.FrTo32(c.hash)
 			digest.Write(tmp[:])
-			hashToFr(&fi[i], common.BytesToHash(digest.Sum(nil)), n.treeConfig.modulus)
+			hashToFr(&fi[i], common.BytesToHash(digest.Sum(nil)))
 		} else {
 			bls.CopyFr(&fi[i], child.ComputeCommitment())
 		}
@@ -667,13 +678,13 @@ func (n *LeafNode) ComputeCommitment() *bls.Fr {
 			continue
 		}
 		h := sha256.Sum256(val)
-		hashToFr(&poly[idx], h, n.treeConfig.modulus)
+		hashToFr(&poly[idx], h)
 	}
 
 	n.commitment = evalPoly(poly, n.treeConfig.lg1, emptyChildren)
 
 	h := sha256.Sum256(bls.ToCompressedG1(n.commitment))
-	hashToFr(n.hash, h, n.treeConfig.modulus)
+	hashToFr(n.hash, h)
 	return n.hash
 }
 
@@ -683,7 +694,7 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []int, [
 	for i, val := range n.values {
 		if val != nil {
 			var fi bls.Fr
-			hashToFr(&fi, sha256.Sum256(val), n.treeConfig.modulus)
+			hashToFr(&fi, sha256.Sum256(val))
 			bls.CopyFr(&fis[i], &fi)
 		}
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -242,14 +242,9 @@ func TestComputeRootCommitmentTwoLeavesLastLevel(t *testing.T) {
 }
 
 func TestHashToFrTrailingZeroBytes(t *testing.T) {
-	modulus, ok := big.NewInt(0).SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
-	if !ok {
-		panic("could not get modulus")
-	}
-
 	h := common.HexToHash("c79e576e0f534a5bbed66b32e5022a9d624b4415779b369a62b2e7a6c3d8e000")
 	var out bls.Fr
-	hashToFr(&out, h, modulus)
+	hashToFr(&out, h)
 
 	h2 := common.HexToHash("c79e576e0f534a5bbed66b32e5022a9d624b4415779b369a62b2e7a6c3d8e000")
 	var expected bls.Fr

--- a/tree_test.go
+++ b/tree_test.go
@@ -1117,7 +1117,7 @@ func TestGetResolveFromHash(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("error getting the correct number of nodes: 1 != %d", count)
 	}
-	if !bytes.Equal(data[:], zeroKeyTest[:]) {
+	if !bytes.Equal(data, zeroKeyTest[:]) {
 		t.Fatalf("invalid result: %x != %x", zeroKeyTest, data)
 	}
 }


### PR DESCRIPTION
This is so that the interface doesn't leak the type of crypto
primitive that is used, thus allowing for quick prototyping with
different curves/commitment schemes.

Co-authored-by: Kevaundray Wedderburn <kevtheappdev@gmail.com>