### PR TITLE
fix: node deserialization now expects commitment

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -43,7 +43,7 @@ func bit(bitlist []byte, nr int) bool {
 
 var serializedPayloadTooShort = errors.New("verkle payload is too short")
 
-func ParseNode(serialized []byte, depth byte) (VerkleNode, error) {
+func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 	if len(serialized) < 64 {
 		return nil, serializedPayloadTooShort
 	}
@@ -74,15 +74,16 @@ func ParseNode(serialized []byte, depth byte) (VerkleNode, error) {
 			committer: cfg,
 			depth:     depth,
 		}
+		ln.ComputeCommitment()
 		return ln, nil
 	case internalRLPType:
-		return CreateInternalNode(serialized[1:33], serialized[33:], depth)
+		return CreateInternalNode(serialized[1:33], serialized[33:], depth, comm)
 	default:
 		return nil, ErrInvalidNodeEncoding
 	}
 }
 
-func CreateInternalNode(bitlist []byte, raw []byte, depth byte) (*InternalNode, error) {
+func CreateInternalNode(bitlist []byte, raw []byte, depth byte, comm []byte) (*InternalNode, error) {
 	tc, err := GetConfig()
 	if err != nil {
 		return nil, err
@@ -102,6 +103,8 @@ func CreateInternalNode(bitlist []byte, raw []byte, depth byte) (*InternalNode, 
 		n.children[index] = hashed
 		n.count++
 	}
+	n.commitment = new(Point)
+	n.commitment.SetBytes(comm)
 	return n, nil
 }
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -3,7 +3,7 @@ package verkle
 import "testing"
 
 func TestParseNodeEmptyPayload(t *testing.T) {
-	_, err := ParseNode([]byte{}, 0)
+	_, err := ParseNode([]byte{}, 0, []byte{})
 	if err != serializedPayloadTooShort {
 		t.Fatalf("invalid error, got %v, expected %v", err, "unexpected EOF")
 	}

--- a/tree.go
+++ b/tree.go
@@ -241,7 +241,7 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 		if err != nil {
 			return fmt.Errorf("verkle tree: error resolving node %x: %w", key, err)
 		}
-		resolved, err := ParseNode(serialized, n.depth+1)
+		resolved, err := ParseNode(serialized, n.depth+1, hash[:])
 		if err != nil {
 			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", key, err)
 		}
@@ -458,7 +458,7 @@ func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 		}
 
 		// deserialize the payload and set it as the child
-		c, err := ParseNode(payload, n.depth+1)
+		c, err := ParseNode(payload, n.depth+1, commitment[:])
 		if err != nil {
 			return nil, err
 		}

--- a/tree_test.go
+++ b/tree_test.go
@@ -594,6 +594,7 @@ func TestNodeSerde(t *testing.T) {
 	tree := New()
 	tree.Insert(zeroKeyTest, testValue, nil)
 	tree.Insert(fourtyKeyTest, testValue, nil)
+	tree.ComputeCommitment()
 	root := tree.(*InternalNode)
 
 	// Serialize all the nodes
@@ -602,32 +603,35 @@ func TestNodeSerde(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	l0c := leaf0.commitment.Bytes()
 
 	leaf64 := (root.children[64]).(*LeafNode)
 	ls64, err := leaf64.Serialize()
 	if err != nil {
 		t.Error(err)
 	}
+	l64c := leaf64.commitment.Bytes()
 
 	rs, err := root.Serialize()
 	if err != nil {
 		t.Error(err)
 	}
+	rc := root.commitment.Bytes()
 
 	// Now deserialize and re-construct tree
-	res, err := ParseNode(ls0, 1)
+	res, err := ParseNode(ls0, 1, l0c[:])
 	if err != nil {
 		t.Error(err)
 	}
 	resLeaf0 := res.(*LeafNode)
 
-	res, err = ParseNode(ls64, 1)
+	res, err = ParseNode(ls64, 1, l64c[:])
 	if err != nil {
 		t.Error(err)
 	}
 	resLeaf64 := res.(*LeafNode)
 
-	res, err = ParseNode(rs, 0)
+	res, err = ParseNode(rs, 0, rc[:])
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
the commitment was not set when deserializing a node, which caused some strange issue in the proof generation.