### PR TITLE
Rename LeafNode to ExtNode

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -64,7 +64,7 @@ func ParseNode(serialized []byte, depth int) (VerkleNode, error) {
 		if NodeWidth != len(values) {
 			return nil, fmt.Errorf("invalid number of nodes in decoded child expected %d, got %d", NodeWidth, len(values))
 		}
-		ln := &LeafNode{
+		ln := &ExtNode{
 			stem:      serialized[1:32],
 			values:    values[:],
 			committer: GetConfig(),


### PR DESCRIPTION
The historical name of `LeafNode` is no longer describing accurately what this node does: it gathers 256 leaves, sharing the same 31-byte stem. Change the name to something more accurate `ExtNode`, which is short for "extension and suffix tree".