### PR TITLE
ipa: add new api for creating Fr from big-endian bytes

### DIFF
--- a/ipa.go
+++ b/ipa.go
@@ -57,6 +57,12 @@ func FromLEBytes(fr *Fr, data []byte) {
 	fr.SetBytesLE(aligned[:])
 }
 
+func FromBytes(fr *Fr, data []byte) {
+	var aligned [32]byte
+	copy(aligned[32-len(data):], data)
+	fr.SetBytes(aligned[:])
+}
+
 func StemFromBytes(fr *Fr, data []byte) {
 	bytes := make([]byte, len(data))
 	copy(bytes, data)

--- a/tree.go
+++ b/tree.go
@@ -33,8 +33,10 @@ import (
 	"github.com/crate-crypto/go-ipa/banderwagon"
 )
 
-type NodeFlushFn func(VerkleNode)
-type NodeResolverFn func([]byte) ([]byte, error)
+type (
+	NodeFlushFn    func(VerkleNode)
+	NodeResolverFn func([]byte) ([]byte, error)
+)
 
 // Committer represents an object that is able to create the
 // commitment to a polynomial.


### PR DESCRIPTION
This PR adds a new API in the `ipa` package to build a `Fr` from a big-endian byte slice.

This is used in this other [go-ethereum PR](https://github.com/gballet/go-ethereum/pull/140).