### PR TITLE
Update link to Verkle tree explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # go-verkle
 
-An implementation of [Verkle trees](https://notes.ethereum.org/nrQqhVpQRi6acQckwm1Ryg). When production-ready, the code is to be merged back into go-ethereum.
+An implementation of [Verkle trees](https://dankradfeist.de/ethereum/2021/06/18/verkle-trie-for-eth1.html). When production-ready, the code is to be merged back into go-ethereum.
 
 Node width is set to 256 children.
 


### PR DESCRIPTION
The [previous link](https://notes.ethereum.org/nrQqhVpQRi6acQckwm1Ryg) was moved to [Data availability checks](https://dankradfeist.de/ethereum/2019/12/20/data-availability-checks.html) however, I think [Verkle trie for Eth1 state](https://dankradfeist.de/ethereum/2021/06/18/verkle-trie-for-eth1.html) is a better explainer