### PR TITLE
InsertStem accepts a node instead of value list

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -36,6 +36,7 @@ var (
 	errNotSupportedInStateless = errors.New("not implemented in stateless")
 	errInsertIntoOtherStem     = errors.New("insert splits a stem where it should not happen")
 	errStatelessAndStatefulMix = errors.New("a stateless node should not be found in a stateful tree")
+	errLeafOverwrite           = errors.New("leaf overwrite disallowed")
 )
 
 const (

--- a/empty.go
+++ b/empty.go
@@ -66,3 +66,7 @@ func (Empty) Copy() VerkleNode {
 func (Empty) toDot(string, string) string {
 	return ""
 }
+
+func (Empty) setDepth(_ byte) {
+	panic("should not be try to set the depth of an Empty node")
+}

--- a/hashednode.go
+++ b/hashednode.go
@@ -81,3 +81,7 @@ func (n *HashedNode) Copy() VerkleNode {
 func (n *HashedNode) toDot(parent, path string) string {
 	return fmt.Sprintf("hash%s [label=\"H: %x\"]\n%s -> hash%s\n", path, n.hash.Bytes(), parent, path)
 }
+
+func (*HashedNode) setDepth(_ byte) {
+	// do nothing
+}

--- a/stateless.go
+++ b/stateless.go
@@ -453,3 +453,7 @@ func (n *StatelessNode) toDot(parent, path string) string {
 
 	return ret
 }
+
+func (n *StatelessNode) setDepth(d byte) {
+	n.depth = d
+}

--- a/tree.go
+++ b/tree.go
@@ -348,7 +348,7 @@ func (n *InternalNode) insertStemUnlocked(stem []byte, node VerkleNode, resolver
 		if resolver == nil {
 			return errInsertIntoHash
 		}
-		hash := child.ComputeCommitment().Bytes()
+		hash := child.commitment.Bytes()
 		serialized, err := resolver(hash[:])
 		if err != nil {
 			return fmt.Errorf("verkle tree: error resolving node %x at depth %d: %w", stem, n.depth, err)
@@ -398,6 +398,9 @@ func (n *InternalNode) insertStemUnlocked(stem []byte, node VerkleNode, resolver
 
 func (n *InternalNode) toHashedNode() *HashedNode {
 	var hash Fr
+	if n.commitment == nil {
+		panic("nil commitment")
+	}
 	toFr(&hash, n.commitment)
 	return &HashedNode{&hash, n.commitment}
 }
@@ -817,6 +820,9 @@ func MergeTrees(subroots []*InternalNode) VerkleNode {
 
 func (n *LeafNode) ToHashedNode() *HashedNode {
 	var hash Fr
+	if n.commitment == nil {
+		panic("nil commitment")
+	}
 	toFr(&hash, n.commitment)
 	return &HashedNode{&hash, n.commitment}
 }

--- a/tree.go
+++ b/tree.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 )
 
@@ -808,6 +809,21 @@ func (n *InternalNode) toDot(parent, path string) string {
 
 func (n *InternalNode) setDepth(d byte) {
 	n.depth = d
+}
+
+// MergeTrees takes a series of subtrees that got filled following
+// a command-and-conquer method, and merges them into a single tree.
+func MergeTrees(subroots []*InternalNode) VerkleNode {
+	root := New().(*InternalNode)
+	offset := 0
+	for i, subroot := range subroots {
+		root.count += subroot.count
+		for offset = i * runtime.NumCPU(); offset < (i+1)*runtime.NumCPU(); offset++ {
+			root.children[offset] = subroot.children[offset]
+		}
+	}
+
+	return root
 }
 
 func (n *LeafNode) ToHashedNode() *HashedNode {

--- a/tree.go
+++ b/tree.go
@@ -246,7 +246,6 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 		return err
 	}
 
-	n.ComputeCommitment()
 	return nil
 }
 
@@ -277,7 +276,6 @@ func (n *InternalNode) insertUnlocked(key []byte, value []byte, resolver NodeRes
 		if err != nil {
 			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", key, err)
 		}
-		resolved.ComputeCommitment()
 		n.children[nChild] = resolved
 		// recurse to handle the case of a LeafNode child that
 		// splits.
@@ -825,7 +823,6 @@ func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 	}
 	n.values[k[31]] = value
 	n.commitment = nil
-	n.ComputeCommitment()
 	return nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -242,12 +242,7 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 	// Clear cached commitment on modification
 	n.commitment = nil
 
-	err := n.insertUnlocked(key, value, resolver)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return n.insertUnlocked(key, value, resolver)
 }
 
 func (n *InternalNode) insertUnlocked(key []byte, value []byte, resolver NodeResolverFn) error {
@@ -338,13 +333,7 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 	// Clear cached commitment on modification
 	n.commitment = nil
 
-	err := n.insertStemUnlocked(stem, node, resolver)
-	if err != nil {
-		return err
-	}
-
-	n.ComputeCommitment()
-	return nil
+	return n.insertStemUnlocked(stem, node, resolver)
 }
 
 func (n *InternalNode) insertStemUnlocked(stem []byte, node VerkleNode, resolver NodeResolverFn) error {
@@ -849,7 +838,6 @@ func (n *LeafNode) insertStem(k []byte, values [][]byte) error {
 	}
 	n.values = values
 	n.commitment = nil
-	n.ComputeCommitment()
 	return nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -234,7 +234,7 @@ func (n *InternalNode) SetChild(i int, c VerkleNode) error {
 func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
 	// Prevent access to that subtree so that nodes aren't
 	// flushed from under us.
-	if n.depth >= 2 {
+	if n.depth >= 1 {
 		n.lock.Lock()
 		defer n.lock.Unlock()
 	}
@@ -325,7 +325,7 @@ func (n *InternalNode) insertUnlocked(key []byte, value []byte, resolver NodeRes
 func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeResolverFn) error {
 	// Prevent access to that subtree so that nodes aren't
 	// flushed from under us.
-	if n.depth >= 2 {
+	if n.depth >= 1 {
 		n.lock.Lock()
 		defer n.lock.Unlock()
 	}
@@ -510,7 +510,7 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 }
 
 func (n *InternalNode) Delete(key []byte) error {
-	if n.depth >= 2 {
+	if n.depth >= 1 {
 		n.lock.Lock()
 		defer n.lock.Unlock()
 	}
@@ -578,7 +578,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 
 func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 	nChild := offset2key(k, n.depth)
-	if n.depth >= 2 {
+	if n.depth >= 1 {
 		n.lock.Lock()
 		defer n.lock.Unlock()
 	}

--- a/tree.go
+++ b/tree.go
@@ -30,7 +30,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"sync"
 )
 
 type NodeFlushFn func(VerkleNode)
@@ -173,8 +172,6 @@ type (
 		commitment *Point
 
 		committer Committer
-
-		lock sync.Mutex
 	}
 
 	LeafNode struct {
@@ -794,16 +791,6 @@ func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 		return errInsertIntoOtherStem
 	}
 	n.values[k[31]] = value
-	n.commitment = nil
-	return nil
-}
-
-func (n *LeafNode) insertStem(k []byte, values [][]byte) error {
-	// Sanity check: ensure the key header is the same:
-	if !equalPaths(k, n.stem) {
-		return errInsertIntoOtherStem
-	}
-	n.values = values
 	n.commitment = nil
 	return nil
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -286,7 +286,7 @@ func TestCachedCommitment(t *testing.T) {
 
 	tree.Insert(key4, fourtyKeyTest, nil)
 
-	if tree.(*InternalNode).commitment.Bytes() == oldRoot {
+	if tree.(*InternalNode).ComputeCommitment().Bytes() == oldRoot {
 		t.Error("root has stale commitment")
 	}
 	if tree.(*InternalNode).children[4].(*InternalNode).commitment.Bytes() == oldInternal {

--- a/tree_test.go
+++ b/tree_test.go
@@ -922,7 +922,12 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil)
+	leaf := &LeafNode{
+		stem:      fourtyKeyTest[:31],
+		values:    values,
+		committer: root1.(*InternalNode).committer,
+	}
+	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], leaf, nil)
 	r1c := root1.ComputeCommitment()
 
 	var key5, key192 [32]byte


### PR DESCRIPTION
A proposal has been made not to insert the leaves during the conversion, and instead to flush them directly to disk. This reduces the tree's memory growth rate, and therefore the total number of tree walks performed by the flushing goroutine.