### PR TITLE
differential insertion on hashed leaf nodes

### DIFF
--- a/benchs/main.go
+++ b/benchs/main.go
@@ -47,7 +47,7 @@ func benchmarkInsertInExisting() {
 		for i := 0; i < 5; i++ {
 			root := verkle.New()
 			for _, k := range keys {
-				if err := root.Insert(k, value, nil); err != nil {
+				if err := root.Insert(k, nil, value, nil); err != nil {
 					panic(err)
 				}
 			}
@@ -56,7 +56,7 @@ func benchmarkInsertInExisting() {
 			// Now insert the 10k leaves and measure time
 			start := time.Now()
 			for _, k := range toInsertKeys {
-				if err := root.Insert(k, value, nil); err != nil {
+				if err := root.Insert(k, nil, value, nil); err != nil {
 					panic(err)
 				}
 			}

--- a/empty.go
+++ b/empty.go
@@ -29,12 +29,12 @@ import "errors"
 
 type Empty struct{}
 
-func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
+func (Empty) Insert([]byte, []byte, []byte, NodeResolverFn) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
 
 func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {
-	return e.Insert(key, value, nil)
+	return e.Insert(key, nil, value, nil)
 }
 
 func (Empty) Delete([]byte, NodeResolverFn) error {

--- a/empty_test.go
+++ b/empty_test.go
@@ -29,7 +29,7 @@ import "testing"
 
 func TestEmptyFuncs(t *testing.T) {
 	var e Empty
-	err := e.Insert(zeroKeyTest, zeroKeyTest, nil)
+	err := e.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when inserting into empty")
 	}

--- a/encoding.go
+++ b/encoding.go
@@ -78,6 +78,15 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 		return ln, nil
 	case internalRLPType:
 		return CreateInternalNode(serialized[1:33], serialized[33:], depth, comm)
+	case hashedLeafRLPType:
+		ln := &HashedNode{
+			stem:       serialized[1:32],
+			commitment: new(Point),
+			hash:       new(Fr),
+		}
+		ln.commitment.SetBytes(serialized[32:])
+		ln.hash.SetBytes(comm)
+		return ln, nil
 	default:
 		return nil, ErrInvalidNodeEncoding
 	}

--- a/hashednode.go
+++ b/hashednode.go
@@ -36,7 +36,7 @@ type HashedNode struct {
 	stem       []byte
 }
 
-func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
+func (*HashedNode) Insert([]byte, []byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -33,6 +33,7 @@ import (
 type HashedNode struct {
 	hash       *Fr
 	commitment *Point
+	stem       []byte
 }
 
 func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -73,6 +74,10 @@ func (n *HashedNode) Copy() VerkleNode {
 	}
 	if n.commitment != nil {
 		CopyPoint(h.commitment, n.commitment)
+	}
+	if n.stem != nil {
+		h.stem = make([]byte, len(n.stem))
+		copy(h.stem, n.stem)
 	}
 
 	return h

--- a/hashednode.go
+++ b/hashednode.go
@@ -60,8 +60,17 @@ func (*HashedNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte) {
 	panic("can not get the full path, and there is no proof of absence")
 }
 
-func (*HashedNode) Serialize() ([]byte, error) {
-	return nil, errSerializeHashedNode
+func (n *HashedNode) Serialize() ([]byte, error) {
+	if len(n.stem) == 0 {
+		return nil, errSerializeHashedNode
+	}
+
+	ser := make([]byte, 1, 1+31+32)
+	ser[0] = hashedLeafRLPType
+	ser = append(ser, n.stem...)
+	serComm := n.commitment.Bytes()
+	ser = append(ser, serComm[:]...)
+	return ser, nil
 }
 
 func (n *HashedNode) Copy() VerkleNode {

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -29,7 +29,7 @@ import "testing"
 
 func TestHashedNodeFuncs(t *testing.T) {
 	e := HashedNode{hash: new(Fr), commitment: new(Point)}
-	err := e.Insert(zeroKeyTest, zeroKeyTest, nil)
+	err := e.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when inserting into a hashed node")
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -35,9 +35,9 @@ import (
 
 func TestProofVerifyTwoLeaves(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(oneKeyTest, zeroKeyTest, nil)
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
+	root.Insert(oneKeyTest, nil, zeroKeyTest, nil)
+	root.Insert(ffx32KeyTest, nil, zeroKeyTest, nil)
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{string(ffx32KeyTest): zeroKeyTest})
 
@@ -56,7 +56,7 @@ func TestProofVerifyMultipleLeaves(t *testing.T) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		root.Insert(key, nil, fourtyKeyTest, nil)
 	}
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{keys[0]}, map[string][]byte{string(keys[0]): fourtyKeyTest})
@@ -77,7 +77,7 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		root.Insert(key, nil, fourtyKeyTest, nil)
 		kv[string(key)] = fourtyKeyTest
 	}
 
@@ -101,7 +101,7 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		kv[string(key)] = fourtyKeyTest
-		root.Insert(key, fourtyKeyTest, nil)
+		root.Insert(key, nil, fourtyKeyTest, nil)
 		if i%2 == 0 {
 			keys = append(keys, key)
 		}
@@ -136,10 +136,10 @@ func TestMultiProofVerifyMultipleLeavesCommitmentRedundancy(t *testing.T) {
 	root := New()
 	keys[0] = zeroKeyTest
 	kv[string(zeroKeyTest)] = fourtyKeyTest
-	root.Insert(keys[0], fourtyKeyTest, nil)
+	root.Insert(keys[0], nil, fourtyKeyTest, nil)
 	keys[1] = oneKeyTest
 	kv[string(oneKeyTest)] = fourtyKeyTest
-	root.Insert(keys[1], fourtyKeyTest, nil)
+	root.Insert(keys[1], nil, fourtyKeyTest, nil)
 
 	proof, _, _, _, _ := MakeVerkleMultiProof(root, keys, kv)
 
@@ -152,8 +152,8 @@ func TestMultiProofVerifyMultipleLeavesCommitmentRedundancy(t *testing.T) {
 
 func TestProofOfAbsenceInternalVerify(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(oneKeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
+	root.Insert(oneKeyTest, nil, zeroKeyTest, nil)
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{})
 
@@ -165,8 +165,8 @@ func TestProofOfAbsenceInternalVerify(t *testing.T) {
 
 func TestProofOfAbsenceLeafVerify(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
+	root.Insert(ffx32KeyTest, nil, zeroKeyTest, nil)
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{oneKeyTest}, map[string][]byte{})
 
@@ -177,8 +177,8 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 }
 func TestProofOfAbsenceLeafVerifyOtherSuffix(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
+	root.Insert(ffx32KeyTest, nil, zeroKeyTest, nil)
 
 	key := func() []byte {
 		ret, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000080")
@@ -195,7 +195,7 @@ func TestProofOfAbsenceLeafVerifyOtherSuffix(t *testing.T) {
 
 func TestProofOfAbsenceStemVerify(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 
 	key := func() []byte {
 		ret, _ := hex.DecodeString("0000000000000000000000000000000000000000100000000000000000000000")
@@ -217,7 +217,7 @@ func BenchmarkProofCalculation(b *testing.B) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
-		root.Insert(key, zeroKeyTest, nil)
+		root.Insert(key, nil, zeroKeyTest, nil)
 	}
 
 	b.ResetTimer()
@@ -235,7 +235,7 @@ func BenchmarkProofVerification(b *testing.B) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
-		root.Insert(key, zeroKeyTest, nil)
+		root.Insert(key, nil, zeroKeyTest, nil)
 	}
 
 	root.ComputeCommitment()
@@ -259,7 +259,7 @@ func TestProofSerializationNoAbsentStem(t *testing.T) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		root.Insert(key, nil, fourtyKeyTest, nil)
 	}
 
 	proof, _, _, _, _ := MakeVerkleMultiProof(root, [][]byte{keys[0]}, map[string][]byte{})
@@ -291,7 +291,7 @@ func TestProofSerializationWithAbsentStem(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		root.Insert(key, nil, fourtyKeyTest, nil)
 	}
 
 	// Create stem  0x0000020100000.... that is not present in the tree,
@@ -331,7 +331,7 @@ func TestProofDeserialize(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		root.Insert(key, nil, fourtyKeyTest, nil)
 		keyvals = append(keyvals, KeyValuePair{
 			Key:   key,
 			Value: fourtyKeyTest,
@@ -420,7 +420,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 	// but does look the same for most of its length.
 	root := New()
 	key, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030000")
-	root.Insert(key, testValue, nil)
+	root.Insert(key, nil, testValue, nil)
 	root.ComputeCommitment()
 
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
@@ -439,7 +439,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 func TestProofOfAbsenceNoneMultipleStems(t *testing.T) {
 	root := New()
 	key, _ := hex.DecodeString("0403030303030303030303030303030303030303030303030303030303030000")
-	root.Insert(key, testValue, nil)
+	root.Insert(key, nil, testValue, nil)
 	root.ComputeCommitment()
 
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")

--- a/stateless_fuzzer_test.go
+++ b/stateless_fuzzer_test.go
@@ -39,8 +39,9 @@ func FuzzStatelessVsStateful(f *testing.F) {
 		rootL := NewStateless()
 
 		for i := 0; i < len(input)/64; i++ {
-			rootF.Insert(input[i*64:i*64+32], input[i*64+32:(i+1)*64], nil)
-			rootL.Insert(input[i*64:i*64+32], input[i*64+32:(i+1)*64], nil)
+			// previous values are unlikely to be non-nil
+			rootF.Insert(input[i*64:i*64+32], nil, input[i*64+32:(i+1)*64], nil)
+			rootL.Insert(input[i*64:i*64+32], nil, input[i*64+32:(i+1)*64], nil)
 		}
 
 		if !Equal(rootL.ComputeCommitment(), rootF.ComputeCommitment()) {

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -37,9 +37,9 @@ func TestStatelessChildren(t *testing.T) {
 	c2key, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000085")
 
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	root.Insert(oneKeyTest, fourtyKeyTest, nil)
-	root.Insert(c2key, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
+	root.Insert(c2key, nil, fourtyKeyTest, nil)
 
 	list := root.Children()
 	if len(list) != NodeWidth {
@@ -68,9 +68,9 @@ func TestStatelessChildren(t *testing.T) {
 	}
 
 	rootRef := New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(c2key, fourtyKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(c2key, nil, fourtyKeyTest, nil)
 
 	if !Equal(rootRef.ComputeCommitment(), root.commitment) {
 		t.Fatalf("differing state(less|ful) roots %x != %x", rootRef.ComputeCommitment(), root.commitment)
@@ -79,11 +79,11 @@ func TestStatelessChildren(t *testing.T) {
 
 func TestStatelessDelete(t *testing.T) {
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 	var single Point
 	CopyPoint(&single, root.commitment)
 
-	root.Insert(oneKeyTest, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
 	if root.commitment.Equal(&single) {
 		t.Fatal("second insert didn't update")
 	}
@@ -91,8 +91,8 @@ func TestStatelessDelete(t *testing.T) {
 	root.Delete(oneKeyTest, nil)
 
 	rootRef := New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
 	rootRef.Delete(oneKeyTest, nil)
 
 	if !Equal(rootRef.ComputeCommitment(), root.commitment) {
@@ -102,10 +102,10 @@ func TestStatelessDelete(t *testing.T) {
 
 func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 
 	rootRef := New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 	hash := rootRef.ComputeCommitment()
 
 	if !Equal(hash, root.commitment) {
@@ -115,10 +115,10 @@ func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 	// Overwrite one leaf and check that the update
 	// is what is expected.
 	rootRef = New()
-	rootRef.Insert(zeroKeyTest, oneKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, oneKeyTest, nil)
 	hash = rootRef.ComputeCommitment()
 
-	root.Insert(zeroKeyTest, oneKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, oneKeyTest, nil)
 
 	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after update %v %v", hash, root.hash)
@@ -127,12 +127,12 @@ func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 
 func TestStatelessInsertLeafIntoLeaf(t *testing.T) {
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	root.Insert(oneKeyTest, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
 
 	rootRef := New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
 	hash := rootRef.ComputeCommitment()
 
 	if !Equal(hash, root.commitment) {
@@ -140,11 +140,11 @@ func TestStatelessInsertLeafIntoLeaf(t *testing.T) {
 	}
 
 	rootRef = New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(oneKeyTest, oneKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, nil, oneKeyTest, nil)
 	hash = rootRef.ComputeCommitment()
 
-	root.Insert(oneKeyTest, oneKeyTest, nil)
+	root.Insert(oneKeyTest, nil, oneKeyTest, nil)
 
 	if !Equal(hash, root.commitment) {
 		t.Fatalf("hashes differ after update %v %v", hash, root.hash)
@@ -154,11 +154,11 @@ func TestStatelessInsertLeafIntoLeaf(t *testing.T) {
 func TestStatelessInsertLeafIntoInternal(t *testing.T) {
 	key1, _ := hex.DecodeString("0000100000000000000000000000000000000000000000000000000000000000")
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	root.Insert(key1, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	root.Insert(key1, nil, fourtyKeyTest, nil)
 	rootRef := New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(key1, fourtyKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(key1, nil, fourtyKeyTest, nil)
 	hash := rootRef.ComputeCommitment()
 
 	if !Equal(hash, root.commitment) {
@@ -176,12 +176,12 @@ func TestStatelessInsertOrdered(t *testing.T) {
 
 func TestStatelessCopy(t *testing.T) {
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 	rootCopy := root.Copy()
 	if !Equal(rootCopy.ComputeCommitment(), root.commitment) {
 		t.Fatal("copy produced the wrong hash")
 	}
-	root.Insert(oneKeyTest, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
 	if Equal(rootCopy.ComputeCommitment(), root.commitment) {
 		t.Fatal("copy did not update the hash")
 	}
@@ -189,7 +189,7 @@ func TestStatelessCopy(t *testing.T) {
 
 func TestStatelessGet(t *testing.T) {
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 	data, err := root.Get(zeroKeyTest, nil)
 	if err != nil {
 		t.Fatalf("error while getting existing value %v", err)
@@ -229,13 +229,13 @@ func TestStatelessComputeCommitmentEmptyRoot(t *testing.T) {
 func TestStatelessToDot(t *testing.T) {
 	key1, _ := hex.DecodeString("0000100000000000000000000000000000000000000000000000000000000000")
 	root := NewStateless()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	root.Insert(oneKeyTest, fourtyKeyTest, nil)
-	root.Insert(key1, fourtyKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	root.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
+	root.Insert(key1, nil, fourtyKeyTest, nil)
 	rootRef := New()
-	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
-	rootRef.Insert(key1, fourtyKeyTest, nil)
+	rootRef.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(oneKeyTest, nil, fourtyKeyTest, nil)
+	rootRef.Insert(key1, nil, fourtyKeyTest, nil)
 	rootRef.ComputeCommitment()
 
 	var stl []string
@@ -266,7 +266,7 @@ func TestStatelessToDot(t *testing.T) {
 func TestStatelessDeserialize(t *testing.T) {
 	root := New()
 	for _, k := range [][]byte{zeroKeyTest, oneKeyTest, fourtyKeyTest, ffx32KeyTest} {
-		root.Insert(k, fourtyKeyTest, nil)
+		root.Insert(k, nil, fourtyKeyTest, nil)
 	}
 	keyvals := []KeyValuePair{
 		{zeroKeyTest, fourtyKeyTest},
@@ -306,7 +306,7 @@ func TestStatelessDeserialize(t *testing.T) {
 func TestStatelessDeserializeMissginChildNode(t *testing.T) {
 	root := New()
 	for _, k := range [][]byte{zeroKeyTest, oneKeyTest, ffx32KeyTest} {
-		root.Insert(k, fourtyKeyTest, nil)
+		root.Insert(k, nil, fourtyKeyTest, nil)
 	}
 	keyvals := []KeyValuePair{
 		{zeroKeyTest, fourtyKeyTest},
@@ -347,7 +347,7 @@ func TestStatelessDeserializeDepth2(t *testing.T) {
 	root := New()
 	key1, _ := hex.DecodeString("0000010000000000000000000000000000000000000000000000000000000000")
 	for _, k := range [][]byte{zeroKeyTest, key1} {
-		root.Insert(k, fourtyKeyTest, nil)
+		root.Insert(k, nil, fourtyKeyTest, nil)
 	}
 	keyvals := []KeyValuePair{
 		{zeroKeyTest, fourtyKeyTest},
@@ -386,7 +386,7 @@ func TestStatelessGetProofItems(t *testing.T) {
 
 	root := New()
 	for _, k := range insertedKeys {
-		root.Insert(k, fourtyKeyTest, nil)
+		root.Insert(k, nil, fourtyKeyTest, nil)
 	}
 	keyvals := []KeyValuePair{
 		{zeroKeyTest, fourtyKeyTest},

--- a/tree.go
+++ b/tree.go
@@ -648,6 +648,16 @@ func (n *InternalNode) InsertStemOrdered(key []byte, leaf *LeafNode, flush NodeF
 		newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
 		n.children[nChild] = newBranch
 
+		// hack for compatibility with the diff insertion: since
+		// InsertStemOrdered does not perform differential inserts
+		// it relies on the old "recalculate the commitment iff it's
+		// nil" trick. But with the introduction of a default comm of
+		// 1 in newInternalNode, ComputeCommitment() doesn't calculate
+		// anything. Force the recalculation until InsertStemOrdered
+		// is ported to the new method. That'll be after InsertStem and
+		// InsertOrdered are removed.
+		newBranch.commitment = nil
+
 		nextWordInInsertedKey := offset2key(key, n.depth+1)
 		if nextWordInInsertedKey != nextWordInExistingKey {
 			// Directly hash the (left) node that was already

--- a/tree.go
+++ b/tree.go
@@ -953,7 +953,7 @@ func (n *LeafNode) ToHashedNode() *HashedNode {
 	return &HashedNode{&hash, n.commitment, n.stem}
 }
 
-func (n *LeafNode) Insert(k []byte, oldv, newv []byte, _ NodeResolverFn) error {
+func (n *LeafNode) Insert(k []byte, _, newv []byte, _ NodeResolverFn) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
 		return errInsertIntoOtherStem

--- a/tree.go
+++ b/tree.go
@@ -306,7 +306,7 @@ func (n *InternalNode) Insert(key []byte, oldv, newv []byte, resolver NodeResolv
 			}
 
 			// this got inserted into the same leaf, update the leaf's
-			// committment differentially.
+			// commitment differentially.
 			cfg, _ := GetConfig()
 			var diff Fr
 			var nv, ov Fr

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -76,7 +76,7 @@ func TestInsertKey0Value0(t *testing.T) {
 		srs       = cfg.conf.SRSPrecompPoints.SRS
 	)
 
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 	comm := root.ComputeCommitment()
 
 	extensionAndSuffixOneKey(zeroKeyTest, zeroKeyTest, &expectedP)
@@ -105,7 +105,7 @@ func TestInsertKey1Value1(t *testing.T) {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
 		25, 26, 27, 28, 29, 30, 31, 32,
 	}
-	root.Insert(key, key, nil)
+	root.Insert(key, nil, key, nil)
 	comm := root.ComputeCommitment()
 
 	extensionAndSuffixOneKey(key, key, &expectedP)
@@ -139,8 +139,8 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
 		25, 26, 27, 28, 29, 30, 31, 128,
 	}
-	root.Insert(key_a, key_a, nil)
-	root.Insert(key_b, key_b, nil)
+	root.Insert(key_a, nil, key_a, nil)
+	root.Insert(key_b, nil, key_b, nil)
 	comm := root.ComputeCommitment()
 
 	stemComm0 := srs[0]
@@ -181,8 +181,8 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 		srs                 = cfg.conf.SRSPrecompPoints.SRS
 	)
 	key_b, _ := hex.DecodeString("0101010101010101010101010101010101010101010101010101010101010101")
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(key_b, key_b, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
+	root.Insert(key_b, nil, key_b, nil)
 	comm := root.ComputeCommitment()
 	fmt.Println(root.toDot("", ""))
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1156,7 +1156,6 @@ func TestInsertStemOrdered(t *testing.T) {
 	root2.Insert(zeroKeyTest, nil, ffx32KeyTest, nil)
 	root2.Insert(key5[:], nil, zeroKeyTest, nil)
 	root2.Insert(key192[:], nil, fourtyKeyTest, nil)
-	root2.Insert(key192[:], nil, fourtyKeyTest, nil)
 	root2.Insert(key64[:], nil, zeroKeyTest, nil)
 	root2.Insert(keysplit[:], nil, ffx32KeyTest, nil)
 	r2c := root2.ComputeCommitment()

--- a/tree_test.go
+++ b/tree_test.go
@@ -50,7 +50,7 @@ var (
 
 func TestInsertIntoRoot(t *testing.T) {
 	root := New()
-	err := root.Insert(zeroKeyTest, testValue, nil)
+	err := root.Insert(zeroKeyTest, nil, testValue, nil)
 	if err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
@@ -67,8 +67,8 @@ func TestInsertIntoRoot(t *testing.T) {
 
 func TestInsertTwoLeaves(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, testValue, nil)
-	root.Insert(ffx32KeyTest, testValue, nil)
+	root.Insert(zeroKeyTest, nil, testValue, nil)
+	root.Insert(ffx32KeyTest, nil, testValue, nil)
 
 	leaf0, ok := root.(*InternalNode).children[0].(*LeafNode)
 	if !ok {
@@ -91,8 +91,8 @@ func TestInsertTwoLeaves(t *testing.T) {
 
 func TestInsertTwoLeavesLastLevel(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, testValue, nil)
-	root.Insert(oneKeyTest, testValue, nil)
+	root.Insert(zeroKeyTest, nil, testValue, nil)
+	root.Insert(oneKeyTest, nil, testValue, nil)
 
 	leaf, ok := root.(*InternalNode).children[0].(*LeafNode)
 	if !ok {
@@ -110,8 +110,8 @@ func TestInsertTwoLeavesLastLevel(t *testing.T) {
 
 func TestGetTwoLeaves(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, testValue, nil)
-	root.Insert(ffx32KeyTest, testValue, nil)
+	root.Insert(zeroKeyTest, nil, testValue, nil)
+	root.Insert(ffx32KeyTest, nil, testValue, nil)
 
 	val, err := root.Get(zeroKeyTest, nil)
 	if err != nil {
@@ -183,7 +183,7 @@ func TestInsertVsOrdered(t *testing.T) {
 
 	root1 := New()
 	for _, k := range keys {
-		err := root1.Insert(k, fourtyKeyTest, nil)
+		err := root1.Insert(k, nil, fourtyKeyTest, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -245,9 +245,9 @@ func TestCopy(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key2, nil, fourtyKeyTest, nil)
+	tree.Insert(key3, nil, fourtyKeyTest, nil)
 	tree.ComputeCommitment()
 
 	copied := tree.Copy()
@@ -258,7 +258,7 @@ func TestCopy(t *testing.T) {
 	if !bytes.Equal(got1[:], got2[:]) {
 		t.Fatalf("error copying commitments %x != %x", got1, got2)
 	}
-	tree.Insert(key2, oneKeyTest, nil)
+	tree.Insert(key2, nil, oneKeyTest, nil)
 	tree.ComputeCommitment()
 	got2 = tree.ComputeCommitment().Bytes()
 	if bytes.Equal(got1[:], got2[:]) {
@@ -274,9 +274,9 @@ func TestCachedCommitment(t *testing.T) {
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	key4, _ := hex.DecodeString("0407000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key2, nil, fourtyKeyTest, nil)
+	tree.Insert(key3, nil, fourtyKeyTest, nil)
 	oldRoot := tree.ComputeCommitment().Bytes()
 	oldInternal := tree.(*InternalNode).children[4].(*LeafNode).commitment.Bytes()
 
@@ -284,7 +284,7 @@ func TestCachedCommitment(t *testing.T) {
 		t.Error("root has not cached commitment")
 	}
 
-	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Insert(key4, nil, fourtyKeyTest, nil)
 
 	if tree.(*InternalNode).ComputeCommitment().Bytes() == oldRoot {
 		t.Error("root has stale commitment")
@@ -302,9 +302,9 @@ func TestClearCache(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key2, nil, fourtyKeyTest, nil)
+	tree.Insert(key3, nil, fourtyKeyTest, nil)
 	tree.ComputeCommitment()
 
 	root := tree.(*InternalNode)
@@ -324,11 +324,11 @@ func TestDelLeaf(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key2, nil, fourtyKeyTest, nil)
 	hash := tree.ComputeCommitment()
 
-	tree.Insert(key3, fourtyKeyTest, nil)
+	tree.Insert(key3, nil, fourtyKeyTest, nil)
 	if err := tree.Delete(key3, nil); err != nil {
 		t.Error(err)
 	}
@@ -352,8 +352,8 @@ func TestDeleteNonExistent(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key2, nil, fourtyKeyTest, nil)
 	if err := tree.Delete(key3, nil); err != errDeleteNonExistent {
 		t.Error("should fail to delete non-existent key")
 	}
@@ -365,13 +365,13 @@ func TestDeletePrune(t *testing.T) {
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	key4, _ := hex.DecodeString("0407000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key2, nil, fourtyKeyTest, nil)
 
 	hash1 := tree.ComputeCommitment()
-	tree.Insert(key3, fourtyKeyTest, nil)
+	tree.Insert(key3, nil, fourtyKeyTest, nil)
 	hash2 := tree.ComputeCommitment()
-	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Insert(key4, nil, fourtyKeyTest, nil)
 
 	if err := tree.Delete(key4, nil); err != nil {
 		t.Error(err)
@@ -409,7 +409,7 @@ func TestDeleteHash(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
 	tree.InsertOrdered(key2, fourtyKeyTest, nil)
 	tree.InsertOrdered(key3, fourtyKeyTest, nil)
 	tree.ComputeCommitment()
@@ -423,8 +423,8 @@ func TestDeleteUnequalPath(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	tree.Insert(key1, nil, fourtyKeyTest, nil)
+	tree.Insert(key3, nil, fourtyKeyTest, nil)
 	tree.ComputeCommitment()
 
 	if err := tree.Delete(key2, nil); err != errDeleteNonExistent {
@@ -467,7 +467,7 @@ func TestDeleteResolve(t *testing.T) {
 
 func TestConcurrentTrees(t *testing.T) {
 	tree := New()
-	err := tree.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	err := tree.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -477,7 +477,7 @@ func TestConcurrentTrees(t *testing.T) {
 	ch := make(chan *Point)
 	builder := func() {
 		tree := New()
-		tree.Insert(zeroKeyTest, fourtyKeyTest, nil)
+		tree.Insert(zeroKeyTest, nil, fourtyKeyTest, nil)
 		ch <- tree.ComputeCommitment()
 	}
 
@@ -513,7 +513,7 @@ func BenchmarkCommitFullNode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		root := New()
 		for _, k := range keys {
-			if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+			if err := root.Insert(k, nil, fourtyKeyTest, nil); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -551,7 +551,7 @@ func benchmarkCommitNLeaves(b *testing.B, n int) {
 		for i := 0; i < b.N; i++ {
 			root := New()
 			for _, el := range kvs {
-				if err := root.Insert(el.k, el.v, nil); err != nil {
+				if err := root.Insert(el.k, nil, el.v, nil); err != nil {
 					b.Error(err)
 				}
 			}
@@ -587,7 +587,7 @@ func BenchmarkModifyLeaves(b *testing.B) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		keys[i] = key
-		root.Insert(key, val, nil)
+		root.Insert(key, nil, val, nil)
 	}
 	root.ComputeCommitment()
 
@@ -600,7 +600,7 @@ func BenchmarkModifyLeaves(b *testing.B) {
 		for j := 0; j < toEdit; j++ {
 			// skipcq: GSC-G404
 			k := keys[mRand.Intn(n)]
-			if err := root.Insert(k, val, nil); err != nil {
+			if err := root.Insert(k, nil, val, nil); err != nil {
 				b.Error(err)
 			}
 		}
@@ -626,8 +626,8 @@ func randomKeysSorted(n int) [][]byte {
 
 func TestNodeSerde(t *testing.T) {
 	tree := New()
-	tree.Insert(zeroKeyTest, testValue, nil)
-	tree.Insert(fourtyKeyTest, testValue, nil)
+	tree.Insert(zeroKeyTest, nil, testValue, nil)
+	tree.Insert(fourtyKeyTest, nil, testValue, nil)
 	origComm := tree.ComputeCommitment().Bytes()
 	root := tree.(*InternalNode)
 
@@ -866,10 +866,10 @@ func TestGetKey(t *testing.T) {
 
 func TestInsertIntoHashedNode(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 	root.InsertOrdered(fourtyKeyTest, zeroKeyTest, nil)
 
-	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != errInsertIntoHash {
+	if err := root.Insert(zeroKeyTest, nil, zeroKeyTest, nil); err != errInsertIntoHash {
 		t.Fatalf("incorrect error type: %v", err)
 	}
 
@@ -879,7 +879,7 @@ func TestInsertIntoHashedNode(t *testing.T) {
 
 		return node.Serialize()
 	}
-	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, resolver); err != nil {
+	if err := root.Copy().Insert(zeroKeyTest, nil, zeroKeyTest, resolver); err != nil {
 		t.Fatalf("error in node resolution: %v", err)
 	}
 
@@ -892,7 +892,7 @@ func TestInsertIntoHashedNode(t *testing.T) {
 		rlp, _ := node.Serialize()
 		return rlp[:len(rlp)-10], nil
 	}
-	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, invalidRLPResolver); !errors.Is(err, serializedPayloadTooShort) {
+	if err := root.Copy().Insert(zeroKeyTest, nil, zeroKeyTest, invalidRLPResolver); !errors.Is(err, serializedPayloadTooShort) {
 		t.Fatalf("error detecting a decoding error after resolution: %v", err)
 	}
 
@@ -901,24 +901,24 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	erroringResolver := func(h []byte) ([]byte, error) {
 		return nil, randomResolverError
 	}
-	if err := root.Copy().Insert(zeroKeyTest, zeroKeyTest, erroringResolver); !errors.Is(err, randomResolverError) {
+	if err := root.Copy().Insert(zeroKeyTest, nil, zeroKeyTest, erroringResolver); !errors.Is(err, randomResolverError) {
 		t.Fatalf("error detecting a resolution error: %v", err)
 	}
 }
 
 func TestToDot(*testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 	root.InsertOrdered(fourtyKeyTest, zeroKeyTest, nil)
 	fourtytwoKeyTest, _ := hex.DecodeString("4020000000000000000000000000000000000000000000000000000000000000")
-	root.Insert(fourtytwoKeyTest, zeroKeyTest, nil)
+	root.Insert(fourtytwoKeyTest, nil, zeroKeyTest, nil)
 
 	fmt.Println(root.toDot("", ""))
 }
 
 func TestEmptyCommitment(t *testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.Insert(zeroKeyTest, nil, zeroKeyTest, nil)
 	root.ComputeCommitment()
 	pe, _, _ := root.GetProofItems(keylist{ffx32KeyTest})
 	if len(pe.Cis) != 1 || len(pe.Zis) != 1 || len(pe.Yis) != 1 || len(pe.Fis) != 1 {
@@ -964,7 +964,7 @@ func TestLeafToCommsLessThan16(*testing.T) {
 func TestGetProofItemsNoPoaIfStemPresent(t *testing.T) {
 
 	root := New()
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Insert(ffx32KeyTest, nil, zeroKeyTest, nil)
 
 	// insert two keys that differ from the inserted stem
 	// by one byte.
@@ -1002,7 +1002,7 @@ var (
 func TestWithRustCompatibility(t *testing.T) {
 	root := New()
 	for i, key := range testAccountKeys {
-		err := root.Insert(key, testAccountValues[i], nil)
+		err := root.Insert(key, nil, testAccountValues[i], nil)
 		if err != nil {
 			t.Fatalf("error inserting: %v", err)
 		}
@@ -1035,8 +1035,8 @@ func TestInsertStem(t *testing.T) {
 	copy(key192[:], fourtyKeyTest[:31])
 	key5[31] = 5
 	key192[31] = 192
-	root2.Insert(key5[:], zeroKeyTest, nil)
-	root2.Insert(key192[:], fourtyKeyTest, nil)
+	root2.Insert(key5[:], nil, zeroKeyTest, nil)
+	root2.Insert(key192[:], nil, fourtyKeyTest, nil)
 	r2c := root2.ComputeCommitment()
 
 	if !Equal(r1c, r2c) {
@@ -1049,7 +1049,7 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 
 	// Insert a unique leaf and flush it
 	root := New()
-	root.Insert(zeroKeyTest, ffx32KeyTest, nil)
+	root.Insert(zeroKeyTest, nil, ffx32KeyTest, nil)
 	root.(*InternalNode).Flush(func(node VerkleNode) {
 		l, ok := node.(*LeafNode)
 		if !ok {
@@ -1069,7 +1069,7 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 
 	// Now insert another leaf, with a resolver function
 	key, _ := hex.DecodeString("0000100000000000000000000000000000000000000000000000000000000000")
-	if err := root.Insert(key, ffx32KeyTest, func(comm []byte) ([]byte, error) {
+	if err := root.Insert(key, nil, ffx32KeyTest, func(comm []byte) ([]byte, error) {
 		leafcomm := leaf.ComputeCommitment().Bytes()
 		if bytes.Equal(comm, leafcomm[:]) {
 			ls, err := leaf.Serialize()
@@ -1087,12 +1087,13 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 	if _, ok := root.(*InternalNode).children[0].(*InternalNode); !ok {
 		t.Fatal("resolution didn't produce and intermediate, intermediate node")
 	}
-	l, ok := root.(*InternalNode).children[0].(*InternalNode).children[0].(*InternalNode).children[0].(*LeafNode)
+	_, ok := root.(*InternalNode).children[0].(*InternalNode).children[0].(*InternalNode).children[0].(*HashedNode)
+	if !ok {
+		t.Fatal("resolve with resolver didn't produce a hashed node where expected")
+	}
+	_, ok = root.(*InternalNode).children[0].(*InternalNode).children[0].(*InternalNode).children[16].(*LeafNode)
 	if !ok {
 		t.Fatal("resolve with resolver didn't produce a leaf node where expected")
-	}
-	if !bytes.Equal(l.stem, zeroKeyTest[:31]) && !bytes.Equal(l.values[0], ffx32KeyTest) {
-		t.Fatal("didn't find the resolved leaf where expected")
 	}
 }
 
@@ -1131,7 +1132,7 @@ func TestInsertStemOrdered(t *testing.T) {
 		values:    values3,
 		committer: root1.(*InternalNode).committer,
 	}
-	root1.(*InternalNode).Insert(zeroKeyTest, ffx32KeyTest, nil)
+	root1.(*InternalNode).Insert(zeroKeyTest, nil, ffx32KeyTest, nil)
 	root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], leaf1, flush)
 	root1.(*InternalNode).InsertStemOrdered(keysplit[:31], leaf2, flush)
 	root1.(*InternalNode).InsertStemOrdered(ffx32KeyTest[:31], leaf3, flush)
@@ -1150,12 +1151,12 @@ func TestInsertStemOrdered(t *testing.T) {
 	key192[31] = 192
 	key64[31] = 64
 	key32[31] = 32
-	root2.Insert(zeroKeyTest, ffx32KeyTest, nil)
-	root2.Insert(key5[:], zeroKeyTest, nil)
-	root2.Insert(key192[:], fourtyKeyTest, nil)
-	root2.Insert(key192[:], fourtyKeyTest, nil)
-	root2.Insert(key64[:], zeroKeyTest, nil)
-	root2.Insert(keysplit[:], ffx32KeyTest, nil)
+	root2.Insert(zeroKeyTest, nil, ffx32KeyTest, nil)
+	root2.Insert(key5[:], nil, zeroKeyTest, nil)
+	root2.Insert(key192[:], nil, fourtyKeyTest, nil)
+	root2.Insert(key192[:], nil, fourtyKeyTest, nil)
+	root2.Insert(key64[:], nil, zeroKeyTest, nil)
+	root2.Insert(keysplit[:], nil, ffx32KeyTest, nil)
 	r2c := root2.ComputeCommitment()
 
 	if !Equal(r1c, r2c) {
@@ -1238,7 +1239,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 
 		v, _ := hex.DecodeString(s)
 		vals = append(vals, v)
-		tree.Insert(keys[i], v, nil)
+		tree.Insert(keys[i], nil, v, nil)
 
 		initialVals[string(keys[i])] = v
 	}
@@ -1246,7 +1247,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 	// Insert the code chunk that isn't part of the proof
 	missingKey, _ := hex.DecodeString("744f493648c83c5ede1726a0cfbe36d3830fd5b64a820b79ca77fe159335268a")
 	missingVal, _ := hex.DecodeString("133b991f93d230604b1b8daaef64766264736f6c634300080700330000000000")
-	tree.Insert(missingKey, missingVal, nil)
+	tree.Insert(missingKey, nil, missingVal, nil)
 
 	r := tree.ComputeCommitment()
 


### PR DESCRIPTION
Second experiment for addressing #229 (see #231) : the signature of `Insert` is changed so that when values are inserted, and if a node is a hashed leaf node (i.e. a `HashedNode` with `stem != nil`), then no value is actually inserted and its commitment is computed from the delta between the old value and the new one.

Although its semantics haven't changed yet, `LeafNode` is expected, in the future, to only be used to initialize an extension-and-leaf-node, and never for an update. The end goal is to only use it into `InsertStemOrdered` and discontinue both `InsertOrdered` and `InsertStem` (if possible, it might be difficult to achieve  because of an out-of-order conversion process).

With this method, `LeafNodes` are never directly stored into the DB: values are read from the snapshot, and provide all the necessary information to update the tree without storing the serialized list of values. This makes the whole tree smaller both in RAM and on disk. It will also reduce IO during the conversion process (pending a modification to embed the hashed node in its parent `InternalNode`) and root commitment calculations (no full polynomial evaluation at each node)

TODO:
 * [x] also update the commitment of its parents
 * [x] fix `TestInsertIntoHashedNode`
 * [ ] also implement it for `StatelessNode`
 * [ ] rebase once the hashed leaf nodes are stored directly into their parent `InternalNode` for reduced I/O.
 * [ ] add a fuzzer against a `LeafNode` tree

Out of scope:
 * Removal of `InsertStem` and `InsertOrdered`
 * diff-insertion of multiple values into the same leaf