### PR TITLE
fix: ensure all nodes in a flushed subtree are locked

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -217,15 +217,15 @@ func (n *InternalNode) SetChild(i int, c VerkleNode) error {
 }
 
 func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
-	// Clear cached commitment on modification
-	n.commitment = nil
-
 	// Prevent access to that subtree so that nodes aren't
 	// flushed from under us.
 	if n.depth >= 2 {
 		n.lock.Lock()
 		defer n.lock.Unlock()
 	}
+
+	// Clear cached commitment on modification
+	n.commitment = nil
 
 	err := n.insert(key, value, resolver)
 	if err != nil {

--- a/tree_test.go
+++ b/tree_test.go
@@ -277,7 +277,8 @@ func TestCachedCommitment(t *testing.T) {
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.ComputeCommitment()
+	oldRoot := tree.ComputeCommitment().Bytes()
+	oldInternal := tree.(*InternalNode).children[4].(*LeafNode).commitment.Bytes()
 
 	if tree.(*InternalNode).commitment == nil {
 		t.Error("root has not cached commitment")
@@ -285,10 +286,10 @@ func TestCachedCommitment(t *testing.T) {
 
 	tree.Insert(key4, fourtyKeyTest, nil)
 
-	if tree.(*InternalNode).commitment != nil {
+	if tree.(*InternalNode).commitment.Bytes() == oldRoot {
 		t.Error("root has stale commitment")
 	}
-	if tree.(*InternalNode).children[4].(*InternalNode).commitment != nil {
+	if tree.(*InternalNode).children[4].(*InternalNode).commitment.Bytes() == oldInternal {
 		t.Error("internal node has stale commitment")
 	}
 	if tree.(*InternalNode).children[1].(*InternalNode).commitment == nil {


### PR DESCRIPTION
Avoid a bug in which a spurious Flush pulls the rug
from under an Insert.