### PR TITLE
rebuild a stateless tree from a proof

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -34,6 +34,7 @@ var (
 	errReadFromInvalid         = errors.New("trying to read from an invalid child")
 	errSerializeHashedNode     = errors.New("trying to serialized a hashed node")
 	errNotSupportedInStateless = errors.New("not implemented in stateless")
+	errInsertIntoOtherStem     = errors.New("insert splits a stem where it should not happen")
 )
 
 const (

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -314,7 +314,7 @@ func TreeFromProof(proof *Proof) (VerkleNode, error) {
 			continue
 		}
 
-		err = root.Insert(k, proof.Values[i], nil)
+		err = root.insertValue(k, proof.Values[i])
 		if err != nil {
 			return nil, err
 		}

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -159,7 +159,8 @@ func SerializeProof(proof *Proof) ([]byte, []KeyValuePair, error) {
 	return bufProof.Bytes(), keyvals, nil
 }
 
-// TODO add keys and values to the signature
+// DeserializeProof deserializes the proof found in blocks, into a format that
+// can be used to rebuild a stateless version of the tree.
 func DeserializeProof(proofSerialized []byte, keyvals []KeyValuePair) (*Proof, error) {
 	var (
 		numPoaStems, numExtStatus uint32

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -243,7 +243,7 @@ type stemInfo struct {
 }
 
 // TreeFromProof builds a stateless tree from the proof
-func TreeFromProof(proof *Proof) (VerkleNode, error) {
+func TreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) {
 	stems := make([][]byte, 0, len(proof.Keys))
 	for _, k := range proof.Keys {
 		if len(stems) == 0 || !bytes.Equal(stems[len(stems)-1], k[:31]) {
@@ -298,7 +298,7 @@ func TreeFromProof(proof *Proof) (VerkleNode, error) {
 		}
 	}
 
-	root := NewStateless()
+	root := NewStatelessWithCommitment(rootC)
 	comms := proof.Cs
 	for _, p := range paths {
 		comms, err = root.insertStem(p, info[string(p)], comms)

--- a/proof_test.go
+++ b/proof_test.go
@@ -326,11 +326,16 @@ func TestProofDeserialize(t *testing.T) {
 
 	keys := make([][]byte, leafCount)
 	root := New()
+	var keyvals []KeyValuePair
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
 		root.Insert(key, fourtyKeyTest, nil)
+		keyvals = append(keyvals, KeyValuePair{
+			Key:   key,
+			Value: fourtyKeyTest,
+		})
 	}
 
 	// Create stem  0x0000020100000.... that is not present in the tree,
@@ -350,7 +355,7 @@ func TestProofDeserialize(t *testing.T) {
 		t.Fatal("zero-length serialized proof payload")
 	}
 
-	deserialized, err := DeserializeProof(serialized)
+	deserialized, err := DeserializeProof(serialized, keyvals)
 	if err != nil {
 		t.Fatalf("could not deserialize verkle proof: %v", err)
 	}
@@ -365,7 +370,7 @@ func TestProofDeserialize(t *testing.T) {
 
 func TestProofDeserializeErrors(t *testing.T) {
 
-	deserialized, err := DeserializeProof([]byte{0})
+	deserialized, err := DeserializeProof([]byte{0}, nil)
 	if err == nil {
 		t.Fatal("deserializing invalid proof didn't cause an error")
 	}
@@ -373,7 +378,7 @@ func TestProofDeserializeErrors(t *testing.T) {
 		t.Fatalf("non-nil deserialized data returned %v", deserialized)
 	}
 
-	deserialized, err = DeserializeProof([]byte{1, 0, 0, 0})
+	deserialized, err = DeserializeProof([]byte{1, 0, 0, 0}, nil)
 	if err == nil {
 		t.Fatal("deserializing invalid proof didn't cause an error")
 	}
@@ -381,7 +386,7 @@ func TestProofDeserializeErrors(t *testing.T) {
 		t.Fatalf("non-nil deserialized data returned %v", deserialized)
 	}
 
-	deserialized, err = DeserializeProof([]byte{0, 0, 0, 0, 0})
+	deserialized, err = DeserializeProof([]byte{0, 0, 0, 0, 0}, nil)
 	if err == nil {
 		t.Fatal("deserializing invalid proof didn't cause an error")
 	}
@@ -389,7 +394,7 @@ func TestProofDeserializeErrors(t *testing.T) {
 		t.Fatalf("non-nil deserialized data returned %v", deserialized)
 	}
 
-	deserialized, err = DeserializeProof([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0})
+	deserialized, err = DeserializeProof([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0}, nil)
 	if err == nil {
 		t.Fatal("deserializing invalid proof didn't cause an error")
 	}

--- a/stateless.go
+++ b/stateless.go
@@ -109,10 +109,6 @@ func (n *StatelessNode) SetChild(i int, v VerkleNode) error {
 	return nil
 }
 
-func (n *StatelessNode) SetStem(stem []byte) {
-	n.stem = stem
-}
-
 func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
 	// if this is a leaf value and the stems are different, intermediate
 	// nodes need to be inserted.
@@ -241,9 +237,6 @@ func (n *StatelessNode) insertStem(path []byte, stemInfo stemInfo, comms []*Poin
 	if len(path) == 1 {
 		switch stemInfo.stemType & 3 {
 		case extStatusAbsentEmpty:
-			n.children[path[0]] = NewStatelessWithCommitment(comms[0])
-			n.children[path[0]].stem = stemInfo.stem
-			n.children[path[0]].depth = n.depth + 1
 			// nothing to do
 		case extStatusAbsentOther:
 			// insert poa stem
@@ -278,7 +271,7 @@ func (n *StatelessNode) insertStem(path []byte, stemInfo stemInfo, comms []*Poin
 
 func (n *StatelessNode) insertValue(key, value []byte) error {
 	// reached a leaf node ?
-	if len(n.values) != 0 {
+	if len(n.children) == 0 {
 		if !bytes.Equal(key[:31], n.stem) {
 			return errInsertIntoOtherStem
 		}

--- a/stateless.go
+++ b/stateless.go
@@ -442,8 +442,15 @@ func (n *StatelessNode) toDot(parent, path string) string {
 	n.ComputeCommitment()
 	me := fmt.Sprintf("internal%s", path)
 	var ret string
-	if n.values != nil {
-		ret = fmt.Sprintf("leaf%s [label=\"L: %x\nC: %x\nC₁: %x\nC₂:%x\"]\n%s -> leaf%s\n", path, n.hash.Bytes(), n.commitment.Bytes(), n.c1.Bytes(), n.c2.Bytes(), parent, path)
+	if len(n.values) != 0 {
+		var c1bytes, c2bytes [32]byte
+		if n.c1 != nil {
+			c1bytes = n.c1.Bytes()
+		}
+		if n.c2 != nil {
+			c2bytes = n.c2.Bytes()
+		}
+		ret = fmt.Sprintf("leaf%s [label=\"L: %x\nC: %x\nC₁: %x\nC₂:%x\"]\n%s -> leaf%s\n", path, n.hash.Bytes(), n.commitment.Bytes(), c1bytes, c2bytes, parent, path)
 		for i, v := range n.values {
 			if v != nil {
 				ret = fmt.Sprintf("%sval%s%x [label=\"%x\"]\nleaf%s -> val%s%x\n", ret, path, i, v, path, path, i)
@@ -452,11 +459,11 @@ func (n *StatelessNode) toDot(parent, path string) string {
 	} else {
 		ret = fmt.Sprintf("%s [label=\"I: %x\"]\n", me, n.hash.BytesLE())
 		if len(parent) > 0 {
-			ret = fmt.Sprintf("%s %s -> %s\n", ret, parent, me)
+			ret += fmt.Sprintf(" %s -> %s\n", parent, me)
 		}
 
 		for i, child := range n.children {
-			ret = fmt.Sprintf("%s%s", ret, child.toDot(me, fmt.Sprintf("%s%02x", path, i)))
+			ret += child.toDot(me, fmt.Sprintf("%s%02x", path, i)) + "\n"
 		}
 	}
 

--- a/stateless.go
+++ b/stateless.go
@@ -26,6 +26,7 @@
 package verkle
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 )
@@ -273,6 +274,21 @@ func (n *StatelessNode) insertStem(path []byte, stemInfo stemInfo, comms []*Poin
 
 	// recurse
 	return n.children[path[0]].insertStem(path[1:], stemInfo, comms)
+}
+
+func (n *StatelessNode) insertValue(key, value []byte) error {
+	// reached a leaf node ?
+	if len(n.values) != 0 {
+		if !bytes.Equal(key[:31], n.stem) {
+			return errInsertIntoOtherStem
+		}
+		n.values[key[31]] = value
+	} else { // no, recurse
+		nChild := offset2key(key, n.depth)
+		n.children[nChild].insertValue(key, value)
+	}
+
+	return nil
 }
 
 func (*StatelessNode) InsertOrdered([]byte, []byte, NodeFlushFn) error {

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -239,11 +239,14 @@ func TestStatelessToDot(t *testing.T) {
 }
 
 func TestStatelessDeserialize(t *testing.T) {
-	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	root.Insert(oneKeyTest, fourtyKeyTest, nil)
-	root.Insert(fourtyKeyTest, fourtyKeyTest, nil)
-	root.Insert(ffx32KeyTest, fourtyKeyTest, nil)
+	root := New()
+	for _, k := range [][]byte{zeroKeyTest, oneKeyTest, fourtyKeyTest, ffx32KeyTest} {
+		root.Insert(k, fourtyKeyTest, nil)
+	}
+	keyvals := []KeyValuePair{
+		{zeroKeyTest, fourtyKeyTest},
+		{fourtyKeyTest, fourtyKeyTest},
+	}
 
 	proof, _, _, _ := MakeVerkleMultiProof(root, keylist{zeroKeyTest, fourtyKeyTest}, map[string][]byte{string(zeroKeyTest): fourtyKeyTest, string(fourtyKeyTest): fourtyKeyTest})
 

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -34,9 +34,12 @@ import (
 )
 
 func TestStatelessChildren(t *testing.T) {
+	c2key, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000085")
+
 	root := NewStateless()
 	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	root.Insert(oneKeyTest, fourtyKeyTest, nil)
+	root.Insert(c2key, fourtyKeyTest, nil)
 
 	list := root.Children()
 	if len(list) != NodeWidth {
@@ -67,9 +70,10 @@ func TestStatelessChildren(t *testing.T) {
 	rootRef := New()
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(c2key, fourtyKeyTest, nil)
 
-	if !Equal(rootRef.ComputeCommitment(), root.ComputeCommitment()) {
-		t.Fatalf("differing state(less|ful) roots %x != %x", rootRef.ComputeCommitment(), root.ComputeCommitment())
+	if !Equal(rootRef.ComputeCommitment(), root.commitment) {
+		t.Fatalf("differing state(less|ful) roots %x != %x", rootRef.ComputeCommitment(), root.commitment)
 	}
 }
 

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -260,7 +260,7 @@ func TestStatelessDeserialize(t *testing.T) {
 		t.Fatalf("error deserializing proof: %v", err)
 	}
 
-	droot, err := TreeFromProof(dproof)
+	droot, err := TreeFromProof(dproof, root.ComputeCommitment())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -262,6 +262,7 @@ func TestStatelessDeserialize(t *testing.T) {
 
 	droot, err := TreeFromProof(dproof)
 	if err != nil {
+		t.Fatal(err)
 	}
 
 	if droot.ComputeCommitment() != root.ComputeCommitment() {

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -237,3 +237,31 @@ func TestStatelessToDot(t *testing.T) {
 		t.Fatalf("hashes differ after insertion %v ||| %v", stf, stl)
 	}
 }
+
+func TestStatelessDeserialize(t *testing.T) {
+	root := NewStateless()
+	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, fourtyKeyTest, nil)
+	root.Insert(fourtyKeyTest, fourtyKeyTest, nil)
+	root.Insert(ffx32KeyTest, fourtyKeyTest, nil)
+
+	proof, _, _, _ := MakeVerkleMultiProof(root, keylist{zeroKeyTest, fourtyKeyTest}, map[string][]byte{string(zeroKeyTest): fourtyKeyTest, string(fourtyKeyTest): fourtyKeyTest})
+
+	serialized, _, err := SerializeProof(proof)
+	if err != nil {
+		t.Fatalf("could not serialize proof: %v", err)
+	}
+
+	dproof, err := DeserializeProof(serialized, keyvals)
+	if err != nil {
+		t.Fatalf("error deserializing proof: %v", err)
+	}
+
+	droot, err := TreeFromProof(dproof)
+	if err != nil {
+	}
+
+	if droot.ComputeCommitment() != root.ComputeCommitment() {
+		t.Fatal("differing root commitments")
+	}
+}

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -226,8 +226,21 @@ func TestStatelessToDot(t *testing.T) {
 	rootRef.Insert(key1, fourtyKeyTest, nil)
 	rootRef.ComputeCommitment()
 
-	stl := strings.Split(root.toDot("", ""), "\n")
-	stf := strings.Split(rootRef.toDot("", ""), "\n")
+	var stl []string
+	for _, str := range strings.Split(root.toDot("", ""), "\n") {
+		if str == "" {
+			continue
+		}
+		stl = append(stl, strings.ReplaceAll(str, " ", ""))
+	}
+
+	var stf []string
+	for _, str := range strings.Split(rootRef.toDot("", ""), "\n") {
+		if str == "" {
+			continue
+		}
+		stf = append(stf, strings.ReplaceAll(str, " ", ""))
+	}
 	sort.Strings(stl)
 	sort.Strings(stf)
 	stfJ := strings.Join(stf, "\n")

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -63,6 +63,14 @@ func TestStatelessChildren(t *testing.T) {
 	if err := root.SetChild(3, &StatelessNode{}); err != nil {
 		t.Fatal("error inserting stateless node")
 	}
+
+	rootRef := New()
+	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+
+	if !Equal(rootRef.ComputeCommitment(), root.ComputeCommitment()) {
+		t.Fatalf("differing state(less|ful) roots %x != %x", rootRef.ComputeCommitment(), root.ComputeCommitment())
+	}
 }
 
 func TestStatelessDelete(t *testing.T) {

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -268,4 +268,12 @@ func TestStatelessDeserialize(t *testing.T) {
 	if droot.ComputeCommitment() != root.ComputeCommitment() {
 		t.Fatal("differing root commitments")
 	}
+
+	if !Equal(droot.(*StatelessNode).children[0].commitment, root.(*InternalNode).children[0].ComputeCommitment()) {
+		t.Fatal("differing commitment for child #0")
+	}
+
+	if !Equal(droot.(*StatelessNode).children[64].commitment, root.(*InternalNode).children[64].ComputeCommitment()) {
+		t.Fatal("differing commitment for child #64")
+	}
 }

--- a/tree.go
+++ b/tree.go
@@ -663,7 +663,7 @@ func (n *LeafNode) toHashedNode() *HashedNode {
 func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
-		return errors.New("split should not happen here")
+		return errInsertIntoOtherStem
 	}
 	n.values[k[31]] = value
 	n.commitment = nil


### PR DESCRIPTION
This adds a function that takes all the elements of a proof that are present in a block, and rebuilds a stateless tree from it. It is the final missing piece for geth to fully verify a verkle block.