### PR TITLE
serialize LeafNode's commitments to get a cheaper deserialization

### DIFF
--- a/config_ipa.go
+++ b/config_ipa.go
@@ -27,7 +27,7 @@ package verkle
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/crate-crypto/go-ipa/ipa"
 )
@@ -50,12 +50,12 @@ const precompFileName = "precomp"
 func GetConfig() (*Config, error) {
 	if cfg == nil {
 		var ipacfg *ipa.IPAConfig
-		if precompSer, err := ioutil.ReadFile(precompFileName); err != nil {
+		if precompSer, err := os.ReadFile(precompFileName); err != nil {
 			ipacfg = ipa.NewIPASettings()
 			serialized, err := ipacfg.SRSPrecompPoints.SerializeSRSPrecomp()
 			if err != nil {
 				return nil, fmt.Errorf("error writing serialized precomputed Lagrange points: %w", err)
-			} else if err = ioutil.WriteFile(precompFileName, serialized, 0555); err != nil {
+			} else if err = os.WriteFile(precompFileName, serialized, 0555); err != nil {
 				return nil, fmt.Errorf("error saving the precomp: %w", err)
 			}
 		} else {

--- a/doc.go
+++ b/doc.go
@@ -36,8 +36,6 @@ var (
 	errNotSupportedInStateless = errors.New("not implemented in stateless")
 	errInsertIntoOtherStem     = errors.New("insert splits a stem where it should not happen")
 	errStatelessAndStatefulMix = errors.New("a stateless node should not be found in a stateful tree")
-	errUnknownNodeType         = errors.New("unknown node type")
-	errLeafOverwrite           = errors.New("leaf overwrite disallowed")
 )
 
 const (

--- a/empty.go
+++ b/empty.go
@@ -29,8 +29,10 @@ import "errors"
 
 type Empty struct{}
 
+var errDirectInsertIntoEmptyNode = errors.New("an empty node should not be inserted directly into")
+
 func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
-	return errors.New("an empty node should not be inserted directly into")
+	return errDirectInsertIntoEmptyNode
 }
 
 func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {

--- a/encoding.go
+++ b/encoding.go
@@ -51,7 +51,7 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 	switch serialized[0] {
 	case leafRLPType:
 		var values [NodeWidth][]byte
-		offset := 64
+		offset := 128
 		for i := 0; i < NodeWidth; i++ {
 			if bit(serialized[32:64], i) {
 				if offset+32 > len(serialized) {
@@ -64,9 +64,14 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 		if NodeWidth != len(values) {
 			return nil, fmt.Errorf("invalid number of nodes in decoded child expected %d, got %d", NodeWidth, len(values))
 		}
-		ln := NewLeafNode(serialized[1:32], values[:])
+		ln := NewLeafNodeWithNoComms(serialized[1:32], values[:])
 		ln.setDepth(depth)
-		ln.Commit()
+		ln.c1 = new(Point)
+		ln.c1.SetBytesTrusted(serialized[64:96])
+		ln.c2 = new(Point)
+		ln.c2.SetBytesTrusted(serialized[96:128])
+		ln.commitment = new(Point)
+		ln.commitment.SetBytesTrusted(comm)
 		return ln, nil
 	case internalRLPType:
 		return deserializeIntoStateless(serialized[1:33], serialized[33:], depth, comm)

--- a/proof_test.go
+++ b/proof_test.go
@@ -38,12 +38,13 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 	root.Insert(zeroKeyTest, zeroKeyTest, nil)
 	root.Insert(oneKeyTest, zeroKeyTest, nil)
 	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Commit()
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{string(ffx32KeyTest): zeroKeyTest})
 
 	cfg, _ := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
-		t.Fatal("could not verify verkle proof")
+		t.Fatalf("could not verify verkle proof: %s", ToDot(root))
 	}
 }
 

--- a/stateless.go
+++ b/stateless.go
@@ -169,17 +169,17 @@ func (n *StatelessNode) updateCn(index byte, value []byte, c *Point) {
 	c.Add(c, &diff)
 }
 
-func (n *StatelessNode) updateLeaf(index byte, value []byte) {
-	c, oldc := n.getOldCn(index)
-	n.updateCn(index, value, c)
-	n.updateC(index, c, oldc)
-	if n.values[index] == nil {
-		// only increase the count if no value is
-		// overwritten.
-		n.count++
-	}
-	n.values[index] = value
-}
+// func (n *StatelessNode) updateLeaf(index byte, value []byte) {
+// 	c, oldc := n.getOldCn(index)
+// 	n.updateCn(index, value, c)
+// 	n.updateC(index, c, oldc)
+// 	if n.values[index] == nil {
+// 		// only increase the count if no value is
+// 		// overwritten.
+// 		n.count++
+// 	}
+// 	n.values[index] = value
+// }
 
 func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
 	values := make([][]byte, NodeWidth)
@@ -320,14 +320,6 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 	}
 
 	return err
-}
-
-func (n *StatelessNode) newLeafChildFromSingleValue(key, value []byte) *LeafNode {
-	newchild := NewLeafNode(key[:31], make([][]byte, NodeWidth))
-	newchild.setDepth(n.depth + 1)
-	newchild.Insert(key, value, nil)
-	newchild.Commit()
-	return newchild
 }
 
 func (n *StatelessNode) newLeafChildFromMultipleValues(stem []byte, values [][]byte) *LeafNode {

--- a/stateless.go
+++ b/stateless.go
@@ -305,6 +305,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 					newbranch.children[inserted] = lastnode
 					newbranch.children[inserted].setDepth(child.depth + 1)
 					lastnode.Insert(key, value, nil)
+					lastnode.Commit()
 					var lnComm Fr
 					var diff Point
 					toFr(&lnComm, lastnode.Commitment())
@@ -315,6 +316,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 				}
 			} else {
 				err = child.Insert(key, value, resolver)
+				child.Commit()
 			}
 		default:
 			err = errNotSupportedInStateless
@@ -410,8 +412,8 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 	var err error
 	switch child := n.children[nChild].(type) {
 	case *InternalNode:
-		leaf := NewLeafNode(stem, values)
-		err = child.InsertStem(stem, leaf, resolver, true)
+		err = child.InsertStem(stem, values, resolver)
+		child.Commit()
 	case *StatelessNode:
 		err = child.InsertAtStem(stem, values, resolver, false)
 	case *LeafNode:
@@ -456,6 +458,7 @@ func (n *StatelessNode) newLeafChildFromSingleValue(key, value []byte) *LeafNode
 	newchild := NewLeafNode(key[:31], make([][]byte, NodeWidth))
 	newchild.setDepth(n.depth + 1)
 	newchild.Insert(key, value, nil)
+	newchild.Commit()
 	return newchild
 }
 

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -94,6 +94,7 @@ func TestStatelessDelete(t *testing.T) {
 	rootRef := New()
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	rootRef.Insert(oneKeyTest, fourtyKeyTest, nil)
+	rootRef.Commit()
 	rootRef.Delete(oneKeyTest, nil)
 
 	if !Equal(rootRef.Commit(), root.commitment) {

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -64,6 +64,8 @@ func TestStatelessChildren(t *testing.T) {
 		t.Fatal("didn't catch a node being inserted at an invalid index in a stateless node")
 	}
 
+	// Adds a node that isn't in the tree, but since its commitmenht will be 0,
+	// it shouldn't have an impact.
 	if err := root.SetChild(3, &StatelessNode{}); err != nil {
 		t.Fatal("error inserting stateless node")
 	}
@@ -74,7 +76,7 @@ func TestStatelessChildren(t *testing.T) {
 	rootRef.Insert(c2key, fourtyKeyTest, nil)
 
 	if !Equal(rootRef.Commit(), root.commitment) {
-		t.Fatalf("differing state(less|ful) roots %x != %x", rootRef.Commitment().Bytes(), root.Commit().Bytes())
+		t.Fatalf("differing state(less|ful) roots %x != %x %s %s", rootRef.Commitment().Bytes(), root.Commit().Bytes(), ToDot(rootRef), ToDot(root))
 	}
 }
 
@@ -432,7 +434,7 @@ func TestStatelessGetProofItems(t *testing.T) {
 	}
 }
 
-// This test check that node resolution works for StatelessNode
+// This test checks that node resolution works for StatelessNode
 func TestStatelessInsertIntoHash(t *testing.T) {
 	root := NewStateless()
 	root.Insert(fourtyKeyTest, ffx32KeyTest, nil)
@@ -506,7 +508,8 @@ func TestStatelessInsertIntoSerialized(t *testing.T) {
 
 func TestStatelessInsertAtStem(t *testing.T) {
 	root := NewStateless()
-	root.InsertAtStem(zeroKeyTest[:31], [][]byte{ffx32KeyTest, fourtyKeyTest, zeroKeyTest, oneKeyTest}, nil, false)
+	values := [256][]byte{ffx32KeyTest, fourtyKeyTest, zeroKeyTest, oneKeyTest}
+	root.InsertAtStem(zeroKeyTest[:31], values[:], nil, false)
 
 	out, err := root.Get(zeroKeyTest, nil)
 	if err != nil {
@@ -576,13 +579,14 @@ func TestStatelessInsertAtStemIntoLeaf(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	values := [256][]byte{nil, ffx32KeyTest, nil, nil, oneKeyTest}
 	// test updating an existing key
-	root.(*StatelessNode).InsertAtStem(zeroKeyTest[:31], [][]byte{nil, ffx32KeyTest, nil, nil, oneKeyTest}, func(b []byte) ([]byte, error) {
+	root.(*StatelessNode).InsertAtStem(zeroKeyTest[:31], values[:], func(b []byte) ([]byte, error) {
 		return flushed[string(b)], nil
 	}, false)
 
 	// test inserting a new key
-	root.(*StatelessNode).InsertAtStem(splitKeyTest[:31], [][]byte{nil, ffx32KeyTest, nil, nil, oneKeyTest}, func(b []byte) ([]byte, error) {
+	root.(*StatelessNode).InsertAtStem(splitKeyTest[:31], values[:], func(b []byte) ([]byte, error) {
 		return flushed[string(b)], nil
 	}, false)
 

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -107,20 +107,22 @@ func TestStatelessInsertLeafIntoRoot(t *testing.T) {
 
 	rootRef := New().(*InternalNode)
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
+	rootRef.Commit()
 
 	if !Equal(rootRef.commitment, root.commitment) {
-		t.Fatalf("hashes differ after insertion %v %v", rootRef.commitment, root.commitment)
+		t.Fatalf("hashes differ after insertion %x %x", rootRef.commitment.Bytes(), root.commitment.Bytes())
 	}
 
 	// Overwrite one leaf and check that the update
 	// is what is expected.
 	rootRef = New().(*InternalNode)
 	rootRef.Insert(zeroKeyTest, oneKeyTest, nil)
+	rootRef.Commit()
 
 	root.Insert(zeroKeyTest, oneKeyTest, nil)
 
 	if !Equal(rootRef.commitment, root.commitment) {
-		t.Fatalf("hashes differ after update %v %v", rootRef.commitment, root.commitment)
+		t.Fatalf("hashes differ after update %x %x", rootRef.commitment.Bytes(), root.commitment.Bytes())
 	}
 }
 
@@ -158,6 +160,7 @@ func TestStatelessInsertLeafIntoInternal(t *testing.T) {
 	rootRef := New().(*InternalNode)
 	rootRef.Insert(zeroKeyTest, fourtyKeyTest, nil)
 	rootRef.Insert(key1, fourtyKeyTest, nil)
+	rootRef.Commit()
 
 	if !Equal(rootRef.commitment, root.commitment) {
 		t.Fatalf("hashes differ after insertion %v %v", rootRef.commitment, root.commitment)
@@ -245,7 +248,7 @@ func TestStatelessToDot(t *testing.T) {
 	stlJ := strings.Join(stl, "\n")
 
 	if stfJ != stlJ {
-		t.Fatalf("hashes differ after insertion %v ||| %v", stf, stl)
+		t.Fatalf("hashes differ after insertion %v ||| %v %s %s", stf, stl, ToDot(rootRef), ToDot(root))
 	}
 }
 
@@ -614,6 +617,7 @@ func TestSerialization(t *testing.T) {
 
 	rootf.Insert(zeroKeyTest, ffx32KeyTest, nil)
 	roots.Insert(zeroKeyTest, ffx32KeyTest, nil)
+	rootf.Commit()
 
 	serf, _ := rootf.Serialize()
 	sers, _ := roots.Serialize()

--- a/tree.go
+++ b/tree.go
@@ -205,18 +205,6 @@ func newInternalNode(depth byte, cmtr Committer) VerkleNode {
 	return node
 }
 
-func newInternalNodeNilCommitment(depth byte, cmtr Committer) VerkleNode {
-	node := new(InternalNode)
-	node.children = make([]VerkleNode, NodeWidth)
-	for idx := range node.children {
-		node.children[idx] = Empty(struct{}{})
-	}
-	node.depth = depth
-	node.committer = cmtr
-	node.commitment = nil
-	return node
-}
-
 // New creates a new tree root
 func New() VerkleNode {
 	cfg, _ := GetConfig()
@@ -871,7 +859,7 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 				n.updateCn(byte(i), v, c2)
 			}
 
-			n.values[i] = v[:]
+			n.values[i] = v
 		}
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -243,6 +243,20 @@ func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
 	return leaf
 }
 
+// NewLeafNodeWithNoComms create a leaf node but does compute its
+// commitments. The created node's commitments are intended to be
+// initialized with `SetTrustedBytes` in a deserialization context.
+func NewLeafNodeWithNoComms(stem []byte, values [][]byte) *LeafNode {
+	cfg, _ := GetConfig()
+	return &LeafNode{
+		committer: cfg,
+		// depth will be 0, but the commitment calculation
+		// does not need it, and so it won't be free.
+		values: values,
+		stem:   stem,
+	}
+}
+
 func (n *InternalNode) Children() []VerkleNode {
 	return n.children
 }
@@ -1117,7 +1131,9 @@ func (n *LeafNode) Serialize() ([]byte, error) {
 			}
 		}
 	}
-	return append(append(append([]byte{leafRLPType}, n.stem...), bitlist[:]...), children...), nil
+	c1bytes := n.c1.Bytes()
+	c2bytes := n.c2.Bytes()
+	return append(append(append(append(append([]byte{leafRLPType}, n.stem...), bitlist[:]...), c1bytes[:]...), c2bytes[:]...), children...), nil
 }
 
 func (n *LeafNode) Copy() VerkleNode {

--- a/tree_test.go
+++ b/tree_test.go
@@ -851,7 +851,7 @@ func TestToDot(*testing.T) {
 	fourtytwoKeyTest, _ := hex.DecodeString("4020000000000000000000000000000000000000000000000000000000000000")
 	root.Insert(fourtytwoKeyTest, zeroKeyTest, nil)
 
-	fmt.Println(root.toDot("", ""))
+	fmt.Println(ToDot(root))
 }
 
 func TestEmptyCommitment(t *testing.T) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -248,24 +248,20 @@ func TestCopy(t *testing.T) {
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.Commit()
 
 	copied := tree.Copy()
-	copied.(*InternalNode).clearCache()
 
-	got1 := copied.Commit().Bytes()
-	got2 := tree.Commit().Bytes()
-	if !bytes.Equal(got1[:], got2[:]) {
-		t.Fatalf("error copying commitments %x != %x", got1, got2)
+	tree.Insert(key3, fourtyKeyTest, nil)
+
+	if Equal(tree.Commit(), copied.Commit()) {
+		t.Fatal("inserting the copy into the original tree updated the copy's commitment")
 	}
-	tree.Insert(key2, oneKeyTest, nil)
-	tree.Commit()
-	got2 = tree.Commit().Bytes()
-	if bytes.Equal(got1[:], got2[:]) {
-		t1, _ := tree.Get(key2, nil)
-		t2, _ := copied.Get(key2, nil)
-		t.Fatalf("error tree and its copy should have a different commitment after the update: %x == %x %s %s", got1, got2, t1, t2)
+
+	copied.Insert(key3, fourtyKeyTest, nil)
+
+	if !Equal(tree.Commitment(), copied.Commit()) {
+		t.Fatalf("differing final commitments %x != %x", tree.Commitment().Bytes(), copied.Commitment().Bytes())
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1052,25 +1052,10 @@ func TestInsertStemOrdered(t *testing.T) {
 	var keysplit [32]byte // a key to check stem splitting in insert
 	copy(keysplit[:], fourtyKeyTest)
 	keysplit[24] = 72
-	leaf1 := &LeafNode{
-		stem:      fourtyKeyTest[:31],
-		values:    values1,
-		committer: root1.(*InternalNode).committer,
-	}
-	leaf2 := &LeafNode{
-		stem:      keysplit[:31],
-		values:    values2,
-		committer: root1.(*InternalNode).committer,
-	}
-	leaf3 := &LeafNode{
-		stem:      ffx32KeyTest[:31],
-		values:    values3,
-		committer: root1.(*InternalNode).committer,
-	}
 	root1.(*InternalNode).Insert(zeroKeyTest, ffx32KeyTest, nil)
-	root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], leaf1, flush)
-	root1.(*InternalNode).InsertStemOrdered(keysplit[:31], leaf2, flush)
-	root1.(*InternalNode).InsertStemOrdered(ffx32KeyTest[:31], leaf3, flush)
+	root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], values1, flush)
+	root1.(*InternalNode).InsertStemOrdered(keysplit[:31], values2, flush)
+	root1.(*InternalNode).InsertStemOrdered(ffx32KeyTest[:31], values3, flush)
 	r1c := root1.Commit()
 
 	// 26 for fourtyKeyTest + 2 children, 1 for zeroKeyTest,
@@ -1100,7 +1085,7 @@ func TestInsertStemOrdered(t *testing.T) {
 
 	// Check that a previous key was flushed and hashed, and that one can no
 	// longer insert in it.
-	err := root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], leaf1, nil)
+	err := root1.(*InternalNode).InsertStemOrdered(fourtyKeyTest[:31], values1, nil)
 	if err != errInsertIntoHash {
 		t.Fatalf("received wrong error %v != %v", err, errInsertIntoHash)
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -286,6 +286,7 @@ func TestCachedCommitment(t *testing.T) {
 	}
 
 	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Commit()
 
 	if tree.(*InternalNode).Commitment().Bytes() == oldRoot {
 		t.Error("root has stale commitment")
@@ -959,12 +960,7 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	leaf := &LeafNode{
-		stem:      fourtyKeyTest[:31],
-		values:    values,
-		committer: root1.(*InternalNode).committer,
-	}
-	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], leaf, nil, false)
+	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil)
 	r1c := root1.Commit()
 
 	var key5, key192 [32]byte

--- a/tree_test.go
+++ b/tree_test.go
@@ -295,28 +295,6 @@ func TestCachedCommitment(t *testing.T) {
 	}
 }
 
-func TestClearCache(t *testing.T) {
-	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
-	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
-	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
-	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.Commit()
-
-	root := tree.(*InternalNode)
-	root.clearCache()
-
-	if root.commitment != nil {
-		t.Error("root cached commitment should have been cleared")
-	}
-
-	if root.children[1].(*InternalNode).commitment != nil {
-		t.Error("internal child's cached commitment should have been cleared")
-	}
-}
-
 func TestDelLeaf(t *testing.T) {
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
@@ -972,7 +950,7 @@ func TestInsertStem(t *testing.T) {
 	r2c := root2.Commit()
 
 	if !Equal(r1c, r2c) {
-		t.Fatalf("differing commitments %x != %x", r1c.Bytes(), r2c.Bytes())
+		t.Fatalf("differing commitments %x != %x %s %s", r1c.Bytes(), r2c.Bytes(), ToDot(root1), ToDot(root2))
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -789,8 +789,9 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	}
 
 	resolver := func(h []byte) ([]byte, error) {
-		node := &LeafNode{stem: zeroKeyTest, values: make([][]byte, NodeWidth)}
-		node.values[0] = zeroKeyTest
+		values := make([][]byte, NodeWidth)
+		values[0] = zeroKeyTest
+		node := NewLeafNode(zeroKeyTest[:31], values)
 
 		return node.Serialize()
 	}
@@ -801,8 +802,9 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	// Check that the proper error is raised if the RLP data is invalid and the
 	// node can not be parsed.
 	invalidRLPResolver := func(h []byte) ([]byte, error) {
-		node := &LeafNode{stem: zeroKeyTest, values: make([][]byte, NodeWidth)}
-		node.values[0] = zeroKeyTest
+		values := make([][]byte, NodeWidth)
+		values[0] = zeroKeyTest
+		node := NewLeafNode(zeroKeyTest[:31], values)
 
 		rlp, _ := node.Serialize()
 		return rlp[:len(rlp)-10], nil

--- a/tree_test.go
+++ b/tree_test.go
@@ -328,7 +328,8 @@ func TestDelLeaf(t *testing.T) {
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
-	hash := tree.Commit()
+	var init Point
+	CopyPoint(&init, tree.Commit())
 
 	tree.Insert(key3, fourtyKeyTest, nil)
 	if err := tree.Delete(key3, nil); err != nil {
@@ -339,8 +340,8 @@ func TestDelLeaf(t *testing.T) {
 	// as deleting a value means replacing it with a 0 in verkle
 	// trees.
 	postHash := tree.Commit()
-	if Equal(hash, postHash) {
-		t.Error("deleting leaf resulted in unexpected tree")
+	if Equal(&init, postHash) {
+		t.Errorf("deleting leaf resulted in unexpected tree %x %x", init.Bytes(), postHash.Bytes())
 	}
 
 	res, err := tree.Get(key3, nil)
@@ -373,16 +374,18 @@ func TestDeletePrune(t *testing.T) {
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 
-	hash1 := tree.Commit()
+	var hash1, hash2 Point
+	CopyPoint(&hash1, tree.Commit())
 	tree.Insert(key3, fourtyKeyTest, nil)
-	hash2 := tree.Commit()
+	CopyPoint(&hash2, tree.Commit())
 	tree.Insert(key4, fourtyKeyTest, nil)
+	tree.Commit()
 
 	if err := tree.Delete(key4, nil); err != nil {
 		t.Error(err)
 	}
 	postHash := tree.Commit()
-	if Equal(hash2, postHash) {
+	if Equal(&hash2, postHash) {
 		t.Error("deleting leaf #4 resulted in unexpected tree")
 	}
 	res, err := tree.Get(key4, nil)
@@ -397,7 +400,7 @@ func TestDeletePrune(t *testing.T) {
 		t.Error(err)
 	}
 	postHash = tree.Commit()
-	if Equal(hash1, postHash) {
+	if Equal(&hash1, postHash) {
 		t.Error("deleting leaf #3 resulted in unexpected tree")
 	}
 	res, err = tree.Get(key3, nil)

--- a/tree_test.go
+++ b/tree_test.go
@@ -201,7 +201,7 @@ func TestInsertVsOrdered(t *testing.T) {
 	h1 := root1.Commit().Bytes()
 
 	if !bytes.Equal(h1[:], h2[:]) {
-		t.Errorf("Insert and InsertOrdered produce different trees %x != %x", h1, h2)
+		t.Errorf("Insert and InsertOrdered produce different trees %x != %x %s %s", h1, h2, ToDot(root1), ToDot(root2))
 	}
 }
 


### PR DESCRIPTION
When deserializing a `LeafNode`, the commitment is recomputed, which is wasterful. This PR saves the  C1 and C2 commitments to the database, and deserializes them into the `LeafNode` using `SetBytesTrusted`.