### PR TITLE
add a lock to run flushing and insertion in parallel

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -255,9 +255,9 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 		if err != nil {
 			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", key, err)
 		}
+		resolved.ComputeCommitment()
 		n.children[nChild] = resolved
-		// the child has been resolved as a LeafNode, so when recursing, the following case will be executed
-		return n.Insert(key, value, resolver)
+		return resolved.Insert(key, value, resolver)
 	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.

--- a/tree.go
+++ b/tree.go
@@ -457,7 +457,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 	for i, child := range n.children {
 		switch c := child.(type) {
 		case *LeafNode:
-			if n.depth+1 >= depth {
+			if n.depth >= depth {
 				child.ComputeCommitment()
 				flush(child)
 				n.children[i] = c.toHashedNode()
@@ -465,14 +465,12 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 		case *InternalNode:
 			c.FlushAtDepth(depth, flush)
 
-			// Lock the subtree so no insertion occur
-			// during the flush.
 			if n.depth >= depth {
+				// Lock the subtree so no insertion
+				// occur during the flush.
 				c.lock.Lock()
 				defer c.lock.Unlock()
-			}
 
-			if n.depth+1 >= depth {
 				child.ComputeCommitment()
 				flush(child)
 				n.children[i] = c.toHashedNode()

--- a/tree.go
+++ b/tree.go
@@ -218,9 +218,7 @@ func (n *InternalNode) SetChild(i int, c VerkleNode) error {
 
 func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
 	// Clear cached commitment on modification
-	if n.commitment != nil {
-		n.commitment = nil
-	}
+	n.commitment = nil
 
 	// Prevent access to that subtree so that nodes aren't
 	// flushed from under us.
@@ -229,7 +227,13 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 		defer n.lock.Unlock()
 	}
 
-	return n.insert(key, value, resolver)
+	err := n.insert(key, value, resolver)
+	if err != nil {
+		return err
+	}
+
+	n.ComputeCommitment()
+	return nil
 }
 
 func (n *InternalNode) insert(key []byte, value []byte, resolver NodeResolverFn) error {
@@ -718,6 +722,7 @@ func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 	}
 	n.values[k[31]] = value
 	n.commitment = nil
+	n.ComputeCommitment()
 	return nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -311,6 +311,99 @@ func (n *InternalNode) insert(key []byte, value []byte, resolver NodeResolverFn)
 	return nil
 }
 
+func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
+	// Prevent access to that subtree so that nodes aren't
+	// flushed from under us.
+	if n.depth >= 2 {
+		n.lock.Lock()
+		defer n.lock.Unlock()
+	}
+
+	// Clear cached commitment on modification
+	n.commitment = nil
+
+	err := n.insertStem(stem, values, resolver)
+	if err != nil {
+		return err
+	}
+
+	n.ComputeCommitment()
+	return nil
+}
+
+func (n *InternalNode) insertStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
+	nChild := offset2key(stem, n.depth)
+
+	switch child := n.children[nChild].(type) {
+	case Empty:
+		lastNode := &LeafNode{
+			stem:      stem,
+			values:    values,
+			committer: n.committer,
+			depth:     n.depth + 1,
+		}
+		n.children[nChild] = lastNode
+		n.count++
+	case *HashedNode:
+		if resolver == nil {
+			return errInsertIntoHash
+		}
+		hash := child.ComputeCommitment().Bytes()
+		serialized, err := resolver(hash[:])
+		if err != nil {
+			return fmt.Errorf("verkle tree: error resolving node %x at depth %d: %w", stem, n.depth, err)
+		}
+		resolved, err := ParseNode(serialized, n.depth+1, hash[:])
+		if err != nil {
+			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", stem, err)
+		}
+		resolved.ComputeCommitment()
+		n.children[nChild] = resolved
+		// recurse to handle the case of a LeafNode child that
+		// splits.
+		return n.insertStem(stem, values, resolver)
+	case *LeafNode:
+		// Need to add a new branch node to differentiate
+		// between two keys, if the keys are different.
+		// Otherwise, just update the key.
+		if equalPaths(child.stem, stem) {
+			if err := child.insertStem(stem, values); err != nil {
+				return err
+			}
+		} else {
+			// A new branch node has to be inserted. Depending
+			// on the next word in both keys, a recursion into
+			// the moved leaf node can occur.
+			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
+			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
+			newBranch.count = 1
+			n.count++
+			n.children[nChild] = newBranch
+			newBranch.children[nextWordInExistingKey] = child
+			child.depth += 1
+
+			nextWordInInsertedKey := offset2key(stem, n.depth+1)
+			if nextWordInInsertedKey != nextWordInExistingKey {
+				// Next word differs, so this was the last level.
+				// Insert it directly into its final slot.
+				lastNode := &LeafNode{
+					stem:      stem,
+					values:    values,
+					committer: n.committer,
+					depth:     n.depth + 2,
+				}
+				newBranch.children[nextWordInInsertedKey] = lastNode
+				newBranch.count++
+			} else if err := newBranch.InsertStem(stem, values, resolver); err != nil {
+				return err
+			}
+		}
+	case *InternalNode:
+		return child.InsertStem(stem, values, resolver)
+	}
+	return nil
+}
+
 func (n *InternalNode) toHashedNode() *HashedNode {
 	var hash Fr
 	toFr(&hash, n.commitment)
@@ -420,13 +513,13 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 }
 
 func (n *InternalNode) Delete(key []byte) error {
-	// Clear cached commitment on modification
-	n.commitment = nil
-
 	if n.depth >= 2 {
 		n.lock.Lock()
 		defer n.lock.Unlock()
 	}
+
+	// Clear cached commitment on modification
+	n.commitment = nil
 
 	nChild := offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
@@ -721,6 +814,17 @@ func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 		return errInsertIntoOtherStem
 	}
 	n.values[k[31]] = value
+	n.commitment = nil
+	n.ComputeCommitment()
+	return nil
+}
+
+func (n *LeafNode) insertStem(k []byte, values [][]byte) error {
+	// Sanity check: ensure the key header is the same:
+	if !equalPaths(k, n.stem) {
+		return errInsertIntoOtherStem
+	}
+	n.values = values
 	n.commitment = nil
 	n.ComputeCommitment()
 	return nil

--- a/tree.go
+++ b/tree.go
@@ -311,6 +311,8 @@ func (n *InternalNode) insert(key []byte, value []byte, resolver NodeResolverFn)
 	return nil
 }
 
