### PR TITLE
Rename ComputeCommitment to Commitment

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -64,17 +64,8 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 		if NodeWidth != len(values) {
 			return nil, fmt.Errorf("invalid number of nodes in decoded child expected %d, got %d", NodeWidth, len(values))
 		}
-		cfg, err := GetConfig()
-		if err != nil {
-			return nil, err
-		}
-		ln := &LeafNode{
-			stem:      serialized[1:32],
-			values:    values[:],
-			committer: cfg,
-			depth:     depth,
-		}
-		ln.ComputeCommitment()
+		ln := NewLeafNode(serialized[1:32], values[:])
+		ln.setDepth(depth)
 		return ln, nil
 	case internalRLPType:
 		return deserializeIntoStateless(serialized[1:33], serialized[33:], depth, comm)

--- a/tree.go
+++ b/tree.go
@@ -200,18 +200,6 @@ func newInternalNode(depth byte, cmtr Committer) VerkleNode {
 	return node
 }
 
-func newInternalNodeNilCommitment(depth byte, cmtr Committer) VerkleNode {
-	node := new(InternalNode)
-	node.children = make([]VerkleNode, NodeWidth)
-	for idx := range node.children {
-		node.children[idx] = Empty(struct{}{})
-	}
-	node.depth = depth
-	node.committer = cmtr
-	node.commitment = nil
-	return node
-}
-
 // New creates a new tree root
 func New() VerkleNode {
 	cfg, _ := GetConfig()
@@ -568,8 +556,6 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 // InsertStemOrdered does the same thing as InsertOrdered but is meant to insert a pre-build
 // LeafNode at a given stem, instead of individual leaves.
 func (n *InternalNode) InsertStemOrdered(key []byte, leaf *LeafNode, flush NodeFlushFn) error {
-	n.commitment = nil
-
 	nChild := offset2key(key, n.depth)
 
 	switch child := n.children[nChild].(type) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -249,10 +249,8 @@ func TestCopy(t *testing.T) {
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.ComputeCommitment()
 
 	copied := tree.Copy()
-	copied.(*InternalNode).clearCache()
 
 	got1 := copied.ComputeCommitment().Bytes()
 	got2 := tree.ComputeCommitment().Bytes()
@@ -295,28 +293,6 @@ func TestCachedCommitment(t *testing.T) {
 	}
 	if tree.(*InternalNode).children[1].(*InternalNode).commitment == nil {
 		t.Error("internal node has mistakenly cleared cached commitment")
-	}
-}
-
-func TestClearCache(t *testing.T) {
-	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
-	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
-	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
-	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.ComputeCommitment()
-
-	root := tree.(*InternalNode)
-	root.clearCache()
-
-	if root.commitment != nil {
-		t.Error("root cached commitment should have been cleared")
-	}
-
-	if root.children[1].(*InternalNode).commitment != nil {
-		t.Error("internal child's cached commitment should have been cleared")
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -935,11 +935,7 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	leaf := &LeafNode{
-		stem:      fourtyKeyTest[:31],
-		values:    values,
-		committer: root1.(*InternalNode).committer,
-	}
+	leaf := NewLeafNode(fourtyKeyTest[:31], values)
 	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], leaf, nil, false)
 	r1c := root1.ComputeCommitment()
 
@@ -1029,21 +1025,12 @@ func TestInsertStemOrdered(t *testing.T) {
 	var keysplit [32]byte // a key to check stem splitting in insert
 	copy(keysplit[:], fourtyKeyTest)
 	keysplit[24] = 72
-	leaf1 := &LeafNode{
-		stem:      fourtyKeyTest[:31],
-		values:    values1,
-		committer: root1.(*InternalNode).committer,
-	}
-	leaf2 := &LeafNode{
-		stem:      keysplit[:31],
-		values:    values2,
-		committer: root1.(*InternalNode).committer,
-	}
-	leaf3 := &LeafNode{
-		stem:      ffx32KeyTest[:31],
-		values:    values3,
-		committer: root1.(*InternalNode).committer,
-	}
+	leaf1 := NewLeafNode(fourtyKeyTest[:31], make([][]byte, NodeWidth))
+	leaf1.updateMultipleLeaves(values1)
+	leaf2 := NewLeafNode(keysplit[:31], make([][]byte, NodeWidth))
+	leaf2.updateMultipleLeaves(values2)
+	leaf3 := NewLeafNode(ffx32KeyTest[:31], make([][]byte, NodeWidth))
+	leaf3.updateMultipleLeaves(values3)
 	root1.(*InternalNode).Insert(zeroKeyTest, ffx32KeyTest, nil)
 	root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], leaf1, flush)
 	root1.(*InternalNode).InsertStemOrdered(keysplit[:31], leaf2, flush)


### PR DESCRIPTION
This PR is the first step in implementing batch inserts. It cleans up the API by separating the commitment getter from the function compuring it (code sold separately).

**TODO**

 - [ ] Rewrite `InsertStemOrdered` to support diff-insert, so it no longer relies on `ComputeCommitment` to get its value