### PR TITLE
Use CoW in node insert + code simplifications

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -36,8 +36,6 @@ var (
 	errNotSupportedInStateless = errors.New("not implemented in stateless")
 	errInsertIntoOtherStem     = errors.New("insert splits a stem where it should not happen")
 	errStatelessAndStatefulMix = errors.New("a stateless node should not be found in a stateful tree")
-	errUnknownNodeType         = errors.New("unknown node type")
-	errLeafOverwrite           = errors.New("leaf overwrite disallowed")
 )
 
 const (

--- a/empty.go
+++ b/empty.go
@@ -29,8 +29,10 @@ import "errors"
 
 type Empty struct{}
 
+var errDirectInsertIntoEmptyNode = errors.New("an empty node should not be inserted directly into")
+
 func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
-	return errors.New("an empty node should not be inserted directly into")
+	return errDirectInsertIntoEmptyNode
 }
 
 func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {

--- a/proof_test.go
+++ b/proof_test.go
@@ -38,12 +38,13 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 	root.Insert(zeroKeyTest, zeroKeyTest, nil)
 	root.Insert(oneKeyTest, zeroKeyTest, nil)
 	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	root.Commit()
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, [][]byte{ffx32KeyTest}, map[string][]byte{string(ffx32KeyTest): zeroKeyTest})
 
 	cfg := GetConfig()
 	if !VerifyVerkleProof(proof, cis, zis, yis, cfg) {
-		t.Fatal("could not verify verkle proof")
+		t.Fatalf("could not verify verkle proof: %s", ToDot(root))
 	}
 }
 

--- a/stateless.go
+++ b/stateless.go
@@ -60,6 +60,10 @@ type StatelessNode struct {
 	// of the current node.
 	hash *Fr
 
+	// cow keeps a copy of the original value of a child's
+	// commitment when writing to it.
+	cow map[byte]*Point
+
 	// Cache the commitment value
 	commitment, c1, c2 *Point
 
@@ -165,168 +169,22 @@ func (n *StatelessNode) updateCn(index byte, value []byte, c *Point) {
 	c.Add(c, &diff)
 }
 
-func (n *StatelessNode) updateLeaf(index byte, value []byte) {
-	c, oldc := n.getOldCn(index)
-	n.updateCn(index, value, c)
-	n.updateC(index, c, oldc)
-	if n.values[index] == nil {
-		// only increase the count if no value is
-		// overwritten.
-		n.count++
-	}
-	n.values[index] = value
-}
+// func (n *StatelessNode) updateLeaf(index byte, value []byte) {
+// 	c, oldc := n.getOldCn(index)
+// 	n.updateCn(index, value, c)
+// 	n.updateC(index, c, oldc)
+// 	if n.values[index] == nil {
+// 		// only increase the count if no value is
+// 		// overwritten.
+// 		n.count++
+// 	}
+// 	n.values[index] = value
+// }
 
 func (n *StatelessNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
-	// if this is a leaf value and the stems are different, intermediate
-	// nodes need to be inserted.
-	if n.values != nil {
-		// Need to add a new branch node to differentiate
-		// between two keys, if the keys are different.
-		// Otherwise, just update the key.
-		if equalPaths(n.stem, key) {
-			n.updateLeaf(key[31], value)
-		} else {
-			// A new branch node has to be inserted. Depending
-			// on the next word in both keys, a recursion into
-			// the moved leaf node can occur.
-			nextexisting := offset2key(n.stem, n.depth)
-			oldExtNode := &StatelessNode{
-				depth:      n.depth + 1,
-				committer:  n.committer,
-				count:      n.count,
-				values:     n.values,
-				stem:       n.stem,
-				commitment: new(Point),
-				hash:       n.hash,
-				c1:         n.c1,
-				c2:         n.c2,
-			}
-			n.children = map[byte]VerkleNode{
-				nextexisting: oldExtNode,
-			}
-			n.values = nil
-			n.stem = nil
-			n.c1 = nil
-			n.c2 = nil
-			n.count++
-			CopyPoint(oldExtNode.commitment, n.commitment)
-			n.hash = new(Fr)
-
-			nextinserted := offset2key(key, n.depth)
-			if nextinserted != nextexisting {
-				// Next word differs, so the branching point
-				// has been reached. Create the "new" child.
-				n.children[nextinserted] = n.newLeafChildFromSingleValue(key, value)
-			}
-
-			// recurse into the newly created child
-			err := n.children[nextinserted].Insert(key, value, resolver)
-			if err != nil {
-				return err
-			}
-			var poly [NodeWidth]Fr
-			CopyFr(&poly[nextexisting], oldExtNode.Hash())
-			if nextexisting != nextinserted {
-				CopyFr(&poly[nextinserted], n.children[nextinserted].Hash())
-			}
-			n.commitment = n.committer.CommitToPoly(poly[:], NodeWidth-2)
-			toFr(n.hash, n.commitment)
-		}
-	} else {
-		// internal node
-		nChild := offset2key(key, n.depth)
-
-		// special case: missing child, check whether there is a child node
-		// to deserialize, and if that is not the case, this is an empty child.
-		cfg := GetConfig()
-		if n.children[nChild] == nil {
-			unresolved := n.unresolved[nChild]
-			if len(unresolved) == 0 {
-				n.children[nChild] = n.newLeafChildFromSingleValue(key, value)
-
-				var diff Point
-				diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nChild], n.children[nChild].Hash())
-				n.commitment.Add(n.commitment, &diff)
-				toFr(n.hash, n.commitment)
-				return nil
-			}
-
-			n.children[nChild] = &HashedNode{unresolved}
-			// fallthrough to hash resolution
-		}
-
-		// If the child is a hash, the node needs to be resolved
-		// before there is an insert into it.
-		if h, ok := n.children[nChild].(*HashedNode); ok {
-			serialized, err := resolver(h.commitment)
-			if err != nil {
-				return err
-			}
-			node, err := ParseStatelessNode(serialized, n.depth+1, h.commitment)
-			if err != nil {
-				return err
-			}
-			n.children[nChild] = node
-		}
-
-		// Save the value of the initial child commitment
-		var pre Fr
-		CopyFr(&pre, n.children[nChild].Hash())
-
-		var err error
-		switch child := n.children[nChild].(type) {
-		case *StatelessNode:
-			err = child.Insert(key, value, resolver)
-		case *LeafNode:
-			if !bytes.Equal(child.stem, key[:31]) {
-				child.setDepth(child.depth + 1)
-				existing := child.stem[n.depth+1]
-				inserted := key[n.depth+1]
-				newbranch := &StatelessNode{
-					children:   map[byte]VerkleNode{existing: child},
-					depth:      n.depth + 1,
-					commitment: Generator(),
-					hash:       new(Fr),
-				}
-				n.children[nChild] = newbranch
-
-				// reuse pre here, since the child commitment is the same for this
-				// new branch as it was for the current node before the insertion.
-				newbranch.commitment.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[existing], &pre)
-
-				if inserted != existing {
-					values := make([][]byte, NodeWidth)
-					lastnode := NewLeafNode(key[:31], values)
-					newbranch.children[inserted] = lastnode
-					newbranch.children[inserted].setDepth(child.depth + 1)
-					lastnode.Insert(key, value, nil)
-					var lnComm Fr
-					var diff Point
-					toFr(&lnComm, lastnode.Commitment())
-					diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[inserted], &lnComm)
-					newbranch.commitment.Add(newbranch.commitment, &diff)
-				} else {
-					err = newbranch.Insert(key, value, resolver)
-				}
-			} else {
-				err = child.Insert(key, value, resolver)
-			}
-		default:
-			err = errNotSupportedInStateless
-		}
-		if err != nil {
-			return err
-		}
-
-		// update the commitment
-		var diff Point
-		diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nChild], pre.Sub(n.children[nChild].Hash(), &pre))
-		n.commitment.Add(n.commitment, &diff)
-	}
-
-	toFr(n.hash, n.commitment)
-	return nil
+	values := make([][]byte, NodeWidth)
+	values[key[31]] = value
+	return n.InsertAtStem(key[:31], values, resolver, true)
 }
 
 func (n *StatelessNode) updateMultipleLeaves(values [][]byte) {
@@ -358,6 +216,21 @@ func (n *StatelessNode) updateMultipleLeaves(values [][]byte) {
 	}
 }
 
