### PR TITLE
merge Insert and InsertStem, diff updates no more

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -29,8 +29,10 @@ import "errors"
 
 type Empty struct{}
 
+var errDirectInsertIntoEmptyNode = errors.New("an empty node should not be inserted directly into")
+
 func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
-	return errors.New("an empty node should not be inserted directly into")
+	return errDirectInsertIntoEmptyNode
 }
 
 func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {

--- a/stateless.go
+++ b/stateless.go
@@ -305,6 +305,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 					newbranch.children[inserted] = lastnode
 					newbranch.children[inserted].setDepth(child.depth + 1)
 					lastnode.Insert(key, value, nil)
+					lastnode.Commit()
 					var lnComm Fr
 					var diff Point
 					toFr(&lnComm, lastnode.Commitment())
@@ -315,6 +316,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 				}
 			} else {
 				err = child.Insert(key, value, resolver)
+				child.Commit()
 			}
 		default:
 			err = errNotSupportedInStateless
@@ -410,8 +412,8 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 	var err error
 	switch child := n.children[nChild].(type) {
 	case *InternalNode:
-		leaf := NewLeafNode(stem, values)
-		err = child.InsertStem(stem, leaf, resolver, true)
+		err = child.InsertStem(stem, values, resolver)
+		child.Commit()
 	case *StatelessNode:
 		err = child.InsertAtStem(stem, values, resolver, false)
 	case *LeafNode:
@@ -456,6 +458,7 @@ func (n *StatelessNode) newLeafChildFromSingleValue(key, value []byte) *LeafNode
 	newchild := NewLeafNode(key[:31], make([][]byte, NodeWidth))
 	newchild.setDepth(n.depth + 1)
 	newchild.Insert(key, value, nil)
+	newchild.Commit()
 	return newchild
 }
 

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -107,20 +107,22 @@ func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 
 	rootRef := New().(*InternalNode)
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	rootRef.Commit()
 
 	if !Equal(rootRef.commitment, root.commitment) {
-		t.Fatalf("hashes differ after insertion %v %v", rootRef.commitment, root.commitment)
+		t.Fatalf("hashes differ after insertion %x %x", rootRef.commitment.Bytes(), root.commitment.Bytes())
 	}
 
 	// Overwrite one leaf and check that the update
 	// is what is expected.
 	rootRef = New().(*InternalNode)
 	rootRef.Insert(zeroKeyTest, oneKeyTest, nil)
+	rootRef.Commit()
 
 	root.Insert(zeroKeyTest, oneKeyTest, nil)
 
 	if !Equal(rootRef.commitment, root.commitment) {
-		t.Fatalf("hashes differ after update %v %v", rootRef.commitment, root.commitment)
+		t.Fatalf("hashes differ after update %x %x", rootRef.commitment.Bytes(), root.commitment.Bytes())
 	}
 }
 
@@ -158,6 +160,7 @@ func TestStatelessInsertLeafIntoInternal(t *testing.T) {
 	rootRef := New().(*InternalNode)
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	rootRef.Insert(key1, fourtyKeyTest, nil)
+	rootRef.Commit()
 
 	if !Equal(rootRef.commitment, root.commitment) {
 		t.Fatalf("hashes differ after insertion %v %v", rootRef.commitment, root.commitment)
@@ -245,7 +248,7 @@ func TestStatelessToDot(t *testing.T) {
 	stlJ := strings.Join(stl, "\n")
 
 	if stfJ != stlJ {
-		t.Fatalf("hashes differ after insertion %v ||| %v", stf, stl)
+		t.Fatalf("hashes differ after insertion %v ||| %v %s %s", stf, stl, ToDot(rootRef), ToDot(root))
 	}
 }
 
@@ -614,6 +617,7 @@ func TestSerialization(t *testing.T) {
 
 	rootf.Insert(zeroKeyTest, ffx32KeyTest, nil)
 	roots.Insert(zeroKeyTest, ffx32KeyTest, nil)
+	rootf.Commit()
 
 	serf, _ := rootf.Serialize()
 	sers, _ := roots.Serialize()

--- a/tree_test.go
+++ b/tree_test.go
@@ -286,6 +286,7 @@ func TestCachedCommitment(t *testing.T) {
 	}
 
 	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Commit()
 
 	if tree.(*InternalNode).Commitment().Bytes() == oldRoot {
 		t.Error("root has stale commitment")
@@ -959,12 +960,7 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	leaf := &LeafNode{
-		stem:      fourtyKeyTest[:31],
-		values:    values,
-		committer: root1.(*InternalNode).committer,
-	}
-	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], leaf, nil, false)
+	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil)
 	r1c := root1.Commit()
 
 	var key5, key192 [32]byte


### PR DESCRIPTION
Even though diff-inserts ended up saving a lot of unnecessary computation, the codebase has reached a point in which, in order to further reduce the amount of computation, these changes needs to be reverted.

To go further, commitments should only be updated at the end of the block execution, to reduce the amount of calculation in the upper nodes, and for the data leaves for which multiple values are inserted one by one. (see #270)

Since the amount of work required is quite huge, this PR documents the first step along the way to achieve this goal: it merges `Insert` and `InsertStem` in the case of a stateful tree, and forces them not to update their commitment on insert, while leaving diff-updates enabled in `StatelessNode` and `InsertOrdered`.