### PR TITLE
Helper functions for flushing nodes to disk during conversion

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -443,6 +443,13 @@ func (n *InternalNode) FlushStem(stem []byte, flush NodeFlushFn) {
 	child := n.children[nChild]
 	switch child := child.(type) {
 	case *InternalNode:
+		if n.depth == 2 {
+			child.ComputeCommitment()
+			child.Flush(flush)
+			n.children[nChild] = child.toHashedNode()
+			return
+		}
+
 		child.FlushStem(stem, flush)
 	case *LeafNode:
 		if child.commitment == nil {

--- a/tree.go
+++ b/tree.go
@@ -471,7 +471,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 	for i, child := range n.children {
 		switch c := child.(type) {
 		case *LeafNode:
-			if n.depth+1 == depth {
+			if n.depth+1 >= depth {
 				child.ComputeCommitment()
 				flush(child)
 				n.children[i] = c.toHashedNode()
@@ -479,7 +479,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 		case *InternalNode:
 			c.FlushAtDepth(depth, flush)
 
-			if n.depth+1 == depth {
+			if n.depth+1 >= depth {
 				child.ComputeCommitment()
 				flush(child)
 				n.children[i] = c.toHashedNode()

--- a/tree.go
+++ b/tree.go
@@ -446,7 +446,7 @@ func (n *InternalNode) FlushStem(stem []byte, flush NodeFlushFn) {
 		child.FlushStem(stem, flush)
 
 		// if n.depth is 2 then the child's depth is 3
-		if n.depth == 2 {
+		if n.depth >= 2 {
 			child.ComputeCommitment()
 			flush(child)
 			n.children[nChild] = child.toHashedNode()

--- a/tree.go
+++ b/tree.go
@@ -473,6 +473,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 		case *LeafNode:
 			if n.depth+1 == depth {
 				child.ComputeCommitment()
+				flush(child)
 				n.children[i] = c.toHashedNode()
 			}
 		case *InternalNode:
@@ -480,6 +481,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 
 			if n.depth+1 == depth {
 				child.ComputeCommitment()
+				flush(child)
 				n.children[i] = c.toHashedNode()
 			}
 		default:


### PR DESCRIPTION
In order not to run out of memory, be a tad more aggressive when flushing a node. This means that deeper nodes will have to be reloaded from the DB, but the memory should remain below 16GB.

This is one of 3 methods that are considered. The other two will receive their own PRs.