### PR TITLE
initial attempt at proof of absence

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -571,7 +571,6 @@ func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []ui
 		return n.children[childIdx].GetCommitmentsAlongPath(key)
 	}
 
-	comms, zis, yis, fis := n.children[childIdx].GetCommitmentsAlongPath(key)
 	var yi bls.Fr
 	fi := make([]bls.Fr, NodeWidth)
 	for i, child := range n.children {
@@ -581,6 +580,12 @@ func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*bls.G1Point, []ui
 			bls.CopyFr(&yi, &fi[i])
 		}
 	}
+	// Special case of a proof of absence: return a zero commitment
+	if _, ok := n.children[childIdx].(Empty); ok {
+		fmt.Println(bls.GenG1)
+		return []*bls.G1Point{&bls.GenG1}, []uint{uint(childIdx)}, []*bls.Fr{&yi}, [][]bls.Fr{fi}
+	}
+	comms, zis, yis, fis := n.children[childIdx].GetCommitmentsAlongPath(key)
 	return append(comms, n.commitment), append(zis, uint(childIdx)), append(yis, &yi), append(fis, fi)
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1123,3 +1123,21 @@ func TestToDot(*testing.T) {
 
 	fmt.Println(root.toDot("", ""))
 }
+
+func TestEmptyCommitment(t *testing.T) {
+	root := New()
+	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	comms, zis, yis, fis := root.GetCommitmentsAlongPath(oneKeyTest)
+	if len(comms) != 1 || len(zis) != 1 || len(yis) != 1 || len(fis) != 1 {
+		t.Fatalf("invalid parameter list length")
+	}
+
+	fmt.Println(comms)
+	if !bls.EqualG1(comms[0], &bls.GenG1) {
+		t.Fatalf("invalid commitment")
+	}
+
+	if !bls.EqualFr(yis[0], &bls.ZERO) {
+		t.Fatalf("invalid yi")
+	}
+}


### PR DESCRIPTION
This PR won't be merged, it's used as a reference of what should have been done with KZG. The final proof of absence work needs to be performed on the IPA PR #105.

The reason why this work is not complete, is the handling of the  "special case" that disappears in Dankrad-3. Fixing it is not trivial, and the work would be immediately obsolete.