+// InsertStem does the same thing as Insert, except all values in an extension-and-suffix node
+// are inserted at once.
 func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
 	// Prevent access to that subtree so that nodes aren't
 	// flushed from under us.

--- a/tree.go
+++ b/tree.go
@@ -227,7 +227,7 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 	// Clear cached commitment on modification
 	n.commitment = nil
 
-	err := n.insert(key, value, resolver)
+	err := n.insertUnlocked(key, value, resolver)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 	return nil
 }
 
-func (n *InternalNode) insert(key []byte, value []byte, resolver NodeResolverFn) error {
+func (n *InternalNode) insertUnlocked(key []byte, value []byte, resolver NodeResolverFn) error {
 	nChild := offset2key(key, n.depth)
 
 	switch child := n.children[nChild].(type) {
@@ -267,7 +267,7 @@ func (n *InternalNode) insert(key []byte, value []byte, resolver NodeResolverFn)
 		n.children[nChild] = resolved
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.insert(key, value, resolver)
+		return n.insertUnlocked(key, value, resolver)
 	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.
@@ -324,7 +324,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 	// Clear cached commitment on modification
 	n.commitment = nil
 
-	err := n.insertStem(stem, values, resolver)
+	err := n.insertStemUnlocked(stem, values, resolver)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 	return nil
 }
 
-func (n *InternalNode) insertStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
+func (n *InternalNode) insertStemUnlocked(stem []byte, values [][]byte, resolver NodeResolverFn) error {
 	nChild := offset2key(stem, n.depth)
 
 	switch child := n.children[nChild].(type) {
@@ -363,7 +363,7 @@ func (n *InternalNode) insertStem(stem []byte, values [][]byte, resolver NodeRes
 		n.children[nChild] = resolved
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.insertStem(stem, values, resolver)
+		return n.insertStemUnlocked(stem, values, resolver)
 	case *LeafNode:
 		// Need to add a new branch node to differentiate
 		// between two keys, if the keys are different.

--- a/tree_test.go
+++ b/tree_test.go
@@ -240,43 +240,6 @@ func TestFlush1kLeaves(t *testing.T) {
 	}
 }
 
-func TestStemFlush(t *testing.T) {
-	n := 1000
-	keys := randomKeysSorted(n)
-
-	flushCh := make(chan VerkleNode)
-	flush := func(node VerkleNode) {
-		flushCh <- node
-	}
-	go func() {
-		root := New()
-		for _, k := range keys {
-			root.Insert(k, fourtyKeyTest, nil)
-		}
-		for _, k := range keys {
-			root.(*InternalNode).FlushStem(k[:31], flush)
-		}
-		close(flushCh)
-	}()
-
-	count := 0
-	leaves := 0
-	for n := range flushCh {
-		_, isLeaf := n.(*LeafNode)
-		if !isLeaf {
-			t.Fatal("invalid node type received, expected leaf")
-		}
-		if isLeaf {
-			leaves++
-		}
-		count++
-	}
-
-	if leaves != n {
-		t.Fatalf("number of flushed leaves incorrect. Expected %d got %d\n", n, leaves)
-	}
-}
-
 func TestCopy(t *testing.T) {
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")

--- a/tree_test.go
+++ b/tree_test.go
@@ -913,3 +913,28 @@ func TestWithRustCompatibility(t *testing.T) {
 		t.Fatalf("rust and golang impl are not compatible rust=%x, go=%x", testAccountRootCommRust, commBytes)
 	}
 }
+
+func TestInsertStem(t *testing.T) {
+	root1 := New()
+	root2 := New()
+
+	values := make([][]byte, 256)
+	values[5] = zeroKeyTest
+	values[192] = fourtyKeyTest
+
+	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil)
+	r1c := root1.ComputeCommitment()
+
+	var key5, key192 [32]byte
+	copy(key5[:], fourtyKeyTest[:31])
+	copy(key192[:], fourtyKeyTest[:31])
+	key5[31] = 5
+	key192[31] = 192
+	root2.Insert(key5[:], zeroKeyTest, nil)
+	root2.Insert(key192[:], fourtyKeyTest, nil)
+	r2c := root2.ComputeCommitment()
+
+	if !Equal(r1c, r2c) {
+		t.Fatalf("differing commitments %x != %x", r1c.Bytes(), r2c.Bytes())
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -277,7 +277,8 @@ func TestCachedCommitment(t *testing.T) {
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.ComputeCommitment()
+	oldRoot := tree.ComputeCommitment().Bytes()
+	oldInternal := tree.(*InternalNode).children[4].(*LeafNode).commitment.Bytes()
 
 	if tree.(*InternalNode).commitment == nil {
 		t.Error("root has not cached commitment")
@@ -285,10 +286,10 @@ func TestCachedCommitment(t *testing.T) {
 
 	tree.Insert(key4, fourtyKeyTest, nil)
 
-	if tree.(*InternalNode).commitment != nil {
+	if tree.(*InternalNode).commitment.Bytes() == oldRoot {
 		t.Error("root has stale commitment")
 	}
-	if tree.(*InternalNode).children[4].(*InternalNode).commitment != nil {
+	if tree.(*InternalNode).children[4].(*InternalNode).commitment.Bytes() == oldInternal {
 		t.Error("internal node has stale commitment")
 	}
 	if tree.(*InternalNode).children[1].(*InternalNode).commitment == nil {


### PR DESCRIPTION
TODO:

 * [x] write a test for a leafnode split upon node resolution
 * [x] fix proof verification tests
 * [x] insert multiple values at the same stem (see #217)
 * [ ] dedup insertion code