### PR TITLE
fix: PoA stems are duplicated when used for multiple keys

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -409,3 +409,24 @@ func TestProofOfAbsenceEdgeCase(t *testing.T) {
 		t.Fatal("could not verify proof")
 	}
 }
+
+func TestProofOfAbsenceOtherMultiple(t *testing.T) {
+	// Create a stem that isn't the one that will be proven,
+	// but does look the same for most of its length.
+	root := New()
+	key, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030000")
+	root.Insert(key, testValue, nil)
+	root.ComputeCommitment()
+
+	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
+	ret2, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030301")
+	proof, cs, zis, yis := MakeVerkleMultiProof(root, [][]byte{ret1, ret2}, map[string][]byte{string(ret1): nil, string(ret2): nil})
+	cfg, _ := GetConfig()
+	if !VerifyVerkleProof(proof, cs, zis, yis, cfg) {
+		t.Fatal("could not verify proof")
+	}
+
+	if len(proof.PoaStems) > 1 {
+		t.Fatalf("invalid number of proof-of-absence stems: %d", len(proof.PoaStems))
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -784,7 +784,7 @@ func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte
 		if !equalPaths(n.stem, key) {
 			// Deduplicate the missing stems - keys must
 			// be sorted.
-			if len(poass) == 0 || !equalPaths(poass[len(poass)-1], key) {
+			if len(poass) == 0 || !equalPaths(poass[len(poass)-1], n.stem) {
 				esses = append(esses, extStatusAbsentOther|(n.depth<<3))
 				poass = append(poass, n.stem)
 			}


### PR DESCRIPTION
fixes #199, not sure yet why a non-existing location has a value though.