### PR TITLE
diff-insert for InsertStem and merge leaves

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1044,7 +1044,7 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 	var c1, c2 *Point
 	var old1, old2 *Fr
 	for i, v := range values {
-		if len(v) != 0 && !bytes.Equal(v, values[i]) {
+		if len(v) != 0 && !bytes.Equal(v, n.values[i]) {
 			if i < 128 {
 				if c1 == nil {
 					c1, old1 = n.getOldCn(byte(i))

--- a/tree.go
+++ b/tree.go
@@ -396,7 +396,7 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 			// on the next word in both keys, a recursion into
 			// the moved leaf node can occur.
 			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
-			newBranch := newInternalNodeNilCommitment(n.depth+1, n.committer).(*InternalNode)
+			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
 			n.children[nChild] = newBranch
 			newBranch.children[nextWordInExistingKey] = child
 			child.depth += 1

--- a/tree.go
+++ b/tree.go
@@ -1056,6 +1056,8 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 				}
 				n.updateCn(byte(i), v, c2)
 			}
+
+			n.values[i] = v[:]
 		}
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -373,6 +373,7 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 		if err != nil {
 			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", stem, err)
 		}
+		resolved.setDepth(n.depth + 1)
 		resolved.ComputeCommitment()
 		n.children[nChild] = resolved
 		// recurse to handle the case of a LeafNode child that
@@ -391,7 +392,7 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 			// Merge the two leaves and recalculate the leaf's
 			// commitment.
 			for i, v := range leaf.values {
-				if len(v) != 0 && !bytes.Equal(v[:], child.values[i]) {
+				if len(v) != 0 && !bytes.Equal(v, child.values[i]) {
 					err = child.updateLeaf(byte(i), v)
 					if err != nil {
 						return err

--- a/tree.go
+++ b/tree.go
@@ -391,7 +391,7 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 			// Merge the two leaves and recalculate the leaf's
 			// commitment.
 			for i, v := range leaf.values {
-				if len(v) != 0 {
+				if len(v) != 0 && !bytes.Equal(v[:], child.values[i]) {
 					err = child.updateLeaf(byte(i), v)
 					if err != nil {
 						return err

--- a/tree_test.go
+++ b/tree_test.go
@@ -963,7 +963,7 @@ func TestInsertStem(t *testing.T) {
 		values:    values,
 		committer: root1.(*InternalNode).committer,
 	}
-	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], leaf, nil)
+	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], leaf, nil, false)
 	r1c := root1.ComputeCommitment()
 
 	var key5, key192 [32]byte


### PR DESCRIPTION
In `TryUpdateAccount`, `Insert` is called 4 times, and with the introduction of diff-insert, this presents even more of a performance drag because the commitments of the internal nodes along the path are recomputed at least 4 times.

The same issue happens when inserting groups code chunks, that could be inserted once and for all with `InsertStem` instead of being inserted multiple times with `TryUpdate`.

This PR provides the basic changes required to implement this: it adds a boolean `overwrite` parameter to `InsertStem`. If `overwrite` is true, it will seek to merge the inserted leaf with the leaf that is already present in the tree (assuming that there is such a leaf node).

*NOTE* This isn't optimal since it will use `updateLeaf` under the hood, which recomputes the intermediate `cn` and commitments for the leaf node. It does save on the updates along the path to the leaf.