### PR TITLE
Use serialized commitments in HashedNode

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -69,7 +69,7 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 		ln.Commit()
 		return ln, nil
 	case internalRLPType:
-		return deserializeIntoStateless(serialized[1:33], serialized[33:], depth, comm)
+		return CreateInternalNode(serialized[1:33], serialized[33:], depth, comm)
 	default:
 		return nil, ErrInvalidNodeEncoding
 	}
@@ -106,10 +106,7 @@ func CreateInternalNode(bitlist []byte, raw []byte, depth byte, comm []byte) (*I
 		return nil, ErrInvalidNodeEncoding
 	}
 	for i, index := range indices {
-		hashed := &HashedNode{hash: new(Fr), commitment: new(Point)}
-		hashed.commitment.SetBytes(raw[i*32 : (i+1)*32])
-		toFr(hashed.hash, hashed.commitment)
-		n.children[index] = hashed
+		n.children[index] = &HashedNode{raw[i*32 : (i+1)*32]}
 	}
 	n.commitment = new(Point)
 	n.commitment.SetBytes(comm)

--- a/encoding.go
+++ b/encoding.go
@@ -75,6 +75,16 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 	}
 }
 
+func ParseStatelessNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
+	if len(serialized) < 64 {
+		return nil, serializedPayloadTooShort
+	}
+	if serialized[0] == internalRLPType {
+		return deserializeIntoStateless(serialized[1:33], serialized[33:], depth, comm)
+	}
+	return nil, ErrInvalidNodeEncoding
+}
+
 func deserializeIntoStateless(bitlist []byte, raw []byte, depth byte, comm []byte) (*StatelessNode, error) {
 	tc := GetConfig()
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -31,8 +31,7 @@ import (
 )
 
 type HashedNode struct {
-	hash       *Fr
-	commitment *Point
+	commitment []byte
 }
 
 func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -55,14 +54,16 @@ func (n *HashedNode) Commit() *Point {
 	if n.commitment == nil {
 		panic("nil commitment")
 	}
-	return n.commitment
+	c := new(Point)
+	c.SetBytes(n.commitment)
+	return c
 }
 
 func (n *HashedNode) Commitment() *Point {
 	if n.commitment == nil {
 		panic("nil commitment")
 	}
-	return n.commitment
+	return n.Commit()
 }
 
 func (*HashedNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte) {
@@ -74,22 +75,16 @@ func (*HashedNode) Serialize() ([]byte, error) {
 }
 
 func (n *HashedNode) Copy() VerkleNode {
-	h := &HashedNode{
-		commitment: new(Point),
-		hash:       new(Fr),
+	if n.commitment == nil {
+		panic("nil commitment")
 	}
-	if n.hash != nil {
-		CopyFr(h.hash, n.hash)
-	}
-	if n.commitment != nil {
-		CopyPoint(h.commitment, n.commitment)
-	}
-
-	return h
+	c := &HashedNode{commitment: make([]byte, len(n.commitment))}
+	copy(c.commitment, n.commitment)
+	return c
 }
 
 func (n *HashedNode) toDot(parent, path string) string {
-	return fmt.Sprintf("hash%s [label=\"H: %x\"]\n%s -> hash%s\n", path, n.hash.Bytes(), parent, path)
+	return fmt.Sprintf("hash%s [label=\"H: %x\"]\n%s -> hash%s\n", path, n.commitment, parent, path)
 }
 
 func (*HashedNode) setDepth(_ byte) {
@@ -97,5 +92,8 @@ func (*HashedNode) setDepth(_ byte) {
 }
 
 func (n *HashedNode) Hash() *Fr {
-	return n.hash
+	h := new(Fr)
+	c := n.Commitment()
+	toFr(h, c)
+	return h
 }

--- a/hashednode.go
+++ b/hashednode.go
@@ -55,7 +55,7 @@ func (n *HashedNode) Commit() *Point {
 		panic("nil commitment")
 	}
 	c := new(Point)
-	c.SetBytes(n.commitment)
+	c.SetBytesTrusted(n.commitment)
 	return c
 }
 

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -28,7 +28,7 @@ package verkle
 import "testing"
 
 func TestHashedNodeFuncs(t *testing.T) {
-	e := HashedNode{hash: new(Fr), commitment: new(Point)}
+	e := HashedNode{}
 	err := e.Insert(zeroKeyTest, zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when inserting into a hashed node")

--- a/stateless.go
+++ b/stateless.go
@@ -260,11 +260,11 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 		// before there is an insert into it.
 		if h, ok := n.children[nChild].(*HashedNode); ok {
 			comm := h.commitment
-			serialized, err := resolver(comm[:])
+			serialized, err := resolver(comm)
 			if err != nil {
 				return err
 			}
-			node, err := ParseNode(serialized, n.depth+1, comm[:])
+			node, err := ParseNode(serialized, n.depth+1, comm)
 			if err != nil {
 				return err
 			}
@@ -385,11 +385,11 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 	// before there is an insert into it.
 	if h, ok := n.children[nChild].(*HashedNode); ok {
 		comm := h.commitment
-		serialized, err := resolver(comm[:])
+		serialized, err := resolver(comm)
 		if err != nil {
 			return fmt.Errorf("stem insertion failed (node resolution error) %x %w", stem, err)
 		}
-		node, err := ParseNode(serialized, n.depth+1, comm[:])
+		node, err := ParseNode(serialized, n.depth+1, comm)
 		if err != nil {
 			return err
 		}

--- a/stateless.go
+++ b/stateless.go
@@ -794,27 +794,6 @@ func (n *StatelessNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][
 	return pe, esses, poass
 }
 
-func (n *StatelessNode) toInternalNode() *InternalNode {
-	internal := &InternalNode{
-		children:   make([]VerkleNode, NodeWidth),
-		depth:      n.depth,
-		commitment: n.commitment,
-		committer:  n.committer,
-	}
-
-	for i := range internal.children {
-		if child, ok := n.children[byte(i)]; ok {
-			internal.children[i] = child
-		} else if serialized, ok := n.unresolved[byte(i)]; ok {
-			internal.children[byte(i)] = &HashedNode{serialized}
-		} else {
-			internal.children[i] = Empty{}
-		}
-	}
-
-	return internal
-}
-
 func (n *StatelessNode) Serialize() ([]byte, error) {
 	var (
 		bitlist  [32]byte

--- a/stateless.go
+++ b/stateless.go
@@ -263,7 +263,7 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 			if err != nil {
 				return err
 			}
-			node, err := ParseNode(serialized, n.depth+1, h.commitment)
+			node, err := ParseStatelessNode(serialized, n.depth+1, h.commitment)
 			if err != nil {
 				return err
 			}
@@ -388,7 +388,7 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 		if err != nil {
 			return fmt.Errorf("stem insertion failed (node resolution error) %x %w", stem, err)
 		}
-		node, err := ParseNode(serialized, n.depth+1, comm)
+		node, err := ParseStatelessNode(serialized, n.depth+1, comm)
 		if err != nil {
 			return err
 		}
@@ -590,7 +590,7 @@ func (n *StatelessNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve unresolved item: %w", err)
 		}
-		child, err = ParseNode(serialized, n.depth+1, n.unresolved[nChild])
+		child, err = ParseStatelessNode(serialized, n.depth+1, n.unresolved[nChild])
 		if err != nil {
 			return nil, fmt.Errorf("could not deserialize node: %w", err)
 		}

--- a/stateless.go
+++ b/stateless.go
@@ -259,12 +259,11 @@ func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn
 		// If the child is a hash, the node needs to be resolved
 		// before there is an insert into it.
 		if h, ok := n.children[nChild].(*HashedNode); ok {
-			comm := h.commitment
-			serialized, err := resolver(comm)
+			serialized, err := resolver(h.commitment)
 			if err != nil {
 				return err
 			}
-			node, err := ParseNode(serialized, n.depth+1, comm)
+			node, err := ParseNode(serialized, n.depth+1, h.commitment)
 			if err != nil {
 				return err
 			}

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -544,7 +544,7 @@ func TestStatelessInsertIntoLeaf(t *testing.T) {
 		flushed[string(comm[:])] = ser
 	})
 
-	root, err := ParseNode(flushed[string(rootc[:])], 0, rootc[:])
+	root, err := ParseStatelessNode(flushed[string(rootc[:])], 0, rootc[:])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -476,7 +476,7 @@ func TestStatelessInsertIntoSerialized(t *testing.T) {
 		flushed[string(comm[:])] = ser
 	})
 
-	root, err := ParseNode(flushed[string(rootc[:])], 0, rootc[:])
+	root, err := ParseStatelessNode(flushed[string(rootc[:])], 0, rootc[:])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -567,7 +567,7 @@ func TestStatelessInsertAtStemIntoLeaf(t *testing.T) {
 		flushed[string(comm[:])] = ser
 	})
 
-	root, err := ParseNode(flushed[string(rootc[:])], 0, rootc[:])
+	root, err := ParseStatelessNode(flushed[string(rootc[:])], 0, rootc[:])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tree.go
+++ b/tree.go
@@ -291,11 +291,11 @@ func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn)
 			return errInsertIntoHash
 		}
 		hash := child.commitment
-		serialized, err := resolver(hash[:])
+		serialized, err := resolver(hash)
 		if err != nil {
 			return fmt.Errorf("verkle tree: error resolving node %x at depth %d: %w", key, n.depth, err)
 		}
-		resolved, err := ParseNode(serialized, n.depth+1, hash[:])
+		resolved, err := ParseNode(serialized, n.depth+1, hash)
 		if err != nil {
 			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", key, err)
 		}
@@ -395,11 +395,11 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 			return errInsertIntoHash
 		}
 		hash := child.commitment
-		serialized, err := resolver(hash[:])
+		serialized, err := resolver(hash)
 		if err != nil {
 			return fmt.Errorf("verkle tree: error resolving node %x at depth %d: %w", stem, n.depth, err)
 		}
-		resolved, err := ParseNode(serialized, n.depth+1, hash[:])
+		resolved, err := ParseNode(serialized, n.depth+1, hash)
 		if err != nil {
 			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", stem, err)
 		}
@@ -687,12 +687,12 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) error {
 			return errDeleteHash
 		}
 		comm := child.commitment
-		payload, err := resolver(comm[:])
+		payload, err := resolver(comm)
 		if err != nil {
 			return err
 		}
 		// deserialize the payload and set it as the child
-		c, err := ParseNode(payload, n.depth+1, comm[:])
+		c, err := ParseNode(payload, n.depth+1, comm)
 		if err != nil {
 			return err
 		}
@@ -774,13 +774,13 @@ func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 			return nil, errReadFromInvalid
 		}
 
-		payload, err := getter(child.commitment[:])
+		payload, err := getter(child.commitment)
 		if err != nil {
 			return nil, err
 		}
 
 		// deserialize the payload and set it as the child
-		c, err := ParseNode(payload, n.depth+1, child.commitment[:])
+		c, err := ParseNode(payload, n.depth+1, child.commitment)
 		if err != nil {
 			return nil, err
 		}

--- a/tree_test.go
+++ b/tree_test.go
@@ -673,7 +673,7 @@ func TestNodeSerde(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	resRoot := res.(*StatelessNode).toInternalNode()
+	resRoot := res.(*InternalNode)
 
 	resRoot.children[0] = resLeaf0
 	resRoot.children[64] = resLeaf64

--- a/tree_test.go
+++ b/tree_test.go
@@ -700,7 +700,7 @@ func isInternalEqual(a, b *InternalNode) bool {
 			if !ok {
 				return false
 			}
-			if !Equal(c.(*HashedNode).commitment, hn.commitment) {
+			if !Equal(c.(*HashedNode).Commitment(), hn.Commitment()) {
 				return false
 			}
 		case *LeafNode:


### PR DESCRIPTION
Until now, when de-serializing an `InternalNode`, the commitments of its 256 children would also be deserialized in order to instantiate them as `HashedNode`. This is wasteful, as this deserialization operaiton is expensive and, when resolving a `HashedNode`, the commitment is serialized again in order to get the serialized child node from the database.

This PR modifies `HashedNode` to only contain the serialized commitment.