### PR TITLE
stateless: add a test for GetCommitmentsAlongPath

### DIFF
--- a/stateless_test.go
+++ b/stateless_test.go
@@ -28,6 +28,7 @@ package verkle
 import (
 	"bytes"
 	"encoding/hex"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -127,6 +128,26 @@ func TestStatelessInsertOrdered(t *testing.T) {
 	err := root.InsertOrdered(zeroKeyTest, fourtyKeyTest, nil)
 	if err != errNotSupportedInStateless {
 		t.Fatalf("got the wrong error: expected %v, got %v", errNotSupportedInStateless, err)
+	}
+}
+
+func TestStatelessGetCommitmentsAlongPath(t *testing.T) {
+	root := NewStateless()
+	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, fourtyKeyTest, nil)
+	root.Insert(fourtyKeyTest, fourtyKeyTest, nil)
+
+	rootRef := New()
+	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(fourtyKeyTest, fourtyKeyTest, nil)
+	rootRef.ComputeCommitment()
+
+	stf := rootRef.GetCommitmentsAlongPath(oneKeyTest)
+	stl := root.GetCommitmentsAlongPath(oneKeyTest)
+
+	if !reflect.DeepEqual(stf, stl) {
+		t.Fatalf("commitments along path differ %v != %v", stf, stl)
 	}
 }
 


### PR DESCRIPTION
In the case of a stateless sync, a client must be able to work on a stateless verkle tree, and calculate its root commitment. It remains an open question whether there is a use case for building a proof from a stateless tree. It is possible, because in order to be usable, the tree needs to contain enough information to be updatable. This PR is a first attempt at implementing this.

Currently, `GetCommitmentAlongPath` does not return enough information to be able to provide a proof - siblings that are not in the map, are not returned. This is not currently possible, because `StatelessNode` does not support "collapsed" or "hashed" nodes.