### PR TITLE
set of changes needed to re-enable the verkle tests in go-ethereum

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -69,7 +69,7 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 		ln.Commit()
 		return ln, nil
 	case internalRLPType:
-		return deserializeIntoStateless(serialized[1:33], serialized[33:], depth, comm)
+		return CreateInternalNode(serialized[1:33], serialized[33:], depth, comm)
 	default:
 		return nil, ErrInvalidNodeEncoding
 	}


### PR DESCRIPTION
This only fixes the verkle tests, not all geth tests, but it's enough to produce sample blocks