### PR TITLE
update GetConfig() error handling

### DIFF
--- a/config_ipa.go
+++ b/config_ipa.go
@@ -26,7 +26,7 @@
 package verkle
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/crate-crypto/go-ipa/ipa"
 )
@@ -49,12 +49,12 @@ const precompFileName = "precomp"
 func GetConfig() *Config {
 	if cfg == nil {
 		var ipacfg *ipa.IPAConfig
-		if precompSer, err := ioutil.ReadFile(precompFileName); err != nil {
+		if precompSer, err := os.ReadFile(precompFileName); err != nil {
 			ipacfg = ipa.NewIPASettings()
 			serialized, err := ipacfg.SRSPrecompPoints.SerializeSRSPrecomp()
 			if err != nil {
 				panic("error writing serialized precomputed Lagrange points:" + err.Error())
-			} else if err = ioutil.WriteFile(precompFileName, serialized, 0555); err != nil {
+			} else if err = os.WriteFile(precompFileName, serialized, 0555); err != nil {
 				panic("error saving the precomp: " + err.Error())
 			}
 		} else {

--- a/config_ipa.go
+++ b/config_ipa.go
@@ -26,7 +26,6 @@
 package verkle
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	"github.com/crate-crypto/go-ipa/ipa"
@@ -47,27 +46,27 @@ var cfg *Config
 
 const precompFileName = "precomp"
 
-func GetConfig() (*Config, error) {
+func GetConfig() *Config {
 	if cfg == nil {
 		var ipacfg *ipa.IPAConfig
 		if precompSer, err := ioutil.ReadFile(precompFileName); err != nil {
 			ipacfg = ipa.NewIPASettings()
 			serialized, err := ipacfg.SRSPrecompPoints.SerializeSRSPrecomp()
 			if err != nil {
-				return nil, fmt.Errorf("error writing serialized precomputed Lagrange points: %w", err)
+				panic("error writing serialized precomputed Lagrange points:" + err.Error())
 			} else if err = ioutil.WriteFile(precompFileName, serialized, 0555); err != nil {
-				return nil, fmt.Errorf("error saving the precomp: %w", err)
+				panic("error saving the precomp: " + err.Error())
 			}
 		} else {
 			srs, err := ipa.DeserializeSRSPrecomp(precompSer)
 			if err != nil {
-				return nil, fmt.Errorf("error deserializing precomputed Lagrange points, regenerating")
+				panic("error deserializing precomputed Lagrange points:" + err.Error())
 			}
 			ipacfg = ipa.NewIPASettingsWithSRSPrecomp(srs)
 		}
 		cfg = &IPAConfig{conf: ipacfg}
 	}
-	return cfg, nil
+	return cfg
 }
 
 var FrZero Fr

--- a/encoding.go
+++ b/encoding.go
@@ -76,10 +76,7 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 }
 
 func deserializeIntoStateless(bitlist []byte, raw []byte, depth byte, comm []byte) (*StatelessNode, error) {
-	tc, err := GetConfig()
-	if err != nil {
-		return nil, err
-	}
+	tc := GetConfig()
 
 	// GetTreeConfig caches computation result, hence
 	// this op has low overhead
@@ -99,10 +96,7 @@ func deserializeIntoStateless(bitlist []byte, raw []byte, depth byte, comm []byt
 }
 
 func CreateInternalNode(bitlist []byte, raw []byte, depth byte, comm []byte) (*InternalNode, error) {
-	tc, err := GetConfig()
-	if err != nil {
-		return nil, err
-	}
+	tc := GetConfig()
 
 	// GetTreeConfig caches computation result, hence
 	// this op has low overhead

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -70,7 +70,7 @@ func MakeVerkleMultiProof(root VerkleNode, keys [][]byte, keyvals map[string][]b
 		vals = append(vals, keyvals[string(k)])
 	}
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	mpArg := ipa.CreateMultiProof(tr, cfg.conf, pe.Cis, pe.Fis, pe.Zis)
 
 	// It's wheel-reinvention time again 🎉: reimplement a basic

--- a/proof_test.go
+++ b/proof_test.go
@@ -41,7 +41,7 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{string(ffx32KeyTest): zeroKeyTest})
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -61,7 +61,7 @@ func TestProofVerifyMultipleLeaves(t *testing.T) {
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{keys[0]}, map[string][]byte{string(keys[0]): fourtyKeyTest})
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -84,7 +84,7 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 	proof, _, _, _, _ := MakeVerkleMultiProof(root, keys[0:2], kv)
 
 	pe, _, _ := GetCommitmentsForMultiproof(root, keys[0:2])
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, pe.Cis, pe.Zis, pe.Yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -124,7 +124,7 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 		t.Fatalf("returning the wrong absent stem: %x != %x", isabsent[0], absentstem)
 	}
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, pe.Cis, pe.Zis, pe.Yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -144,7 +144,7 @@ func TestMultiProofVerifyMultipleLeavesCommitmentRedundancy(t *testing.T) {
 	proof, _, _, _, _ := MakeVerkleMultiProof(root, keys, kv)
 
 	pe, _, _ := GetCommitmentsForMultiproof(root, keys)
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, pe.Cis, pe.Zis, pe.Yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -157,7 +157,7 @@ func TestProofOfAbsenceInternalVerify(t *testing.T) {
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{})
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -170,7 +170,7 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{oneKeyTest}, map[string][]byte{})
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -187,7 +187,7 @@ func TestProofOfAbsenceLeafVerifyOtherSuffix(t *testing.T) {
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{key}, map[string][]byte{})
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -204,7 +204,7 @@ func TestProofOfAbsenceStemVerify(t *testing.T) {
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{key}, map[string][]byte{})
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -244,7 +244,7 @@ func BenchmarkProofVerification(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	for i := 0; i < b.N; i++ {
 		VerifyVerkleProof(proof, cis, zis, yis, cfg)
 	}
@@ -362,7 +362,7 @@ func TestProofDeserialize(t *testing.T) {
 	_ = deserialized
 
 	pe, _, _ := root.GetProofItems(keylist{absentkey[:]})
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(deserialized, pe.Cis, pe.Zis, pe.Yis, cfg) {
 		t.Fatal("could not verify verkle proof")
 	}
@@ -409,7 +409,7 @@ func TestProofOfAbsenceEdgeCase(t *testing.T) {
 
 	ret, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030303")
 	proof, cs, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ret}, map[string][]byte{string(ret): nil})
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cs, zis, yis, cfg) {
 		t.Fatal("could not verify proof")
 	}
@@ -426,7 +426,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
 	ret2, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030301")
 	proof, cs, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ret1, ret2}, map[string][]byte{string(ret1): nil, string(ret2): nil})
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cs, zis, yis, cfg) {
 		t.Fatal("could not verify proof")
 	}
@@ -445,7 +445,7 @@ func TestProofOfAbsenceNoneMultipleStems(t *testing.T) {
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
 	ret2, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030200")
 	proof, cs, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ret1, ret2}, map[string][]byte{string(ret1): nil, string(ret2): nil})
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cs, zis, yis, cfg) {
 		t.Fatal("could not verify proof")
 	}

