### PR TITLE
Add support for proofs of absence

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -507,7 +507,7 @@ func (n *InternalNode) ComputeCommitment() *Fr {
 func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*Point, []uint8, []*Fr, [][]Fr) {
 	childIdx := offset2key(key, n.depth)
 
-	comms, zis, yis, fis := n.children[childIdx].GetCommitmentsAlongPath(key)
+	// Build the list of elements for this level
 	var yi Fr
 	fi := make([]Fr, NodeWidth)
 	for i, child := range n.children {
@@ -517,6 +517,15 @@ func (n *InternalNode) GetCommitmentsAlongPath(key []byte) ([]*Point, []uint8, [
 			CopyFr(&yi, &fi[i])
 		}
 	}
+
+	// Special case of a proof of absence: return a zero commitment
+	if _, ok := n.children[childIdx].(Empty); !ok {
+		var p Point
+		p.Identity()
+		return []*Point{&p}, []uint8{uint8(childIdx)}, []*Fr{&yi}, [][]Fr{fi}
+	}
+
+	comms, zis, yis, fis := n.children[childIdx].GetCommitmentsAlongPath(key)
 	return append(comms, n.commitment), append(zis, childIdx), append(yis, &yi), append(fis, fi)
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -868,3 +868,24 @@ func TestToDot(*testing.T) {
 
 	fmt.Println(root.toDot("", ""))
 }
+
+func TestEmptyCommitment(t *testing.T) {
+	root := New()
+	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	comms, zis, yis, fis := root.GetCommitmentsAlongPath(oneKeyTest)
+	if len(comms) != 1 || len(zis) != 1 || len(yis) != 1 || len(fis) != 1 {
+		t.Fatalf("invalid parameter list length")
+	}
+
+	var id Point
+	id.Identity()
+	fmt.Println(comms)
+	if !comms[0].Equal(&id) {
+		t.Fatalf("invalid commitment %x %x", comms[0], id)
+	}
+
+	zero := new(Fr)
+	if yis[0].Equal(zero) {
+		t.Fatalf("invalid yi")
+	}
+}


### PR DESCRIPTION
Fixes #109 

Simply return a 0 value to mark the data isn't present.

