### PR TITLE
fix: don't compute leaf commitment in LeafNode.Commit

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -238,10 +238,19 @@ func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
 
 	// Initialize the commitment with the extension tree
 	// marker and the stem.
-	var poly [256]Fr
+	count := 0
+	var poly, c1poly, c2poly [256]Fr
 	poly[0].SetUint64(1)
 	StemFromBytes(&poly[1], leaf.stem)
-	leaf.commitment = leaf.committer.CommitToPoly(poly[:], 2)
+
+	count = fillSuffixTreePoly(c1poly[:], values[:128])
+	leaf.c1 = leaf.committer.CommitToPoly(c1poly[:], 256-count)
+	toFr(&poly[2], leaf.c1)
+	count = fillSuffixTreePoly(c2poly[:], values[128:])
+	leaf.c2 = leaf.committer.CommitToPoly(c2poly[:], 256-count)
+	toFr(&poly[3], leaf.c2)
+
+	leaf.commitment = leaf.committer.CommitToPoly(poly[:], 252)
 
 	return leaf
 }
@@ -921,19 +930,6 @@ func (n *LeafNode) Commitment() *Point {
 }
 
 func (n *LeafNode) Commit() *Point {
-	count := 0
-	var poly, c1poly, c2poly [256]Fr
-	poly[0].SetUint64(1)
-	StemFromBytes(&poly[1], n.stem)
-
-	count = fillSuffixTreePoly(c1poly[:], n.values[:128])
-	n.c1 = n.committer.CommitToPoly(c1poly[:], 256-count)
-	toFr(&poly[2], n.c1)
-	count = fillSuffixTreePoly(c2poly[:], n.values[128:])
-	n.c2 = n.committer.CommitToPoly(c2poly[:], 256-count)
-	toFr(&poly[3], n.c2)
-
-	n.commitment = n.committer.CommitToPoly(poly[:], 252)
 	return n.commitment
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -295,28 +295,6 @@ func TestCachedCommitment(t *testing.T) {
 	}
 }
 
-func TestClearCache(t *testing.T) {
-	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
-	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
-	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
-	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.Commit()
-
-	root := tree.(*InternalNode)
-	root.clearCache()
-
-	if root.commitment != nil {
-		t.Error("root cached commitment should have been cleared")
-	}
-
-	if root.children[1].(*InternalNode).commitment != nil {
-		t.Error("internal child's cached commitment should have been cleared")
-	}
-}
-
 func TestDelLeaf(t *testing.T) {
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
@@ -972,7 +950,7 @@ func TestInsertStem(t *testing.T) {
 	r2c := root2.Commit()
 
 	if !Equal(r1c, r2c) {
-		t.Fatalf("differing commitments %x != %x", r1c.Bytes(), r2c.Bytes())
+		t.Fatalf("differing commitments %x != %x %s %s", r1c.Bytes(), r2c.Bytes(), ToDot(root1), ToDot(root2))
 	}
 }
 


### PR DESCRIPTION
`LeafNode.Commit` was recomputing the commitment each time it was called, which anihilated the benefits from the CoW approach in `StatelessNode`. This PR computes the commitment upon leaf creation, and subsequent inserts are diff-inserted.

TODO: check that there is a test for subsequent diff-inserts