### PR TITLE
Add Committer interface to separate proof generation from tree structure

### DIFF
--- a/config.go
+++ b/config.go
@@ -90,53 +90,53 @@ func GetKZGConfig() *KZGConfig {
 }
 
 func initKZGConfig(lg1 []bls.G1Point) *KZGConfig {
-	tc := &KZGConfig{
+	kc := &KZGConfig{
 		lg1: lg1,
 	}
-	tc.omegaIs = make([]bls.Fr, NodeWidth)
-	tc.inverses = make([]bls.Fr, NodeWidth)
+	kc.omegaIs = make([]bls.Fr, NodeWidth)
+	kc.inverses = make([]bls.Fr, NodeWidth)
 
 	// Calculate the lagrangian evaluation basis.
 	var tmp bls.Fr
 	bls.CopyFr(&tmp, &bls.ONE)
 	for i := 0; i < NodeWidth; i++ {
-		bls.CopyFr(&tc.omegaIs[i], &tmp)
+		bls.CopyFr(&kc.omegaIs[i], &tmp)
 		bls.MulModFr(&tmp, &tmp, &bls.Scale2RootOfUnity[8])
 	}
 
 	// Compute all 1 / (1 - ωⁱ)
-	bls.CopyFr(&tc.inverses[0], &bls.ZERO)
+	bls.CopyFr(&kc.inverses[0], &bls.ZERO)
 	for i := 1; i < NodeWidth; i++ {
 		var tmp bls.Fr
-		bls.SubModFr(&tmp, &bls.ONE, &tc.omegaIs[i])
-		bls.DivModFr(&tc.inverses[i], &bls.ONE, &tmp)
+		bls.SubModFr(&tmp, &bls.ONE, &kc.omegaIs[i])
+		bls.DivModFr(&kc.inverses[i], &bls.ONE, &tmp)
 	}
 
-	bls.AsFr(&tc.nodeWidthInversed, uint64(NodeWidth))
-	bls.InvModFr(&tc.nodeWidthInversed, &tc.nodeWidthInversed)
+	bls.AsFr(&kc.nodeWidthInversed, uint64(NodeWidth))
+	bls.InvModFr(&kc.nodeWidthInversed, &kc.nodeWidthInversed)
 
-	return tc
+	return kc
 }
 
 // Compute a function in eval form at one of the points in the domain
-func (tc *KZGConfig) innerQuotients(f []bls.Fr, index int) []bls.Fr {
+func (kc *KZGConfig) innerQuotients(f []bls.Fr, index int) []bls.Fr {
 	q := make([]bls.Fr, NodeWidth)
 
 	y := f[index]
 	for i := 0; i < NodeWidth; i++ {
 		if i != index {
-			omegaIdx := (len(tc.omegaIs) - i) % len(tc.omegaIs)
+			omegaIdx := (len(kc.omegaIs) - i) % len(kc.omegaIs)
 			invIdx := (index + NodeWidth - i) % NodeWidth
 			iMinIdx := (i - index + NodeWidth) % NodeWidth
 
 			// calculate q[i]
 			var tmp bls.Fr
 			bls.SubModFr(&tmp, &f[i], &y)
-			bls.MulModFr(&tmp, &tmp, &tc.omegaIs[omegaIdx])
-			bls.MulModFr(&q[i], &tmp, &tc.inverses[invIdx])
+			bls.MulModFr(&tmp, &tmp, &kc.omegaIs[omegaIdx])
+			bls.MulModFr(&q[i], &tmp, &kc.inverses[invIdx])
 
 			// calculate q[i]'s contribution to q[index]
-			bls.MulModFr(&tmp, &tc.omegaIs[iMinIdx], &q[i])
+			bls.MulModFr(&tmp, &kc.omegaIs[iMinIdx], &q[i])
 			bls.SubModFr(&tmp, &bls.ZERO, &tmp)
 			bls.AddModFr(&q[index], &q[index], &tmp)
 		}
@@ -146,13 +146,13 @@ func (tc *KZGConfig) innerQuotients(f []bls.Fr, index int) []bls.Fr {
 }
 
 // Compute a function in eval form at a point outside of the domain
-func (tc *KZGConfig) outerQuotients(f []bls.Fr, z, y *bls.Fr) []bls.Fr {
+func (kc *KZGConfig) outerQuotients(f []bls.Fr, z, y *bls.Fr) []bls.Fr {
 	q := make([]bls.Fr, NodeWidth)
 
 	for i := 0; i < NodeWidth; i++ {
 		var tmp, quo bls.Fr
 		bls.SubModFr(&tmp, &f[i], y)
-		bls.SubModFr(&quo, &tc.omegaIs[i], z)
+		bls.SubModFr(&quo, &kc.omegaIs[i], z)
 		bls.DivModFr(&q[i], &tmp, &quo)
 	}
 
@@ -160,16 +160,16 @@ func (tc *KZGConfig) outerQuotients(f []bls.Fr, z, y *bls.Fr) []bls.Fr {
 }
 
 // Evaluate a polynomial in the lagrange basis
-func commitToPoly(poly []bls.Fr, lg1 []bls.G1Point, emptyChildren int) *bls.G1Point {
+func (kc *KZGConfig) CommitToPoly(poly []bls.Fr, emptyChildren int) *bls.G1Point {
 	if NodeWidth-emptyChildren >= multiExpThreshold8 {
-		return bls.LinCombG1(lg1, poly)
+		return bls.LinCombG1(kc.lg1, poly)
 	} else {
 		var comm bls.G1Point
 		bls.CopyG1(&comm, &bls.ZERO_G1)
 		for i := range poly {
 			if !bls.EqualZero(&poly[i]) {
 				var tmpG1, eval bls.G1Point
-				bls.MulG1(&eval, &lg1[i], &poly[i])
+				bls.MulG1(&eval, &kc.lg1[i], &poly[i])
 				bls.CopyG1(&tmpG1, &comm)
 				bls.AddG1(&comm, &tmpG1, &eval)
 			}

--- a/encoding.go
+++ b/encoding.go
@@ -70,14 +70,13 @@ func ParseNode(serialized []byte, depth int) (VerkleNode, error) {
 		if err := rlp.DecodeBytes(rest, &values); err != nil {
 			return nil, err
 		}
-		tc := GetKZGConfig()
 		if NodeWidth != len(values) {
 			return nil, fmt.Errorf("invalid number of nodes in decoded child expected %d, got %d", NodeWidth, len(values))
 		}
 		ln := &LeafNode{
-			key:        key,
-			values:     values,
-			treeConfig: tc,
+			key:       key,
+			values:    values,
+			committer: GetKZGConfig(),
 		}
 		return ln, nil
 	case internalRLPType:


### PR DESCRIPTION
This is a rewrite of #94, whose changes have been accidentally destroyed.

It abstracts the way the commitment is calculated by introducing a `Committer` interface, that provides `CommitToPoly`. The implementation details (evaluations of powers of `s`, Lagrange basis, etc...) are now unknown to the tree.

Co-authored-by: Kevaundray Wedderburn <kevtheappdev@gmail.com>