### PR TITLE
Compatibility with rust-verkle's proof format

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,5 +41,5 @@ func equalPaths(key1, key2 []byte) bool {
 // offset2key extracts the n bits of a key that correspond to the
 // index of a child node.
 func offset2key(key []byte, offset byte) byte {
-	return key[int(offset)/8]
+	return key[offset]
 }

--- a/encoding.go
+++ b/encoding.go
@@ -68,6 +68,7 @@ func ParseNode(serialized []byte, depth byte) (VerkleNode, error) {
 			stem:      serialized[1:32],
 			values:    values[:],
 			committer: GetConfig(),
+			depth:     depth,
 		}
 		return ln, nil
 	case internalRLPType:

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -114,49 +114,50 @@ func VerifyVerkleProof(proof *Proof, Cs []*Point, indices []uint8, ys []*Fr, tc 
 // * len(depths) || serialize(depthi || ext statusi)
 // * len(commitments) || serialize(commitment)
 // * Multipoint proof
-func SerializeProof(proof *Proof) ([]byte, error) {
-	var buf bytes.Buffer
+// it also returns the serialized keys and values
+func SerializeProof(proof *Proof) ([]byte, []byte, error) {
+	var bufProof, bufKV bytes.Buffer
 
-	binary.Write(&buf, binary.LittleEndian, uint32(len(proof.PoaStems)))
+	binary.Write(&bufProof, binary.LittleEndian, uint32(len(proof.PoaStems)))
 	for _, stem := range proof.PoaStems {
-		_, err := buf.Write(stem)
+		_, err := bufProof.Write(stem)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	binary.Write(&buf, binary.LittleEndian, uint32(len(proof.ExtStatus)))
+	binary.Write(&bufProof, binary.LittleEndian, uint32(len(proof.ExtStatus)))
 	for _, daes := range proof.ExtStatus {
-		err := buf.WriteByte(daes)
+		err := bufProof.WriteByte(daes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	binary.Write(&buf, binary.LittleEndian, uint32(len(proof.Cs)))
+	binary.Write(&bufProof, binary.LittleEndian, uint32(len(proof.Cs)))
 	for _, C := range proof.Cs {
 		serialized := C.Bytes()
-		_, err := buf.Write(serialized[:])
+		_, err := bufProof.Write(serialized[:])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	proof.Multipoint.Write(&buf)
+	proof.Multipoint.Write(&bufProof)
 
 	// Temporary: add the keys and values to the proof
-	binary.Write(&buf, binary.LittleEndian, uint32(len(proof.Keys)))
+	binary.Write(&bufKV, binary.LittleEndian, uint32(len(proof.Keys)))
 	for i, key := range proof.Keys {
-		buf.Write(key)
+		bufKV.Write(key)
 		if proof.Values[i] != nil {
-			buf.WriteByte(1)
-			buf.Write(proof.Values[i])
+			bufKV.WriteByte(1)
+			bufKV.Write(proof.Values[i])
 		} else {
-			buf.WriteByte(0)
+			bufKV.WriteByte(0)
 		}
 	}
 
-	return buf.Bytes(), nil
+	return bufProof.Bytes(), bufKV.Bytes(), nil
 }
 
 func DeserializeProof(proofSerialized []byte) (*Proof, error) {

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -160,10 +160,11 @@ func SerializeProof(proof *Proof) ([]byte, []byte, error) {
 	return bufProof.Bytes(), bufKV.Bytes(), nil
 }
 
+// TODO add keys and values to the signature
 func DeserializeProof(proofSerialized []byte) (*Proof, error) {
 	var (
 		numPoaStems, numExtStatus uint32
-		numCommitments, numKeys   uint32
+		numCommitments            uint32
 		poaStems, keys, values    [][]byte
 		extStatus                 []byte
 		commitments               []*Point
@@ -215,23 +216,6 @@ func DeserializeProof(proofSerialized []byte) (*Proof, error) {
 
 	// TODO submit PR to go-ipa to make this return an error if it fails to Read
 	multipoint.Read(reader)
-
-	// Temporary: read the keys and values, serialized as binary data
-	if err := binary.Read(reader, binary.LittleEndian, &numKeys); err != nil {
-		return nil, err
-	}
-	for i := 0; i < int(numKeys); i++ {
-		var key, value [32]byte
-		reader.Read(key[:])
-		keys = append(keys, key[:])
-		b, _ := reader.ReadByte()
-		if b == 1 {
-			reader.Read(value[:])
-			values = append(values, value[:])
-		} else {
-			values = append(values, nil)
-		}
-	}
 
 	proof := Proof{
 		&multipoint,

--- a/proof_test.go
+++ b/proof_test.go
@@ -71,15 +71,17 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 	const leafCount = 1000
 
 	keys := make([][]byte, leafCount)
+	kv := make(map[string][]byte)
 	root := New()
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
 		root.Insert(key, fourtyKeyTest, nil)
+		kv[string(key)] = fourtyKeyTest
 	}
 
-	proof, _, _, _ := MakeVerkleMultiProof(root, keys[0:2])
+	proof, _, _, _ := MakeVerkleMultiProof(root, keys[0:2], kv)
 
 	pe, _, _ := GetCommitmentsForMultiproof(root, keys[0:2])
 	if !VerifyVerkleProof(proof, pe.Cis, pe.Zis, pe.Yis, GetConfig()) {
@@ -92,10 +94,12 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 
 	var keys [][]byte
 	var absentstem [31]byte
+	kv := make(map[string][]byte)
 	root := New()
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
 		key[2] = byte(i)
+		kv[string(key)] = fourtyKeyTest
 		root.Insert(key, fourtyKeyTest, nil)
 		if i%2 == 0 {
 			keys = append(keys, key)
@@ -109,7 +113,7 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 	absent[3] = 1 // and the stem differs
 	keys = append(keys, absent)
 
-	proof, _, _, _ := MakeVerkleMultiProof(root, keys)
+	proof, _, _, _ := MakeVerkleMultiProof(root, keys, kv)
 
 	pe, _, isabsent := GetCommitmentsForMultiproof(root, keys)
 	if len(isabsent) == 0 {
@@ -125,14 +129,17 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 }
 
 func TestMultiProofVerifyMultipleLeavesCommitmentRedundancy(t *testing.T) {
+	kv := make(map[string][]byte)
 	keys := make([][]byte, 2)
 	root := New()
 	keys[0] = zeroKeyTest
+	kv[string(zeroKeyTest)] = fourtyKeyTest
 	root.Insert(keys[0], fourtyKeyTest, nil)
 	keys[1] = oneKeyTest
+	kv[string(oneKeyTest)] = fourtyKeyTest
 	root.Insert(keys[1], fourtyKeyTest, nil)
 
-	proof, _, _, _ := MakeVerkleMultiProof(root, keys)
+	proof, _, _, _ := MakeVerkleMultiProof(root, keys, kv)
 
 	pe, _, _ := GetCommitmentsForMultiproof(root, keys)
 	if !VerifyVerkleProof(proof, pe.Cis, pe.Zis, pe.Yis, GetConfig()) {

--- a/proof_test.go
+++ b/proof_test.go
@@ -254,7 +254,7 @@ func TestProofSerializationNoAbsentStem(t *testing.T) {
 
 	proof := MakeVerkleProofOneLeaf(root, keys[0])
 
-	serialized, err := SerializeProof(proof)
+	serialized, _, err := SerializeProof(proof)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestProofSerializationWithAbsentStem(t *testing.T) {
 
 	proof := MakeVerkleProofOneLeaf(root, absentkey[:])
 
-	serialized, err := SerializeProof(proof)
+	serialized, _, err := SerializeProof(proof)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestProofDeserialize(t *testing.T) {
 
 	proof := MakeVerkleProofOneLeaf(root, absentkey[:])
 
-	serialized, err := SerializeProof(proof)
+	serialized, _, err := SerializeProof(proof)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stateless.go
+++ b/stateless.go
@@ -134,7 +134,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 			// the moved leaf node can occur.
 			nextWordInExistingKey := offset2key(n.stem, n.depth)
 			oldExtNode := &StatelessNode{
-				depth:      n.depth + NodeBitWidth,
+				depth:      n.depth + 1,
 				committer:  n.committer,
 				count:      n.count,
 				values:     n.values,
@@ -160,7 +160,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 				// Next word differs, so the branching point
 				// has been reached. Create the "new" child.
 				n.children[nextWordInInsertedKey] = &StatelessNode{
-					depth:     n.depth + NodeBitWidth,
+					depth:     n.depth + 1,
 					stem:      key[:31],
 					values:    map[byte][]byte{key[31]: value},
 					committer: n.committer,
@@ -189,7 +189,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 		// special case: missing child, insert a leaf
 		if n.children[nChild] == nil {
 			n.children[nChild] = &StatelessNode{
-				depth:      n.depth + NodeBitWidth,
+				depth:      n.depth + 1,
 				count:      1,
 				values:     map[byte][]byte{key[31]: value},
 				committer:  n.committer,

--- a/tree.go
+++ b/tree.go
@@ -775,6 +775,8 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 		scomm = n.c2
 	}
 
+	slotPath := string(key[:n.depth]) + string([]byte{suffSlot})
+
 	// Proof of absence: case of a missing value.
 	//
 	// Suffix tree is present as a child of the extension,
@@ -789,7 +791,7 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 				Zis:    []byte{0, 1, suffSlot, slot},
 				Yis:    []*Fr{&extPoly[0], &extPoly[1], &extPoly[suffSlot], &FrZero},
 				Fis:    [][]Fr{extPoly[:], extPoly[:], extPoly[:], poly[:]},
-				ByPath: map[string]*Point{string(key[:n.depth]): n.commitment, string(append(key[:n.depth], suffSlot)): scomm},
+				ByPath: map[string]*Point{string(key[:n.depth]): n.commitment, slotPath: scomm},
 			}, extStatusPresent | (n.depth << 3), // present, since the stem is present
 			nil
 	}
@@ -803,7 +805,7 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 		Zis:    []byte{0, 1, suffSlot, 2 * slot, 2*slot + 1},
 		Yis:    []*Fr{&extPoly[0], &extPoly[1], &extPoly[suffSlot], &leaves[0], &leaves[1]},
 		Fis:    [][]Fr{extPoly[:], extPoly[:], extPoly[:], poly[:], poly[:]},
-		ByPath: map[string]*Point{string(key[:n.depth]): n.commitment, string(append(key[:n.depth], suffSlot)): scomm},
+		ByPath: map[string]*Point{string(key[:n.depth]): n.commitment, slotPath: scomm},
 	}, extStatusPresent | (n.depth << 3), nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -79,10 +79,11 @@ type VerkleNode interface {
 
 // ProofElements gathers the elements needed to build a proof.
 type ProofElements struct {
-	Cis []*Point
-	Zis []byte
-	Yis []*Fr
-	Fis [][]Fr
+	Cis    []*Point
+	Zis    []byte
+	Yis    []*Fr
+	Fis    [][]Fr
+	ByPath map[string]*Point // Gather commitments by path
 
 	// dedups flags the presence of each (Ci,zi) tuple
 	dedups map[*Point]map[byte]struct{}
@@ -121,6 +122,12 @@ func (pe *ProofElements) Merge(other *ProofElements) {
 		pe.Zis = append(pe.Zis, other.Zis[i])
 		pe.Yis = append(pe.Yis, other.Yis[i])
 		pe.Fis = append(pe.Fis, other.Fis[i])
+	}
+
+	for path, C := range other.ByPath {
+		if _, ok := pe.ByPath[path]; !ok {
+			pe.ByPath[path] = C
+		}
 	}
 }
 
@@ -511,10 +518,11 @@ func (n *InternalNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte
 
 	// The proof elements that are to be added at this level
 	pe := &ProofElements{
-		Cis: []*Point{n.commitment},
-		Zis: []byte{childIdx},
-		Yis: []*Fr{&yi}, // Should be 0
-		Fis: [][]Fr{fi},
+		Cis:    []*Point{n.commitment},
+		Zis:    []byte{childIdx},
+		Yis:    []*Fr{&yi}, // Should be 0
+		Fis:    [][]Fr{fi},
+		ByPath: map[string]*Point{string(key[:n.depth]): n.commitment},
 	}
 
 	// Special case of a proof of absence: no children
@@ -712,10 +720,11 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 		toFr(&poly[2], n.c1)
 		toFr(&poly[3], n.c2)
 		return &ProofElements{
-			Cis: []*Point{n.commitment, n.commitment},
-			Zis: []byte{0, 1},
-			Yis: []*Fr{&poly[0], &poly[1]},
-			Fis: [][]Fr{poly[:], poly[:]},
+			Cis:    []*Point{n.commitment, n.commitment},
+			Zis:    []byte{0, 1},
+			Yis:    []*Fr{&poly[0], &poly[1]},
+			Fis:    [][]Fr{poly[:], poly[:]},
+			ByPath: map[string]*Point{string(key[:n.depth]): n.commitment},
 		}, extStatusAbsentOther | (n.depth << 3), n.stem
 	}
 
@@ -751,10 +760,11 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 		// has to be called, save the count.
 		return &ProofElements{
 			// leaf marker, stem, path to child (which is 0)
-			Cis: []*Point{n.commitment, n.commitment, n.commitment},
-			Zis: []byte{0, 1, suffSlot},
-			Yis: []*Fr{&extPoly[0], &extPoly[1], &FrZero},
-			Fis: [][]Fr{extPoly[:], extPoly[:], extPoly[:]},
+			Cis:    []*Point{n.commitment, n.commitment, n.commitment},
+			Zis:    []byte{0, 1, suffSlot},
+			Yis:    []*Fr{&extPoly[0], &extPoly[1], &FrZero},
+			Fis:    [][]Fr{extPoly[:], extPoly[:], extPoly[:]},
+			ByPath: map[string]*Point{string(key[:n.depth]): n.commitment},
 		}, extStatusAbsentEmpty | (n.depth << 3), nil
 	}
 
@@ -775,10 +785,11 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 	if n.values[slot] == nil {
 		return &ProofElements{
 				// leaf marker, stem, path to child, missing value (zero)
-				Cis: []*Point{n.commitment, n.commitment, n.commitment, scomm},
-				Zis: []byte{0, 1, suffSlot, slot},
-				Yis: []*Fr{&extPoly[0], &extPoly[1], &extPoly[2+slot/128], &FrZero},
-				Fis: [][]Fr{extPoly[:], extPoly[:], extPoly[:], poly[:]},
+				Cis:    []*Point{n.commitment, n.commitment, n.commitment, scomm},
+				Zis:    []byte{0, 1, suffSlot, slot},
+				Yis:    []*Fr{&extPoly[0], &extPoly[1], &extPoly[suffSlot], &FrZero},
+				Fis:    [][]Fr{extPoly[:], extPoly[:], extPoly[:], poly[:]},
+				ByPath: map[string]*Point{string(key[:n.depth]): n.commitment, string(append(key[:n.depth], suffSlot)): scomm},
 			}, extStatusPresent | (n.depth << 3), // present, since the stem is present
 			nil
 	}
@@ -788,10 +799,11 @@ func (n *LeafNode) GetCommitmentsAlongPath(key []byte) (*ProofElements, byte, []
 	leafToComms(leaves[:], n.values[slot])
 	return &ProofElements{
 		// leaf marker, stem, path to child, C{1,2} lo, C{1,2} hi
-		Cis: []*Point{n.commitment, n.commitment, n.commitment, scomm, scomm},
-		Zis: []byte{0, 1, suffSlot, 2 * slot, 2*slot + 1},
-		Yis: []*Fr{&extPoly[0], &extPoly[1], &extPoly[2+slot/128], &leaves[0], &leaves[1]},
-		Fis: [][]Fr{extPoly[:], extPoly[:], extPoly[:], poly[:], poly[:]},
+		Cis:    []*Point{n.commitment, n.commitment, n.commitment, scomm, scomm},
+		Zis:    []byte{0, 1, suffSlot, 2 * slot, 2*slot + 1},
+		Yis:    []*Fr{&extPoly[0], &extPoly[1], &extPoly[suffSlot], &leaves[0], &leaves[1]},
+		Fis:    [][]Fr{extPoly[:], extPoly[:], extPoly[:], poly[:], poly[:]},
+		ByPath: map[string]*Point{string(key[:n.depth]): n.commitment, string(append(key[:n.depth], suffSlot)): scomm},
 	}, extStatusPresent | (n.depth << 3), nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -246,6 +246,7 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
 			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
 			newBranch.count = 1
+			n.count++
 			n.children[nChild] = newBranch
 			newBranch.children[nextWordInExistingKey] = child
 			child.depth += 1

--- a/tree_test.go
+++ b/tree_test.go
@@ -167,7 +167,7 @@ func TestComputeRootCommitmentOnlineThreeLeavesFlush(t *testing.T) {
 func TestOffset2key8BitsWide(t *testing.T) {
 	key, _ := hex.DecodeString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
 	for i := byte(0); i < 32; i++ {
-		childId := offset2key(key, i*8)
+		childId := offset2key(key, i)
 		if childId != i {
 			t.Fatalf("error getting child number in key %d != %d", childId, i)
 		}


### PR DESCRIPTION
Changes introduced by this PR:

 * For an easier decoding of the proof, the keys and values are moved to their own field in the block. For this to happen, proof and keyvals are no longer serialized as a single block;
 * It serializes the de-duplicated commitments by path, and no longer by (commitment, zi) tuples;
 * It fixes some issues that got introduced with #102 