### PR TITLE
hashednode: cache commitment resolution

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -118,7 +118,7 @@ func CreateInternalNode(bitlist []byte, raw []byte, depth byte, comm []byte) (*I
 		return nil, ErrInvalidNodeEncoding
 	}
 	for i, index := range indices {
-		n.children[index] = &HashedNode{raw[i*32 : (i+1)*32]}
+		n.children[index] = &HashedNode{commitment: raw[i*32 : (i+1)*32]}
 	}
 	n.commitment = new(Point)
 	n.commitment.SetBytesTrusted(comm)

--- a/hashednode.go
+++ b/hashednode.go
@@ -31,8 +31,8 @@ import (
 )
 
 type HashedNode struct {
-	commitment []byte
-	resolution *Point
+	commitment  []byte
+	cachedPoint *Point
 }
 
 func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -55,11 +55,11 @@ func (n *HashedNode) Commit() *Point {
 	if n.commitment == nil {
 		panic("nil commitment")
 	}
-	if n.resolution == nil {
-		n.resolution = new(Point)
-		n.resolution.SetBytesTrusted(n.commitment)
+	if n.cachedPoint == nil {
+		n.cachedPoint = new(Point)
+		n.cachedPoint.SetBytesTrusted(n.commitment)
 	}
-	return n.resolution
+	return n.cachedPoint
 }
 
 func (n *HashedNode) Commitment() *Point {

--- a/hashednode.go
+++ b/hashednode.go
@@ -32,6 +32,7 @@ import (
 
 type HashedNode struct {
 	commitment []byte
+	resolution *Point
 }
 
 func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -54,9 +55,11 @@ func (n *HashedNode) Commit() *Point {
 	if n.commitment == nil {
 		panic("nil commitment")
 	}
-	c := new(Point)
-	c.SetBytesTrusted(n.commitment)
-	return c
+	if n.resolution == nil {
+		n.resolution = new(Point)
+		n.resolution.SetBytesTrusted(n.commitment)
+	}
+	return n.resolution
 }
 
 func (n *HashedNode) Commitment() *Point {
@@ -92,8 +95,8 @@ func (*HashedNode) setDepth(_ byte) {
 }
 
 func (n *HashedNode) Hash() *Fr {
-	h := new(Fr)
-	c := n.Commitment()
-	toFr(h, c)
-	return h
+	comm := n.Commitment()
+	hash := new(Fr)
+	toFr(hash, comm)
+	return hash
 }

--- a/stateless.go
+++ b/stateless.go
@@ -250,7 +250,7 @@ func (n *StatelessNode) InsertAtStem(stem []byte, values [][]byte, resolver Node
 			return nil
 		}
 
-		n.children[nChild] = &HashedNode{unresolved}
+		n.children[nChild] = &HashedNode{commitment: unresolved}
 		// fallthrough to hash resolution
 	}
 
@@ -774,7 +774,7 @@ func (n *StatelessNode) setDepth(d byte) {
 
 func (n *StatelessNode) ToHashedNode() *HashedNode {
 	b := n.commitment.Bytes()
-	return &HashedNode{b[:]}
+	return &HashedNode{commitment: b[:]}
 }
 
 func (n *StatelessNode) Flush(flush NodeFlushFn) {

--- a/tree.go
+++ b/tree.go
@@ -333,7 +333,7 @@ func (n *InternalNode) toHashedNode() *HashedNode {
 		panic("nil commitment")
 	}
 	comm := n.commitment.Bytes()
-	return &HashedNode{comm[:]}
+	return &HashedNode{commitment: comm[:]}
 }
 func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn) error {
 	values := make([][]byte, NodeWidth)
@@ -774,7 +774,7 @@ func (n *LeafNode) ToHashedNode() *HashedNode {
 		panic("nil commitment")
 	}
 	comm := n.commitment.Bytes()
-	return &HashedNode{comm[:]}
+	return &HashedNode{commitment: comm[:]}
 }
 
 func (n *LeafNode) Insert(k []byte, value []byte, _ NodeResolverFn) error {


### PR DESCRIPTION
Cache resolved commitment in `HashedNode{resolution:...}` to prevent the potential for duplicate deserialization. Fixes #307.