### PR TITLE
ComputeCommitment's return type: Fr -> Point

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -45,8 +45,10 @@ func (Empty) Get([]byte, NodeResolverFn) ([]byte, error) {
 	return nil, nil
 }
 
-func (Empty) ComputeCommitment() *Fr {
-	return &FrZero
+func (Empty) ComputeCommitment() *Point {
+	var id Point
+	id.Identity()
+	return &id
 }
 
 func (Empty) GetProofItems(keylist) (*ProofElements, []byte, [][]byte) {

--- a/encoding.go
+++ b/encoding.go
@@ -88,12 +88,9 @@ func CreateInternalNode(bitlist []byte, raw []byte, depth byte) (*InternalNode, 
 		return nil, ErrInvalidNodeEncoding
 	}
 	for i, index := range indices {
-		hashed := &HashedNode{hash: new(Fr)}
-		// TODO(@gballet) use (*[32]byte)() when geth moves
-		// to deprecate pre-Go 1.17 compilers
-		var h [32]byte
-		copy(h[:], raw[i*32:(i+1)*32])
-		from32(hashed.hash, h)
+		hashed := &HashedNode{hash: new(Fr), commitment: new(Point)}
+		hashed.commitment.SetBytes(raw[i*32 : (i+1)*32])
+		toFr(hashed.hash, hashed.commitment)
 		n.children[index] = hashed
 		n.count++
 	}

--- a/hashednode.go
+++ b/hashednode.go
@@ -51,8 +51,8 @@ func (*HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {
 	return nil, errors.New("can not read from a hash node")
 }
 
-func (n *HashedNode) ComputeCommitment() *Fr {
-	return n.hash
+func (n *HashedNode) ComputeCommitment() *Point {
+	return n.commitment
 }
 
 func (*HashedNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte) {

--- a/ipa.go
+++ b/ipa.go
@@ -47,10 +47,6 @@ func toFr(fr *Fr, p *Point) {
 	fr.SetBytesLE(bytes[:])
 }
 
-func from32(fr *Fr, data [32]byte) {
-	fr.SetBytes(data[:])
-}
-
 func FromLEBytes(fr *Fr, data []byte) {
 	var aligned [32]byte
 	for i := range data {

--- a/ipa.go
+++ b/ipa.go
@@ -65,8 +65,8 @@ func StemFromBytes(fr *Fr, data []byte) {
 	fr.SetBytesLE(bytes)
 }
 
-func Equal(fr *Fr, other *Fr) bool {
-	return fr.Equal(other)
+func Equal(self *Point, other *Point) bool {
+	return other.Equal(self)
 }
 
 func Generator() *Point {

--- a/stateless.go
+++ b/stateless.go
@@ -268,9 +268,9 @@ func (n *StatelessNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 	return child.Get(k, getter)
 }
 
-func (n *StatelessNode) ComputeCommitment() *Fr {
+func (n *StatelessNode) ComputeCommitment() *Point {
 	if n.hash != nil {
-		return n.hash
+		return n.commitment
 	}
 
 	if n.count == 0 {
@@ -282,7 +282,7 @@ func (n *StatelessNode) ComputeCommitment() *Fr {
 		n.commitment.Identity()
 		n.hash = new(Fr)
 		toFr(n.hash, n.commitment)
-		return n.hash
+		return n.commitment
 	}
 
 	n.hash = new(Fr)
@@ -316,7 +316,7 @@ func (n *StatelessNode) ComputeCommitment() *Fr {
 		emptyChildren := 0
 		poly := make([]Fr, NodeWidth)
 		for idx, child := range n.children {
-			CopyFr(&poly[idx], child.ComputeCommitment())
+			toFr(&poly[idx], child.ComputeCommitment())
 		}
 
 		// All the coefficients have been computed, evaluate the polynomial,
@@ -325,7 +325,7 @@ func (n *StatelessNode) ComputeCommitment() *Fr {
 		toFr(n.hash, n.commitment)
 	}
 
-	return n.hash
+	return n.commitment
 }
 
 func (*StatelessNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte) {

--- a/stateless.go
+++ b/stateless.go
@@ -337,16 +337,24 @@ func (*StatelessNode) Serialize() ([]byte, error) {
 }
 
 func (n *StatelessNode) Copy() VerkleNode {
-	ret := &InternalNode{
-		children:   make([]VerkleNode, len(n.children)),
+	ret := &StatelessNode{
 		commitment: new(Point),
 		depth:      n.depth,
 		committer:  n.committer,
 		count:      n.count,
 	}
 
-	for i, child := range n.children {
-		ret.children[i] = child.Copy()
+	if n.children != nil {
+		ret.children = make(map[byte]*StatelessNode, len(n.children))
+		for i, child := range n.children {
+			ret.children[i] = child.Copy().(*StatelessNode)
+		}
+	} else {
+		ret.values = make(map[byte][]byte, len(n.values))
+		for i, val := range n.values {
+			ret.values[i] = make([]byte, len(val))
+			copy(ret.values[i], val)
+		}
 	}
 
 	if n.hash != nil {

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -83,7 +83,7 @@ func TestStatelessDelete(t *testing.T) {
 	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
 	rootRef.Delete(oneKeyTest)
 
-	if !Equal(rootRef.ComputeCommitment(), root.hash) {
+	if !Equal(rootRef.ComputeCommitment(), root.commitment) {
 		t.Fatal("error in delete", rootRef.ComputeCommitment(), root.hash)
 	}
 }
@@ -96,7 +96,7 @@ func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	hash := rootRef.ComputeCommitment()
 
-	if !Equal(hash, root.hash) {
+	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after insertion %v %v", hash, root.hash)
 	}
 
@@ -108,7 +108,7 @@ func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 
 	root.Insert(zeroKeyTest, oneKeyTest, nil)
 
-	if !Equal(hash, root.hash) {
+	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after update %v %v", hash, root.hash)
 	}
 }
@@ -123,7 +123,7 @@ func TestStatelessInsertLeafIntoLeaf(t *testing.T) {
 	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
 	hash := rootRef.ComputeCommitment()
 
-	if !Equal(hash, root.hash) {
+	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after insertion %v %v", hash, root.hash)
 	}
 
@@ -134,7 +134,7 @@ func TestStatelessInsertLeafIntoLeaf(t *testing.T) {
 
 	root.Insert(oneKeyTest, oneKeyTest, nil)
 
-	if !Equal(hash, root.hash) {
+	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after update %v %v", hash, root.hash)
 	}
 }
@@ -149,7 +149,7 @@ func TestStatelessInsertLeafIntoInternal(t *testing.T) {
 	rootRef.Insert(key1, fourtyKeyTest, nil)
 	hash := rootRef.ComputeCommitment()
 
-	if !Equal(hash, root.hash) {
+	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after insertion %v %v", hash, root.hash)
 	}
 }
@@ -166,11 +166,11 @@ func TestStatelessCopy(t *testing.T) {
 	root := NewStateless()
 	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	rootCopy := root.Copy()
-	if !Equal(rootCopy.ComputeCommitment(), root.hash) {
+	if !Equal(rootCopy.ComputeCommitment(), root.commitment) {
 		t.Fatal("copy produced the wrong hash")
 	}
 	root.Insert(oneKeyTest, fourtyKeyTest, nil)
-	if Equal(rootCopy.ComputeCommitment(), root.hash) {
+	if Equal(rootCopy.ComputeCommitment(), root.commitment) {
 		t.Fatal("copy did not update the hash")
 	}
 }
@@ -198,7 +198,7 @@ func TestStatelessGet(t *testing.T) {
 func TestStatelessComputeCommitmentEmptyRoot(t *testing.T) {
 	root := &StatelessNode{}
 	root.ComputeCommitment()
-	if !Equal(root.hash, &FrZero) {
+	if !root.hash.Equal(&FrZero) {
 		t.Fatal("invalid commitment for the empty root")
 	}
 

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -83,9 +83,8 @@ func TestInsertKey0Value0(t *testing.T) {
 
 	toFr(&expected, &expectedP)
 	expectedP.ScalarMul(&srs[0], &expected)
-	toFr(&expected, &expectedP)
 
-	if !Equal(comm, &expected) {
+	if !Equal(comm, &expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -112,9 +111,7 @@ func TestInsertKey1Value1(t *testing.T) {
 		t.Fatal("commitment is identity")
 	}
 
-	toFr(&expected, &expectedP)
-
-	if !Equal(comm, &expected) {
+	if !Equal(comm, &expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -164,9 +161,7 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 		t.Fatal("commitment is identity")
 	}
 
-	toFr(&expected, &expectedP)
-
-	if !Equal(comm, &expected) {
+	if !Equal(comm, &expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -197,9 +192,7 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 		t.Fatal("commitment is identity")
 	}
 
-	toFr(&expected, &expectedP)
-
-	if !Equal(comm, &expected) {
+	if !Equal(comm, &expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -208,10 +201,7 @@ func TestEmptyTrie(t *testing.T) {
 	root := New()
 	comm := root.ComputeCommitment()
 
-	var expected Fr
-	toFr(&expected, identity)
-
-	if !comm.Equal(&expected) {
-		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
+	if !comm.Equal(identity) {
+		t.Fatalf("invalid root commitment %v != %v", comm, identity)
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -440,7 +440,7 @@ func TestConcurrentTrees(t *testing.T) {
 	expected := tree.ComputeCommitment()
 
 	threads := 2
-	ch := make(chan *Fr)
+	ch := make(chan *Point)
 	builder := func() {
 		tree := New()
 		tree.Insert(zeroKeyTest, fourtyKeyTest, nil)
@@ -654,7 +654,7 @@ func isInternalEqual(a, b *InternalNode) bool {
 			if !ok {
 				return false
 			}
-			if !Equal(c.(*HashedNode).hash, hn.hash) {
+			if !Equal(c.(*HashedNode).commitment, hn.commitment) {
 				return false
 			}
 		case *LeafNode:

--- a/tree_test.go
+++ b/tree_test.go
@@ -637,7 +637,7 @@ func TestNodeSerde(t *testing.T) {
 	resRoot.children[64] = resLeaf64
 
 	if !isInternalEqual(root, resRoot) {
-		t.Errorf("parsed node not equal, %x != %x", root.hash, resRoot.hash)
+		t.Errorf("parsed node not equal, %x != %x", root.commitment.Bytes(), resRoot.commitment.Bytes())
 	}
 }
 


### PR DESCRIPTION
rust-verkle doesn't expect the state root to be a field element, but a serialized point. Change the interface so that the proofs become compatible.