### PR TITLE
Support proof of absence at node level

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -27,6 +27,7 @@ package verkle
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"testing"
 )
 
@@ -84,6 +85,18 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 	}
 }
 
+func TestProofOfAbsenceLeafVerify(t *testing.T) {
+	root := New()
+	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+
+	proof := MakeVerkleProofOneLeaf(root, oneKeyTest)
+
+	comms, zis, yis, _ := root.GetCommitmentsAlongPath(oneKeyTest)
+	if !VerifyVerkleProof(proof, comms, zis, yis, GetConfig()) {
+		t.Fatal("could not verify verkle proof")
+	}
+}
 func BenchmarkProofCalculation(b *testing.B) {
 	value := []byte("value")
 	keys := make([][]byte, 100000)

--- a/proof_test.go
+++ b/proof_test.go
@@ -85,6 +85,19 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 	}
 }
 
+func TestProofOfAbsenceInternalVerify(t *testing.T) {
+	root := New()
+	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(oneKeyTest, zeroKeyTest, nil)
+
+	proof := MakeVerkleProofOneLeaf(root, ffx32KeyTest)
+
+	comms, zis, yis, _ := root.GetCommitmentsAlongPath(ffx32KeyTest)
+	if !VerifyVerkleProof(proof, comms, zis, yis, GetConfig()) {
+		t.Fatal("could not verify verkle proof")
+	}
+}
+
 func TestProofOfAbsenceLeafVerify(t *testing.T) {
 	root := New()
 	root.Insert(zeroKeyTest, zeroKeyTest, nil)

--- a/proof_test.go
+++ b/proof_test.go
@@ -97,6 +97,24 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 		t.Fatal("could not verify verkle proof")
 	}
 }
+func TestProofOfAbsenceLeafVerifyOtherSuffix(t *testing.T) {
+	root := New()
+	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+
+	key := func() []byte {
+		ret, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000080")
+		return ret
+	}()
+
+	proof := MakeVerkleProofOneLeaf(root, key)
+
+	comms, zis, yis, _ := root.GetCommitmentsAlongPath(key)
+	if !VerifyVerkleProof(proof, comms, zis, yis, GetConfig()) {
+		t.Fatal("could not verify verkle proof")
+	}
+}
+
 func BenchmarkProofCalculation(b *testing.B) {
 	value := []byte("value")
 	keys := make([][]byte, 100000)

--- a/tree.go
+++ b/tree.go
@@ -665,7 +665,7 @@ func fillSuffixTreePoly(poly []Fr, values [][]byte) int {
 func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*Point, []byte, []*Fr, [][]Fr) {
 	var (
 		slot     = key[31]
-		suffSlot = 2 + byte(slot/128)
+		suffSlot = 2 + slot/128
 		poly     [256]Fr
 		count    int
 	)

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -58,7 +58,7 @@ func extensionAndSuffixOneKey(key, value []byte, ret *Point) {
 
 	(&zero).Identity()
 	toFr(&v, &zero)
-	stemComm3.ScalarMul(&srs[3], &v)
+	stemComm3.ScalarMul(&srs[3], &FrZero)
 
 	t1.Add(&stemComm0, &stemComm1)
 	t2.Add(&stemComm2, &stemComm3)

--- a/tree_test.go
+++ b/tree_test.go
@@ -868,11 +868,8 @@ func TestEmptyCommitment(t *testing.T) {
 		t.Fatalf("invalid parameter list length")
 	}
 
-	var id Point
-	id.Identity()
-	fmt.Println(comms)
-	if !comms[0].Equal(&id) {
-		t.Fatalf("invalid commitment %x %x", comms[0], id)
+	if !comms[0].Equal(root.(*InternalNode).commitment) {
+		t.Fatalf("invalid commitment %x %x", comms[0], root.(*InternalNode).commitment)
 	}
 
 	zero := new(Fr)


### PR DESCRIPTION
The previous IPA code didn't support proof of absence at `LeafNode` level, this PR fixes it, and all proofs at `LeafNode` level, really.