### PR TITLE
use cow in insert[stem]

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -38,12 +38,13 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 	root.Insert(zeroKeyTest, zeroKeyTest, nil)
 	root.Insert(oneKeyTest, zeroKeyTest, nil)
 	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Commit()
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{string(ffx32KeyTest): zeroKeyTest})
 
 	cfg, _ := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
-		t.Fatal("could not verify verkle proof")
+		t.Fatalf("could not verify verkle proof: %s", ToDot(root))
 	}
 }
 

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -94,6 +94,7 @@ func TestStatelessDelete(t *testing.T) {
 	rootRef := New()
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+	rootRef.Commit()
 	rootRef.Delete(oneKeyTest, nil)
 
 	if !Equal(rootRef.Commit(), root.commitment) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -328,7 +328,8 @@ func TestDelLeaf(t *testing.T) {
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
-	hash := tree.Commit()
+	var init Point
+	CopyPoint(&init, tree.Commit())
 
 	tree.Insert(key3, fourtyKeyTest, nil)
 	if err := tree.Delete(key3, nil); err != nil {
@@ -339,8 +340,8 @@ func TestDelLeaf(t *testing.T) {
 	// as deleting a value means replacing it with a 0 in verkle
 	// trees.
 	postHash := tree.Commit()
-	if Equal(hash, postHash) {
-		t.Error("deleting leaf resulted in unexpected tree")
+	if Equal(&init, postHash) {
+		t.Errorf("deleting leaf resulted in unexpected tree %x %x", init.Bytes(), postHash.Bytes())
 	}
 
 	res, err := tree.Get(key3, nil)
@@ -373,16 +374,18 @@ func TestDeletePrune(t *testing.T) {
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 
-	hash1 := tree.Commit()
+	var hash1, hash2 Point
+	CopyPoint(&hash1, tree.Commit())
 	tree.Insert(key3, fourtyKeyTest, nil)
-	hash2 := tree.Commit()
+	CopyPoint(&hash2, tree.Commit())
 	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Commit()
 
 	if err := tree.Delete(key4, nil); err != nil {
 		t.Error(err)
 	}
 	postHash := tree.Commit()
-	if Equal(hash2, postHash) {
+	if Equal(&hash2, postHash) {
 		t.Error("deleting leaf #4 resulted in unexpected tree")
 	}
 	res, err := tree.Get(key4, nil)
@@ -397,7 +400,7 @@ func TestDeletePrune(t *testing.T) {
 		t.Error(err)
 	}
 	postHash = tree.Commit()
-	if Equal(hash1, postHash) {
+	if Equal(&hash1, postHash) {
 		t.Error("deleting leaf #3 resulted in unexpected tree")
 	}
 	res, err = tree.Get(key3, nil)


### PR DESCRIPTION
One more step towards #270: `InsertStem` and `Insert` use copy-on-write to speed-up commitment calculations. This is also true of `InsertOrdered`.

`InsertStemOrdered`, however, does not - it should be merged with `InsertOrdered` if possible.

Note this only affects `InternalNode`. `StatelessNode` and `LeafNode` still update their commitments on insert.