### PR TITLE
revert diff-update in insertordered + add non-update insert

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -29,7 +29,11 @@ import "errors"
 
 type Empty struct{}
 
-func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
+func (n Empty) Insert(k []byte, v []byte, r NodeResolverFn) error {
+	return n.insert(k, v, r, true)
+}
+
+func (Empty) insert([]byte, []byte, NodeResolverFn, bool) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -39,6 +39,10 @@ func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
+func (*HashedNode) insert([]byte, []byte, NodeResolverFn, bool) error {
+	return errInsertIntoHash
+}
+
 func (*HashedNode) InsertOrdered([]byte, []byte, NodeFlushFn) error {
 	return errInsertIntoHash
 }

--- a/stateless.go
+++ b/stateless.go
@@ -178,6 +178,14 @@ func (n *StatelessNode) updateLeaf(index byte, value []byte) {
 }
 
 func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
+	return n.insert(key, value, resolver, true)
+}
+
+func (n *StatelessNode) insert(key []byte, value []byte, resolver NodeResolverFn, updateC bool) error {
+	if !updateC {
+		return errors.New("not updating a ")
+	}
+
 	// if this is a leaf value and the stems are different, intermediate
 	// nodes need to be inserted.
 	if n.values != nil {

--- a/tree.go
+++ b/tree.go
@@ -1008,7 +1008,7 @@ func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 	return n.insert(k, value, nil, true)
 }
 
-func (n *LeafNode) insert(k []byte, v []byte, r NodeResolverFn, update bool) error {
+func (n *LeafNode) insert(k []byte, v []byte, _ NodeResolverFn, update bool) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
 		return errInsertIntoOtherStem


### PR DESCRIPTION
This PR:

 1, Reverts the changes that made `InsetOrdered` to update its commitments on insert, as they made no sense: `InsertOrdered` is meant to be used in the conversion process, and updating the commitment at each insert will cause more computations than necessary, especially in the upper nodes;
 2. Introduces a new `InsertNoCommUpdate` method on `InternalNode`, that has the same behavior as `Insert` before the update-on-insert PR was merged.

The goal of this PR is to speed up conversion, it should not affect performance of the block replay process.

I am not yet sure that this PR will be merged, as I am considering a more thorough rewrite of the API: set the update behavior at node creation time, remove `InsertNoCommUpdate`, and keep a list of touched values so that only these are recomputed by `Commit`, as called by `IntermediateRoot`.