### PR TITLE
copy-on-write commitments, take 1

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -29,7 +29,11 @@ import "errors"
 
 type Empty struct{}
 
-func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
+func (n Empty) Insert(k []byte, v []byte, r NodeResolverFn) error {
+	return n.insert(k, v, r, true)
+}
+
+func (Empty) insert([]byte, []byte, NodeResolverFn, bool) error {
 	return errors.New("an empty node should not be inserted directly into")
 }
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -39,6 +39,10 @@ func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
+func (*HashedNode) insert([]byte, []byte, NodeResolverFn, bool) error {
+	return errInsertIntoHash
+}
+
 func (*HashedNode) InsertOrdered([]byte, []byte, NodeFlushFn) error {
 	return errInsertIntoHash
 }

--- a/stateless.go
+++ b/stateless.go
@@ -178,6 +178,14 @@ func (n *StatelessNode) updateLeaf(index byte, value []byte) {
 }
 
 func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
+	return n.insert(key, value, resolver, true)
+}
+
+func (n *StatelessNode) insert(key []byte, value []byte, resolver NodeResolverFn, updateC bool) error {
+	if !updateC {
+		return errors.New("not updating a ")
+	}
+
 	// if this is a leaf value and the stems are different, intermediate
 	// nodes need to be inserted.
 	if n.values != nil {

--- a/tree.go
+++ b/tree.go
@@ -808,6 +808,7 @@ func (n *InternalNode) Commit() *Point {
 		toFr(&poly[idx], n.children[idx].Commit())
 		poly[idx].Sub(&poly[idx], &pre)
 	}
+	n.cow = nil
 
 	// Add the evaluated diff-polynomial to the current commitment
 	// in order to update it.
@@ -1173,6 +1174,7 @@ func (n *LeafNode) Commit() *Point {
 			leafToComms(c2poly[byte((idx-128)<<1):], val)
 		}
 	}
+	n.cow = nil
 
 	n.c1.Add(n.c1, n.committer.CommitToPoly(c1poly[:], NodeWidth))
 	n.c2.Add(n.c2, n.committer.CommitToPoly(c2poly[:], NodeWidth))

--- a/tree.go
+++ b/tree.go
@@ -1008,7 +1008,7 @@ func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
 	return n.insert(k, value, nil, true)
 }
 
-func (n *LeafNode) insert(k []byte, v []byte, r NodeResolverFn, update bool) error {
+func (n *LeafNode) insert(k []byte, v []byte, _ NodeResolverFn, update bool) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
 		return errInsertIntoOtherStem

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -181,8 +181,14 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 		srs                 = cfg.conf.SRSPrecompPoints.SRS
 	)
 	key_b, _ := hex.DecodeString("0101010101010101010101010101010101010101010101010101010101010101")
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(key_b, key_b, nil)
+	err := root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = root.Insert(key_b, key_b, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	comm := root.Commit()
 	fmt.Println(root.toDot("", ""))
 
@@ -199,8 +205,12 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 		t.Fatal("commitment is identity")
 	}
 
+	if !expectedP.IsOnCurve() {
+		t.Fatalf("commitment %x isn't on curve", expectedP.Bytes())
+	}
+
 	if !Equal(comm, &expectedP) {
-		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
+		t.Fatalf("invalid root commitment %x != %x", comm.Bytes(), expected.Bytes())
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -201,6 +201,8 @@ func TestInsertVsOrdered(t *testing.T) {
 	h1 := root1.Commit().Bytes()
 
 	if !bytes.Equal(h1[:], h2[:]) {
+		t.Logf(root1.toDot("", ""))
+		t.Logf(root2.toDot("", ""))
 		t.Errorf("Insert and InsertOrdered produce different trees %x != %x", h1, h2)
 	}
 }
@@ -1218,39 +1220,5 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 
 	if !VerifyVerkleProof(dproof, pe.Cis, pe.Zis, pe.Yis, cfg) {
 		t.Fatal("deserialized proof didn't verify")
-	}
-}
-
-func TestInsertNoCommUpdateTwoLeaves(t *testing.T) {
-	root := New().(*InternalNode)
-	root.InsertNoCommUpdate(zeroKeyTest, testValue, nil)
-	root.InsertNoCommUpdate(ffx32KeyTest, testValue, nil)
-
-	leaf0, ok := root.children[0].(*LeafNode)
-	if !ok {
-		t.Fatalf("invalid leaf node type %v", root.children[0])
-	}
-
-	leaff, ok := root.children[255].(*LeafNode)
-	if !ok {
-		t.Fatalf("invalid leaf node type %v", root.children[255])
-	}
-
-	if !bytes.Equal(leaf0.values[zeroKeyTest[31]], testValue) {
-		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf0.values[zeroKeyTest[31]])
-	}
-
-	if !bytes.Equal(leaff.values[255], testValue) {
-		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaff.values[ffx32KeyTest[31]])
-	}
-
-	if root.commitment != nil {
-		t.Fatalf("non-nil commitment %x", root.commitment.Bytes())
-	}
-
-	root.Commit()
-
-	if root.commitment == nil {
-		t.Fatal("commitment is still nil")
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -201,8 +201,7 @@ func TestInsertVsOrdered(t *testing.T) {
 	h1 := root1.Commit().Bytes()
 
 	if !bytes.Equal(h1[:], h2[:]) {
-		t.Logf(root1.toDot("", ""))
-		t.Logf(root2.toDot("", ""))
+		t.Logf("%s != %s", ToDot(root1), ToDot(root2))
 		t.Errorf("Insert and InsertOrdered produce different trees %x != %x", h1, h2)
 	}
 }
@@ -288,6 +287,7 @@ func TestCachedCommitment(t *testing.T) {
 	}
 
 	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Commit()
 
 	if tree.(*InternalNode).Commitment().Bytes() == oldRoot {
 		t.Error("root has stale commitment")
@@ -415,7 +415,7 @@ func TestDeleteHash(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
+	tree.InsertOrdered(key1, fourtyKeyTest, nil)
 	tree.InsertOrdered(key2, fourtyKeyTest, nil)
 	tree.InsertOrdered(key3, fourtyKeyTest, nil)
 	tree.Commit()
@@ -848,7 +848,7 @@ func TestInsertIntoHashedNode(t *testing.T) {
 
 func TestToDot(*testing.T) {
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	root.InsertOrdered(zeroKeyTest, zeroKeyTest, nil)
 	root.InsertOrdered(fourtyKeyTest, zeroKeyTest, nil)
 	root.Commit()
 	fourtytwoKeyTest, _ := hex.DecodeString("4020000000000000000000000000000000000000000000000000000000000000")
@@ -1072,7 +1072,7 @@ func TestInsertStemOrdered(t *testing.T) {
 		values:    values3,
 		committer: root1.(*InternalNode).committer,
 	}
-	root1.(*InternalNode).Insert(zeroKeyTest, ffx32KeyTest, nil)
+	root1.(*InternalNode).InsertOrdered(zeroKeyTest, ffx32KeyTest, nil)
 	root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], leaf1, flush)
 	root1.(*InternalNode).InsertStemOrdered(keysplit[:31], leaf2, flush)
 	root1.(*InternalNode).InsertStemOrdered(ffx32KeyTest[:31], leaf3, flush)


### PR DESCRIPTION
This is a first attempt at creating copy-on-write commitments, so that only the contribution for the values that were created are recomputed. This PR has a few issues, and will probably be rewritten and broken down into smaller pieces.