### PR TITLE
move endianness management to ipa.go

### DIFF
--- a/ipa.go
+++ b/ipa.go
@@ -51,6 +51,12 @@ func from32(fr *Fr, data [32]byte) {
 	fr.SetBytes(data[:])
 }
 
+func fromLEBytes(fr *Fr, data []byte) {
+	for i := range data {
+		data[i], data[len(data)-1-i] = data[len(data)-1-i], data[i]
+	}
+	fr.SetBytes(data)
+}
 func fromBytes(fr *Fr, data []byte) {
 	fr.SetBytes(data)
 }

--- a/ipa.go
+++ b/ipa.go
@@ -58,7 +58,7 @@ func fromLEBytes(fr *Fr, data []byte) {
 	fr.SetBytes(data)
 }
 func fromBytes(fr *Fr, data []byte) {
-	fr.SetBytes(data)
+	fromLEBytes(fr, data)
 }
 
 func Equal(fr *Fr, other *Fr) bool {

--- a/tree.go
+++ b/tree.go
@@ -625,22 +625,11 @@ func leafToComms(poly []Fr, val []byte) {
 	if len(val) > 32 {
 		panic(fmt.Sprintf("invalid leaf length %d, %v", len(val), val))
 	}
-	var (
-		valLoWithMarker [17]byte
-		valHi           [16]byte
-	)
-	valLoWithMarker[0] = 1 // 2**21
-	// swap bytes because bandersnatch uses big endian
-	for i := range valLoWithMarker[1:] {
-		if len(val) > 16-i {
-			valLoWithMarker[1+i] = val[15-i]
-		}
-		if len(val) > 32-i {
-			valHi[i] = val[31-i]
-		}
-	}
-	fromBytes(&poly[0], valLoWithMarker[:])
-	fromBytes(&poly[1], valHi[:])
+	var valLoWithMarker [17]byte
+	copy(valLoWithMarker[:16], val[:16])
+	valLoWithMarker[16] = 1 // 2**128
+	fromLEBytes(&poly[0], valLoWithMarker[:])
+	fromLEBytes(&poly[1], val[16:])
 }
 
 func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*Point, []byte, []*Fr, [][]Fr) {

--- a/tree.go
+++ b/tree.go
@@ -625,11 +625,19 @@ func leafToComms(poly []Fr, val []byte) {
 	if len(val) > 32 {
 		panic(fmt.Sprintf("invalid leaf length %d, %v", len(val), val))
 	}
-	var valLoWithMarker [17]byte
-	copy(valLoWithMarker[:16], val[:16])
+	var (
+		valLoWithMarker [17]byte
+		loEnd           = 16
+	)
+	if len(val) < loEnd {
+		loEnd = len(val)
+	}
+	copy(valLoWithMarker[:loEnd], val[:loEnd])
 	valLoWithMarker[16] = 1 // 2**128
 	fromLEBytes(&poly[0], valLoWithMarker[:])
-	fromLEBytes(&poly[1], val[16:])
+	if len(val) >= 16 {
+		fromLEBytes(&poly[1], val[16:])
+	}
 }
 
 func (n *LeafNode) GetCommitmentsAlongPath(key []byte) ([]*Point, []byte, []*Fr, [][]Fr) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -824,3 +824,29 @@ func TestEmptyCommitment(t *testing.T) {
 		t.Fatalf("invalid yi %v %v", zero, yis[0])
 	}
 }
+
+func TestLeafToCommsMoreThan32(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("didn't catch length error")
+		}
+	}()
+	var value [33]byte
+	leafToComms([]Fr{}, value[:])
+}
+
+func TestLeafToCommsLessThan32(*testing.T) {
+	var (
+		value [16]byte
+		p     [2]Fr
+	)
+	leafToComms(p[:], value[:])
+}
+
+func TestLeafToCommsLessThan16(*testing.T) {
+	var (
+		value [4]byte
+		p     [2]Fr
+	)
+	leafToComms(p[:], value[:])
+}


### PR DESCRIPTION
Move all endianness considerations to an IPA-specific file, so that it can be fixed in the dependency.