### PR TITLE
use SetBytesTrusted in CopyPoint

### DIFF
--- a/ipa.go
+++ b/ipa.go
@@ -39,7 +39,7 @@ func CopyFr(dst, src *Fr) {
 
 func CopyPoint(dst, src *Point) {
 	bytes := src.Bytes()
-	dst.SetBytes(bytes[:])
+	dst.SetBytesTrusted(bytes[:])
 }
 
 func toFr(fr *Fr, p *Point) {


### PR DESCRIPTION
`CopyPoint` takes its data from `Bytes` and then use these bytes to initialize another point.

This is very inefficient and takes a lot of execution time (9%).

By calling `SetTrustedBytes` instead, it shaves 30% of the execution time of that function, and almost 3% of the execution time.