+func (n *StatelessNode) cowChild(index byte) {
+	if n.children == nil {
+		return // only internal nodes are supported
+	}
+
+	if n.cow == nil {
+		n.cow = make(map[byte]*Point)
+	}
+
+	if n.cow[index] == nil {
+		n.cow[index] = new(Point)
+		CopyPoint(n.cow[index], n.children[index].Commitment())
+	}
+}
+
 func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver NodeResolverFn, _ bool) error {
 	nChild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
 
@@ -368,10 +241,17 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 
 	// special case: missing child, check whether there is a child node
 	// to deserialize, and if that is not the case, this is an empty child.
-	cfg := GetConfig()
 	if n.children[nChild] == nil {
 		unresolved := n.unresolved[nChild]
 		if len(unresolved) == 0 {
+			// This is a hack so that n.cowChild can recover a 0
+			// commitment as the 'pre' value. newLeafChildFromMultipleValues
+			// will compute the commitment of the leaf node, and
+			// its 'default' value will be lost. This becomes unnecessary
+			// when/if LeafNode also implements CoW.
+			n.children[nChild] = Empty{}
+
+			n.cowChild(nChild)
 			n.children[nChild] = n.newLeafChildFromMultipleValues(stem, values)
 			return nil
 		}
@@ -395,15 +275,13 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 		n.children[nChild] = node
 	}
 
-	// Save the value of the initial child commitment
-	var pre Fr
-	CopyFr(&pre, n.children[nChild].Hash())
+	n.cowChild(nChild)
 
 	var err error
 	switch child := n.children[nChild].(type) {
 	case *InternalNode:
-		leaf := NewLeafNode(stem, values)
-		err = child.InsertStem(stem, leaf, resolver, true)
+		err = child.InsertStem(stem, values, resolver)
+		child.Commit()
 	case *StatelessNode:
 		err = child.InsertAtStem(stem, values, resolver, false)
 	case *LeafNode:
@@ -417,72 +295,37 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 				commitment: Generator(),
 				depth:      child.depth,
 				committer:  n.committer,
+				// manually set the commitment to 0 so that it doesn't
+				// capture that of `child` in case it has already been
+				// calculated. This would cause the resulting child
+				// commitment to be subtracted from itself later on.
+				// TODO Implement cow for LeafNode, this issue will
+				// disappear.
+				cow: map[byte]*Point{nextexisting: Generator()},
 			}
 			child.setDepth(child.depth + 1)
 			n.children[nChild] = newbranch
 			n.count++
 
-			// pre-insertion commitment - it's a bit wasteful since
-			// it is computed once and then updated. TODO see if this
-			// can be optimized by inserting intermediate nodes iteratively.
-			newbranch.commitment.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nextexisting], child.Hash())
-
+			// NOTE: No cowChild() for the inserted node, that case
+			// is handled when recursing.
 			err = newbranch.InsertAtStem(stem, values, resolver, false)
 		}
 	default:
-		return errNotSupportedInStateless
-	}
-	if err != nil {
-		return err
+		err = errNotSupportedInStateless
 	}
 
-	// update the commitment
-	var poly [256]Fr
-	poly[nChild].Sub(n.children[nChild].Hash(), &pre)
-	diff := cfg.conf.Commit(poly[:])
-	n.commitment.Add(n.commitment, &diff)
-	return nil
+	return err
 }
 
-func (n *StatelessNode) newLeafChildFromSingleValue(key, value []byte) *LeafNode {
-	newchild := NewLeafNode(key[:31], make([][]byte, NodeWidth))
+func (n *StatelessNode) newLeafChildFromMultipleValues(stem []byte, values [][]byte) *LeafNode {
+	if len(values) != 256 {
+		panic("expecting a 256 leaf values")
+	}
+
+	newchild := NewLeafNode(stem, values)
 	newchild.setDepth(n.depth + 1)
-	newchild.Insert(key, value, nil)
-	return newchild
-}
-
-func (n *StatelessNode) newLeafChildFromMultipleValues(stem []byte, values [][]byte) *StatelessNode {
-	newchild := &StatelessNode{
-		depth:     n.depth + 1,
-		stem:      stem,
-		values:    map[byte][]byte{},
-		committer: n.committer,
-		count:     1,
-		hash:      new(Fr),
-		c1:        Generator(),
-		c2:        Generator(),
-	}
-
-	var poly [4]Fr
-	poly[0].SetUint64(1)
-	StemFromBytes(&poly[1], newchild.stem)
-
-	for i, v := range values {
-		var cpoly [256]Fr
-		newchild.values[byte(i)] = v
-
-		leafToComms(cpoly[byte(i%128)*2:], v)
-		if i < 128 {
-			newchild.c1 = n.committer.CommitToPoly(cpoly[:], 2)
-			toFr(&poly[2], newchild.c1)
-		} else {
-			newchild.c2 = n.committer.CommitToPoly(cpoly[:], 2)
-			toFr(&poly[3], newchild.c2)
-		}
-		newchild.commitment = n.committer.CommitToPoly(poly[:], 4)
-		toFr(newchild.hash, newchild.commitment)
-	}
-
+	newchild.Commit()
 	return newchild
 }
 
@@ -590,7 +433,7 @@ func (n *StatelessNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve unresolved item: %w", err)
 		}
-		child, err = ParseStatelessNode(serialized, n.depth+1, n.unresolved[nChild])
+		child, err = ParseNode(serialized, n.depth+1, n.unresolved[nChild])
 		if err != nil {
 			return nil, fmt.Errorf("could not deserialize node: %w", err)
 		}
@@ -605,8 +448,25 @@ func (n *StatelessNode) Commitment() *Point {
 }
 
 func (n *StatelessNode) Commit() *Point {
-	// TODO go over dirty children and update the
-	// current commitment.
+	if len(n.values) != 0 {
+		// skip this, stateless leaf nodes are currently broken
+	} else {
+		var poly [NodeWidth]Fr
+		empty := 256
+		if len(n.cow) != 0 {
+			for idx, comm := range n.cow {
+				empty--
+				var pre Fr
+				toFr(&pre, comm)
+				toFr(&poly[idx], n.children[idx].Commit())
+				poly[idx].Sub(&poly[idx], &pre)
+			}
+			n.cow = nil
+			n.commitment.Add(n.commitment, GetConfig().CommitToPoly(poly[:], empty))
+			return n.commitment
+		}
+	}
+
 	return n.commitment
 }
 
@@ -871,12 +731,21 @@ func (n *StatelessNode) Copy() VerkleNode {
 	if n.commitment != nil {
 		CopyPoint(ret.commitment, n.commitment)
 	}
+	if n.cow != nil {
+		ret.cow = make(map[byte]*Point)
+		for k, v := range n.cow {
+			ret.cow[k] = new(Point)
+			CopyPoint(ret.cow[k], v)
+		}
+	}
 
 	return ret
 }
 
 func (n *StatelessNode) toDot(parent, path string) string {
 	n.Commit()
+	var hash Fr
+	toFr(&hash, n.Commitment())
 	me := fmt.Sprintf("internal%s", path)
 	var ret string
 	if len(n.values) != 0 {
@@ -887,8 +756,6 @@ func (n *StatelessNode) toDot(parent, path string) string {
 		if n.c2 != nil {
 			c2bytes = n.c2.Bytes()
 		}
-		var hash Fr
-		toFr(&hash, n.commitment)
 		ret = fmt.Sprintf("leaf%s [label=\"L: %x\nC: %x\nC₁: %x\nC₂:%x\"]\n%s -> leaf%s\n", path, n.hash.Bytes(), n.commitment.Bytes(), c1bytes, c2bytes, parent, path)
 		for i, v := range n.values {
 			if v != nil {
@@ -896,7 +763,7 @@ func (n *StatelessNode) toDot(parent, path string) string {
 			}
 		}
 	} else {
-		ret = fmt.Sprintf("%s [label=\"I: %x\"]\n", me, n.hash.BytesLE())
+		ret = fmt.Sprintf("%s [label=\"I: %x\"]\n", me, hash.BytesLE())
 		if len(parent) > 0 {
 			ret += fmt.Sprintf(" %s -> %s\n", parent, me)
 		}

--- a/stateless.go
+++ b/stateless.go
@@ -433,7 +433,7 @@ func (n *StatelessNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve unresolved item: %w", err)
 		}
-		child, err = ParseNode(serialized, n.depth+1, n.unresolved[nChild])
+		child, err = ParseStatelessNode(serialized, n.depth+1, n.unresolved[nChild])
 		if err != nil {
 			return nil, fmt.Errorf("could not deserialize node: %w", err)
 		}

--- a/tree.go
+++ b/tree.go
@@ -472,6 +472,7 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) error {
 // Flush hashes the children of an internal node and replaces them
 // with HashedNode. It also sends the current node on the flush channel.
 func (n *InternalNode) Flush(flush NodeFlushFn) {
+	n.Commit()
 	for i, child := range n.children {
 		if c, ok := child.(*InternalNode); ok {
 			c.Commit()

--- a/tree.go
+++ b/tree.go
@@ -179,6 +179,8 @@ type (
 		commitment *Point
 
 		committer Committer
+
+		cow map[byte]*Point
 	}
 
 	LeafNode struct {
@@ -205,18 +207,6 @@ func newInternalNode(depth byte, cmtr Committer) VerkleNode {
 	return node
 }
 
-func newInternalNodeNilCommitment(depth byte, cmtr Committer) VerkleNode {
-	node := new(InternalNode)
-	node.children = make([]VerkleNode, NodeWidth)
-	for idx := range node.children {
-		node.children[idx] = Empty(struct{}{})
-	}
-	node.depth = depth
-	node.committer = cmtr
-	node.commitment = nil
-	return node
-}
-
 // New creates a new tree root
 func New() VerkleNode {
 	cfg := GetConfig()
@@ -238,19 +228,21 @@ func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
 
 	// Initialize the commitment with the extension tree
 	// marker and the stem.
-	var poly [256]Fr
+	count := 0
+	var poly, c1poly, c2poly [256]Fr
 	poly[0].SetUint64(1)
 	StemFromBytes(&poly[1], leaf.stem)
-	leaf.commitment = leaf.committer.CommitToPoly(poly[:], 2)
+
+	count = fillSuffixTreePoly(c1poly[:], values[:128])
+	leaf.c1 = leaf.committer.CommitToPoly(c1poly[:], 256-count)
+	toFr(&poly[2], leaf.c1)
+	count = fillSuffixTreePoly(c2poly[:], values[128:])
+	leaf.c2 = leaf.committer.CommitToPoly(c2poly[:], 256-count)
+	toFr(&poly[3], leaf.c2)
+
+	leaf.commitment = leaf.committer.CommitToPoly(poly[:], 252)
 
 	return leaf
-}
-
-func NewLeafNodeWithSingleValue(key []byte, value []byte, depth byte) *LeafNode {
-	ln := NewLeafNode(key[:31], make([][]byte, NodeWidth))
-	ln.setDepth(depth)
-	ln.Insert(key, value, nil)
-	return ln
 }
 
 func (n *InternalNode) Children() []VerkleNode {
@@ -265,131 +257,31 @@ func (n *InternalNode) SetChild(i int, c VerkleNode) error {
 	return nil
 }
 
-func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
-	var (
-		err       error
-		pre, post Fr                         // serialized value of this node's commitment pre- and post-insertion
-		nChild    = offset2key(key, n.depth) // index of the child pointed by the next byte in the key
-	)
-
-	// keep the initial value of the child commitment
-	toFr(&pre, n.children[nChild].Commitment())
-
-	switch child := n.children[nChild].(type) {
-	case Empty:
-		lastNode := &LeafNode{
-			stem:      key[:31],
-			values:    make([][]byte, NodeWidth),
-			committer: n.committer,
-			depth:     n.depth + 1,
-		}
-		lastNode.values[key[31]] = value
-		n.children[nChild] = lastNode
-		lastNode.Commit()
-	case *HashedNode:
-		if resolver == nil {
-			return errInsertIntoHash
-		}
-		hash := child.commitment
-		serialized, err := resolver(hash)
-		if err != nil {
-			return fmt.Errorf("verkle tree: error resolving node %x at depth %d: %w", key, n.depth, err)
-		}
-		resolved, err := ParseNode(serialized, n.depth+1, hash)
-		if err != nil {
-			return fmt.Errorf("verkle tree: error parsing resolved node %x: %w", key, err)
-		}
-		n.children[nChild] = resolved
-		// recurse to handle the case of a LeafNode child that
-		// splits, short-cut the diff-update path as it will be
-		// called again during the recursion.
-		return n.Insert(key, value, resolver)
-	case *LeafNode:
-		// Need to add a new branch node to differentiate
-		// between two keys, if the keys are different.
-		// Otherwise, just update the key.
-		if equalPaths(child.stem, key) {
-			err = child.Insert(key, value, resolver)
-		} else {
-			// A new branch node has to be inserted. Depending
-			// on the next word in both keys, a recursion into
-			// the moved leaf node can occur.
-			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
-			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
-			n.children[nChild] = newBranch
-			newBranch.children[nextWordInExistingKey] = child
-			child.depth += 1
-
-			// Initialize the intermediate branch commitment with the value
-			// of the child that we know for sure is present. `pre` can be
-			// reused here, as is it the hash of the commitment to the node
-			// we are simply moving.
-			var poly [256]Fr
-			poly[nextWordInExistingKey] = pre
-			*newBranch.commitment = cfg.conf.Commit(poly[:])
-			poly[nextWordInExistingKey].SetZero()
-			// newBranch.commitment.Add(newBranch.commitment, &diff)
-
-			nextWordInInsertedKey := offset2key(key, n.depth+1)
-			if nextWordInInsertedKey != nextWordInExistingKey {
-				// Next word differs, so this was the last level.
-				// Insert it directly into its final slot.
-				lastNode := &LeafNode{
-					stem:      key[:31],
-					values:    make([][]byte, NodeWidth),
-					committer: n.committer,
-					depth:     n.depth + 2,
-				}
-				lastNode.values[key[31]] = value
-				newBranch.children[nextWordInInsertedKey] = lastNode
-
-				// diff-update the commitment of newBranch by adding the
-				// newly-inserted child.
-				var diff Point
-				toFr(&poly[nextWordInInsertedKey], lastNode.Commit())
-				diff = cfg.conf.Commit(poly[:])
-				newBranch.commitment.Add(newBranch.commitment, &diff)
-			} else {
-				err = newBranch.Insert(key, value, resolver)
-			}
-		}
-	case *InternalNode:
-		err = child.Insert(key, value, resolver)
-	case *StatelessNode:
-		err = child.Insert(key, value, resolver)
-	default:
-		return errUnknownNodeType
+func (n *InternalNode) cowChild(index byte) {
+	if n.cow == nil {
+		n.cow = make(map[byte]*Point)
 	}
 
-	// diff-update this commitment upon exiting this method
-	if err == nil {
-		var diff Point
-		toFr(&post, n.children[nChild].Commitment())
-		diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nChild], pre.Sub(&post, &pre))
-		n.commitment.Add(n.commitment, &diff)
+	if n.cow[index] == nil {
+		n.cow[index] = new(Point)
+		CopyPoint(n.cow[index], n.children[index].Commitment())
 	}
-
-	return err
 }
 
-// InsertStem inserts a pre-constructed node into the tree at stem stem. If the `overwrite` bit is set to true,
-// if and the inserted node is a leaf, it will attempt to merge that leaf with the one already present in the
-// trie (if such a leaf is already present). Merging a leaf and another type of node (i.e. a subtree insertion)
-// will return an error.
-func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeResolverFn, overwrite bool) error {
-	var (
-		err       error
-		pre, post Fr                          // serialized value of this node's commitment pre- and post-insertion
-		nChild    = offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
-	)
+func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
+	values := make([][]byte, NodeWidth)
+	values[key[31]] = value
+	return n.InsertStem(key[:31], values, resolver)
+}
 
-	// keep the initial value of the child commitment
-	toFr(&pre, n.children[nChild].Commitment())
+func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
+	nChild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
+	n.cowChild(nChild)
 
 	switch child := n.children[nChild].(type) {
 	case Empty:
-		node.setDepth(n.depth + 1)
-		n.children[nChild] = node
+		n.children[nChild] = NewLeafNode(stem, values)
+		n.children[nChild].setDepth(n.depth + 1)
 	case *HashedNode:
 		if resolver == nil {
 			return errInsertIntoHash
@@ -406,51 +298,37 @@ func (n *InternalNode) InsertStem(stem []byte, node VerkleNode, resolver NodeRes
 		n.children[nChild] = resolved
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.InsertStem(stem, node, resolver, overwrite)
+		return n.InsertStem(stem, values, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
-			if !overwrite {
-				return errLeafOverwrite
-			}
-			leaf, ok := node.(*LeafNode)
-			if !ok {
-				return errors.New("unsupported use case: inserting a non-leaf node into a leaf node")
-			}
-			// Merge the two leaves and recalculate the leaf's
-			// commitment.
-			child.updateMultipleLeaves(leaf.values)
-		} else {
-			// A new branch node has to be inserted. Depending
-			// on the next word in both keys, a recursion into
-			// the moved leaf node can occur.
-			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
-			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
-			n.children[nChild] = newBranch
-			newBranch.children[nextWordInExistingKey] = child
-			child.depth += 1
-
-			nextWordInInsertedKey := offset2key(stem, n.depth+1)
-			if nextWordInInsertedKey != nextWordInExistingKey {
-				// Next word differs, so this was the last level.
-				// Insert it directly into its final slot.
-				node.setDepth(n.depth + 2)
-				newBranch.children[nextWordInInsertedKey] = node
-			} else {
-				err = newBranch.InsertStem(stem, node, resolver, overwrite)
-			}
+			return child.insertMultiple(stem, values)
 		}
+
+		// A new branch node has to be inserted. Depending
+		// on the next word in both keys, a recursion into
+		// the moved leaf node can occur.
+		nextWordInExistingKey := offset2key(child.stem, n.depth+1)
+		newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
+		newBranch.cowChild(nextWordInExistingKey)
+		n.children[nChild] = newBranch
+		newBranch.children[nextWordInExistingKey] = child
+		child.depth += 1
+
+		nextWordInInsertedKey := offset2key(stem, n.depth+1)
+		if nextWordInInsertedKey == nextWordInExistingKey {
+			return newBranch.InsertStem(stem, values, resolver)
+		}
+
+		// Next word differs, so this was the last level.
+		// Insert it directly into its final slot.
+		leaf := NewLeafNode(stem, values)
+		leaf.setDepth(n.depth + 2)
+		newBranch.cowChild(nextWordInInsertedKey)
+		newBranch.children[nextWordInInsertedKey] = leaf
 	case *InternalNode:
-		err = child.InsertStem(stem, node, resolver, overwrite)
+		return child.InsertStem(stem, values, resolver)
 	default: // StatelessNode
 		return errStatelessAndStatefulMix
-	}
-
-	// diff-update this commitment upon exiting this method
-	if err == nil {
-		var diff Point
-		toFr(&post, n.children[nChild].Commit())
-		diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nChild], pre.Sub(&post, &pre))
-		n.commitment.Add(n.commitment, &diff)
 	}
 
 	return nil
@@ -463,25 +341,17 @@ func (n *InternalNode) toHashedNode() *HashedNode {
 	comm := n.commitment.Bytes()
 	return &HashedNode{comm[:]}
 }
+func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn) error {
+	values := make([][]byte, NodeWidth)
+	values[key[31]] = value
+	return n.InsertStemOrdered(key[:31], values, flush)
+}
 
-func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn) (err error) {
-	var (
-		pre, post Fr                         // serialized value of this node's commitment pre- and post-insertion
-		nChild    = offset2key(key, n.depth) // index of the child pointed by the next byte in the key
-	)
-
-	// keep the initial value of the child commitment
-	toFr(&pre, n.children[nChild].Commitment())
-
-	// diff-update this commitment upon exiting this method
-	defer func() {
-		if err == nil {
-			var diff Point
-			toFr(&post, n.children[nChild].Commitment())
-			diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nChild], pre.Sub(&post, &pre))
-			n.commitment.Add(n.commitment, &diff)
-		}
-	}()
+// InsertStemOrdered does the same thing as InsertOrdered but is meant to insert a pre-build
+// LeafNode at a given stem, instead of individual leaves.
+func (n *InternalNode) InsertStemOrdered(key []byte, values [][]byte, flush NodeFlushFn) error {
+	nChild := offset2key(key, n.depth)
+	n.cowChild(nChild)
 
 	switch child := n.children[nChild].(type) {
 	case Empty:
@@ -513,124 +383,13 @@ func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn
 		}
 
 		// NOTE: these allocations are inducing a noticeable slowdown
-		lastNode := &LeafNode{
-			stem:      key[:31],
-			values:    make([][]byte, NodeWidth),
-			committer: n.committer,
-			depth:     n.depth + 1,
-		}
-		lastNode.values[key[31]] = value
+		lastNode := NewLeafNode(key[:31], values)
+		lastNode.setDepth(n.depth + 1)
 		n.children[nChild] = lastNode
-		lastNode.Commit()
 
 		// If the node was already created, then there was at least one
 		// child. As a result, inserting this new leaf means there are
 		// now more than one child in this node.
-	case *HashedNode:
-		err = errInsertIntoHash
-	case *LeafNode:
-		// Need to add a new branch node to differentiate
-		// between two keys, if the keys are different.
-		// Otherwise, just update the key.
-		if equalPaths(child.stem, key) {
-			child.values[key[31]] = value
-		} else {
-			// A new branch node has to be inserted. Depending
-			// on the next word in both keys, a recursion into
-			// the moved leaf node can occur.
-			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
-			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
-			n.children[nChild] = newBranch
-
-			// Initialize the intermediate branch commitment with the value
-			// of the child that we know for sure is present.
-			var (
-				childComm Fr
-				diff      Point
-			)
-			toFr(&childComm, child.Commitment())
-			diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nextWordInExistingKey], &childComm)
-			newBranch.commitment.Add(newBranch.commitment, &diff)
-
-			nextWordInInsertedKey := offset2key(key, n.depth+1)
-			if nextWordInInsertedKey != nextWordInExistingKey {
-				// Directly hash the (left) node that was already
-				// inserted.
-				child.Commit()
-				if flush != nil {
-					flush(child)
-				}
-				newBranch.children[nextWordInExistingKey] = child.ToHashedNode()
-				// Next word differs, so this was the last level.
-				// Insert it directly into its final slot.
-				lastNode := &LeafNode{
-					stem:      key[:31],
-					values:    make([][]byte, NodeWidth),
-					committer: n.committer,
-					depth:     n.depth + 1,
-				}
-				lastNode.values[key[31]] = value
-				newBranch.children[nextWordInInsertedKey] = lastNode
-
-				// diff-update the commitment of newBranch by adding the
-				// newly-inserted child.
-				var lnComm Fr
-				toFr(&lnComm, lastNode.Commit())
-				diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nextWordInInsertedKey], &lnComm)
-				newBranch.commitment.Add(newBranch.commitment, &diff)
-			} else {
-				// Reinsert the leaf in order to recurse
-				newBranch.children[nextWordInExistingKey] = child
-				err = newBranch.InsertOrdered(key, value, flush)
-			}
-		}
-	case *InternalNode: // InternalNode
-		err = child.InsertOrdered(key, value, flush)
-	default: // StatelessNode
-		err = errStatelessAndStatefulMix
-	}
-	return
-}
-
-// InsertStemOrdered does the same thing as InsertOrdered but is meant to insert a pre-build
-// LeafNode at a given stem, instead of individual leaves.
-func (n *InternalNode) InsertStemOrdered(key []byte, leaf *LeafNode, flush NodeFlushFn) error {
-	n.commitment = nil
-
-	nChild := offset2key(key, n.depth)
-
-	switch child := n.children[nChild].(type) {
-	case Empty:
-		// Insert into a new subtrie, which means that the
-		// subtree directly preceding this new one, can
-		// safely be flushed.
-	searchFirstNonEmptyChild:
-		for i := int(nChild) - 1; i >= 0; i-- {
-			switch child := n.children[i].(type) {
-			case Empty:
-				continue
-			case *LeafNode:
-				child.Commit()
-				if flush != nil {
-					flush(child)
-				}
-				n.children[i] = child.ToHashedNode()
-				break searchFirstNonEmptyChild
-			case *HashedNode:
-				break searchFirstNonEmptyChild
-			case *InternalNode:
-				n.children[i].Commit()
-				if flush != nil {
-					child.Flush(flush)
-				}
-				n.children[i] = child.toHashedNode()
-				break searchFirstNonEmptyChild
-			}
-		}
-
-		leaf.depth = n.depth + 1
-		n.children[nChild] = leaf
-
 	case *HashedNode:
 		return errInsertIntoHash
 	case *LeafNode:
@@ -638,39 +397,45 @@ func (n *InternalNode) InsertStemOrdered(key []byte, leaf *LeafNode, flush NodeF
 		// between two keys, if the keys are different.
 		// Otherwise, just update the key.
 		if equalPaths(child.stem, key) {
-			return errLeafOverwrite
-		}
-
-		// A new branch node has to be inserted. Depending
-		// on the next word in both keys, a recursion into
-		// the moved leaf node can occur.
-		nextWordInExistingKey := offset2key(child.stem, n.depth+1)
-		newBranch := newInternalNodeNilCommitment(n.depth+1, n.committer).(*InternalNode)
-		n.children[nChild] = newBranch
-
-		nextWordInInsertedKey := offset2key(key, n.depth+1)
-		if nextWordInInsertedKey != nextWordInExistingKey {
-			// Directly hash the (left) node that was already
-			// inserted.
-			child.Commit()
-			if flush != nil {
-				flush(child)
-			}
-			newBranch.children[nextWordInExistingKey] = child.ToHashedNode()
-
-			// Next word differs, so this was the last level.
-			// Insert it directly into its final slot.
-			leaf.depth = n.depth + 2
-			newBranch.children[nextWordInInsertedKey] = leaf
+			// TODO when LeafNode no longer updates on insert,
+			// just set the values here.
+			child.updateMultipleLeaves(values)
 		} else {
-			// Reinsert the leaf in order to recurse
-			newBranch.children[nextWordInExistingKey] = child
-			if err := newBranch.InsertStemOrdered(key, leaf, flush); err != nil {
-				return err
+			// A new branch node has to be inserted. Depending
+			// on the next word in both keys, a recursion into
+			// the moved leaf node can occur.
+			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
+			newBranch := newInternalNode(n.depth+1, n.committer).(*InternalNode)
+			newBranch.cowChild(nextWordInExistingKey)
+			n.children[nChild] = newBranch
+
+			nextWordInInsertedKey := offset2key(key, n.depth+1)
+			if nextWordInInsertedKey != nextWordInExistingKey {
+				// Directly hash the (left) node that was already
+				// inserted. In case the commitment update should
+				// not be updated, the left node's commitment has
+				// to be calculated anyways, in order to flush it
+				// to disk.
+				child.Commit()
+				if flush != nil {
+					flush(child)
+				}
+				newBranch.children[nextWordInExistingKey] = child.ToHashedNode()
+
+				// Next word differs, so this was the last level.
+				// Insert it directly into its final slot.
+				lastNode := NewLeafNode(key[:31], values)
+				lastNode.setDepth(n.depth + 1)
+				newBranch.cowChild(nextWordInInsertedKey)
+				newBranch.children[nextWordInInsertedKey] = lastNode
+			} else {
+				// Reinsert the leaf in order to recurse
+				newBranch.children[nextWordInExistingKey] = child
+				return newBranch.InsertStemOrdered(key, values, flush)
 			}
 		}
 	case *InternalNode: // InternalNode
-		return child.InsertStemOrdered(key, leaf, flush)
+		return child.InsertStemOrdered(key, values, flush)
 	default: // StatelessNode
 		return errStatelessAndStatefulMix
 	}
@@ -696,25 +461,11 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) error {
 		if err != nil {
 			return err
 		}
-		c.Commit()
 		n.children[nChild] = c
 		return n.Delete(key, resolver)
 	default:
-		var old, new Fr
-		toFr(&old, child.Commitment())
-		err := child.Delete(key, resolver)
-		if err == nil {
-			toFr(&new, child.Commitment())
-			new.Sub(&new, &old)
-			var diff, newComm Point
-			// copy the point so any external references
-			// are still holding the old value
-			CopyPoint(&newComm, n.commitment)
-			diff.ScalarMul(&cfg.conf.SRSPrecompPoints.SRS[nChild], &new)
-			newComm.Add(n.commitment, &diff)
-			n.commitment = &newComm
-		}
-		return err
+		n.cowChild(nChild)
+		return child.Delete(key, resolver)
 	}
 }
 
@@ -784,7 +535,6 @@ func (n *InternalNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		c.Commit()
 		n.children[nChild] = c
 
 		return c.Get(k, getter)
@@ -807,20 +557,27 @@ func (n *InternalNode) Commitment() *Point {
 }
 
 func (n *InternalNode) Commit() *Point {
-	emptyChildren := 0
 	poly := make([]Fr, NodeWidth)
-	for idx, child := range n.children {
-		switch child.(type) {
-		case Empty:
-			emptyChildren++
-		default:
-			toFr(&poly[idx], child.Commit())
+	emptyChildren := 256
+
+	if len(n.cow) != 0 {
+		for idx, comm := range n.cow {
+			emptyChildren--
+			var pre Fr
+			// TODO use kev's multimaptofield
+			toFr(&pre, comm)
+			// child in cow, so its child has also been
+			// modified, so call `Commit()` instead of
+			// `Commitment()`
+			toFr(&poly[idx], n.children[idx].Commit())
+			poly[idx].Sub(&poly[idx], &pre)
 		}
+		n.cow = nil
+
+		n.commitment.Add(n.commitment, n.committer.CommitToPoly(poly, emptyChildren))
+		return n.commitment
 	}
 
-	// All the coefficients have been computed, evaluate the polynomial,
-	// serialize and hash the resulting point - this is the commitment.
-	n.commitment = n.committer.CommitToPoly(poly, emptyChildren)
 	return n.commitment
 }
 
@@ -946,20 +703,15 @@ func (n *InternalNode) Copy() VerkleNode {
 		CopyPoint(ret.commitment, n.commitment)
 	}
 
-	return ret
-}
-
-// clearCache sets the commitment field of node
-// and all of its children (recursively) to nil.
-func (n *InternalNode) clearCache() {
-	for _, c := range n.children {
-		in, ok := c.(*InternalNode)
-		if !ok {
-			continue
+	if n.cow != nil {
+		ret.cow = make(map[byte]*Point)
+		for k, v := range n.cow {
+			ret.cow[k] = new(Point)
+			CopyPoint(ret.cow[k], v)
 		}
-		in.clearCache()
 	}
-	n.commitment = nil
+
+	return ret
 }
 
 func (n *InternalNode) toDot(parent, path string) string {
@@ -1007,12 +759,19 @@ func (n *LeafNode) ToHashedNode() *HashedNode {
 }
 
 func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {
+	values := make([][]byte, NodeWidth)
+	values[k[31]] = value
+	return n.insertMultiple(k[:31], values)
+}
+
+func (n *LeafNode) insertMultiple(k []byte, values [][]byte) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
 		return errInsertIntoOtherStem
 	}
 
-	n.updateLeaf(k[31], value)
+	n.updateMultipleLeaves(values)
+
 	return nil
 }
 
@@ -1046,9 +805,9 @@ func (n *LeafNode) updateC(index byte, c *Point, oldc *Fr) {
 
 func (n *LeafNode) updateCn(index byte, value []byte, c *Point) {
 	var (
-		old, new [2]Fr
-		diff     Point
-		poly     [256]Fr
+		old, newH [2]Fr
+		diff      Point
+		poly      [256]Fr
 	)
 
 	// Optimization idea:
@@ -1058,16 +817,16 @@ func (n *LeafNode) updateCn(index byte, value []byte, c *Point) {
 	// but the computation time should be faster as one doesn't need to
 	// compute 1 - 1 mod N.
 	leafToComms(old[:], n.values[index])
-	leafToComms(new[:], value)
+	leafToComms(newH[:], value)
 
-	new[0].Sub(&new[0], &old[0])
-	poly[2*(index%128)] = new[0]
+	newH[0].Sub(&newH[0], &old[0])
+	poly[2*(index%128)] = newH[0]
 	diff = cfg.conf.Commit(poly[:])
 	poly[2*(index%128)].SetZero()
 	c.Add(c, &diff)
 
-	new[1].Sub(&new[1], &old[1])
-	poly[2*(index%128)+1] = new[1]
+	newH[1].Sub(&newH[1], &old[1])
+	poly[2*(index%128)+1] = newH[1]
 	diff = cfg.conf.Commit(poly[:])
 	c.Add(c, &diff)
 }
@@ -1099,7 +858,7 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 				n.updateCn(byte(i), v, c2)
 			}
 
-			n.values[i] = v[:]
+			n.values[i] = v
 		}
 	}
 
@@ -1158,19 +917,6 @@ func (n *LeafNode) Commitment() *Point {
 }
 
 func (n *LeafNode) Commit() *Point {
-	count := 0
-	var poly, c1poly, c2poly [256]Fr
-	poly[0].SetUint64(1)
-	StemFromBytes(&poly[1], n.stem)
-
-	count = fillSuffixTreePoly(c1poly[:], n.values[:128])
-	n.c1 = n.committer.CommitToPoly(c1poly[:], 256-count)
-	toFr(&poly[2], n.c1)
-	count = fillSuffixTreePoly(c2poly[:], n.values[128:])
-	n.c2 = n.committer.CommitToPoly(c2poly[:], 256-count)
-	toFr(&poly[3], n.c2)
-
-	n.commitment = n.committer.CommitToPoly(poly[:], 252)
 	return n.commitment
 }
 
@@ -1432,5 +1178,6 @@ func setBit(bitlist []byte, index int) {
 }
 
 func ToDot(root VerkleNode) string {
+	root.Commit()
 	return fmt.Sprintf("digraph D {\n%s}", root.toDot("", ""))
 }

--- a/tree.go
+++ b/tree.go
@@ -696,6 +696,7 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 	children := make([]byte, 0, (len(commitments)+nhashed)*32)
 
 	bytecomms := banderwagon.ElementsToBytes(commitments)
+	consumed := 0
 	for i := 0; i < NodeWidth; i++ {
 		if bit(bitlist[:], i) {
 			// if a child is present and is a hash, add its
@@ -703,7 +704,8 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 			if bit(hashlist[:], i) {
 				children = append(children, n.children[i].(*HashedNode).commitment...)
 			} else {
-				children = append(children, bytecomms[i][:]...)
+				children = append(children, bytecomms[consumed][:]...)
+				consumed++
 			}
 		}
 	}


### PR DESCRIPTION
This PR is a major refactor that is needed to introduce various optimizations for the block replay:

Optimization:

 * Use a "copy-on-write" approach in `InternalNode` : the commitment of a node is updated from only the commitments of its children that were written to with `Insert` or `Delete`. That computation is intended to be performed once, at the end of a block creation/verification.
 * Use `MapToScalarField` to speed up some stuff, although this is already covered by #291 so it won't be integrated here.

Refactoring:

  * `StatelessNode` and `InternalNode` no longer use diff-insert, as multiple children will typically be updated during block execution
  * `LeafNode` uses diff-insert, as insertion into this type of nodes typically happen only once per block
  * `LeafNodeCommit` therefore no longer perform any calculation
  * `InternalNode.Commit` on the other hand, will only recompute the commitment contribution from the nodes that were written to.
  * Simplify the code by merging `Insert` and `InsertStem`, as well as `InsertOrdered` and `InsertStemOrdered`.

This PR shaves roughly 20% of the execution time, compared to `master`.