### PR TITLE
revert diff-update InsertOrdered on top of the Insert[Stem] merge

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -851,7 +851,7 @@ func TestToDot(*testing.T) {
 	fourtytwoKeyTest, _ := hex.DecodeString("4020000000000000000000000000000000000000000000000000000000000000")
 	root.Insert(fourtytwoKeyTest, zeroKeyTest, nil)
 
-	fmt.Println(root.toDot("", ""))
+	fmt.Println(ToDot(root))
 }
 
 func TestEmptyCommitment(t *testing.T) {


### PR DESCRIPTION
Second step on the path to #270, revert the diff update for `InsertOrdered`. Supersedes #279 if merged.