--- a/stateless.go
+++ b/stateless.go
@@ -67,7 +67,7 @@ type StatelessNode struct {
 }
 
 func NewStateless() *StatelessNode {
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	return &StatelessNode{
 		children:   make(map[byte]VerkleNode),
 		hash:       new(Fr).SetZero(),
@@ -82,7 +82,7 @@ func NewStatelessWithCommitment(point *Point) *StatelessNode {
 		xfr Fr
 	)
 	toFr(&xfr, point)
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	return &StatelessNode{
 		children:   make(map[byte]VerkleNode),
 		hash:       &xfr,
@@ -239,7 +239,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 
 		// special case: missing child, check whether there is a child node
 		// to deserialize, and if that is not the case, this is an empty child.
-		cfg, _ := GetConfig()
+		cfg := GetConfig()
 		if n.children[nChild] == nil {
 			unresolved := n.unresolved[nChild]
 			if len(unresolved) == 0 {
@@ -372,7 +372,7 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 
 	// special case: missing child, check whether there is a child node
 	// to deserialize, and if that is not the case, this is an empty child.
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if n.children[nChild] == nil {
 		unresolved := n.unresolved[nChild]
 		if len(unresolved) == 0 {

--- a/tree.go
+++ b/tree.go
@@ -217,13 +217,13 @@ func newInternalNodeNilCommitment(depth byte, cmtr Committer) VerkleNode {
 
 // New creates a new tree root
 func New() VerkleNode {
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	return newInternalNode(0, cfg)
 }
 
 // New creates a new leaf node
 func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	leaf := &LeafNode{
 		committer: cfg,
 		// depth will be 0, but the commitment calculation

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -45,7 +45,7 @@ func extensionAndSuffixOneKey(key, value []byte, ret *Point) {
 	var (
 		v                               Fr
 		vs                              [2]Fr
-		cfg, _                          = GetConfig()
+		cfg                             = GetConfig()
 		srs                             = cfg.conf.SRSPrecompPoints.SRS
 		stemComm1, stemComm3, stemComm2 Point
 		t1, t2, c1                      Point
@@ -72,7 +72,7 @@ func TestInsertKey0Value0(t *testing.T) {
 		expected  Fr
 		root      = New()
 		expectedP Point
-		cfg, _    = GetConfig()
+		cfg       = GetConfig()
 		srs       = cfg.conf.SRSPrecompPoints.SRS
 	)
 
@@ -98,7 +98,7 @@ func TestInsertKey1Value1(t *testing.T) {
 		v, expected Fr
 		root        = New()
 		expectedP   Point
-		cfg, _      = GetConfig()
+		cfg         = GetConfig()
 		srs         = cfg.conf.SRSPrecompPoints.SRS
 	)
 	key := []byte{
@@ -128,7 +128,7 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 		root                            = New()
 		expectedP, c1, c2, t1, t2       Point
 		stemComm1, stemComm3, stemComm2 Point
-		cfg, _                          = GetConfig()
+		cfg                             = GetConfig()
 		srs                             = cfg.conf.SRSPrecompPoints.SRS
 	)
 	key_a := []byte{
@@ -177,7 +177,7 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 		v, v1, v2, expected Fr
 		root                = New()
 		expectedP, t1, t2   Point
-		cfg, _              = GetConfig()
+		cfg                 = GetConfig()
 		srs                 = cfg.conf.SRSPrecompPoints.SRS
 	)
 	key_b, _ := hex.DecodeString("0101010101010101010101010101010101010101010101010101010101010101")

--- a/tree_test.go
+++ b/tree_test.go
@@ -1194,7 +1194,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 	}
 	t.Logf("serialized proof=%x", serialized)
 
-	cfg, _ := GetConfig()
+	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
 		t.Fatal("proof didn't verify")
 	}


### PR DESCRIPTION
Use panic() instead of printing errors. Remove Get Config() error return value and update all references.