### PR TITLE
Batch toFr in proof calculation & go-ipa update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/gballet/go-verkle
 
 go 1.18
 
-require github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808
+require github.com/crate-crypto/go-ipa v0.0.0-20230202201618-2e6f5bfc5401
 
 require golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/gballet/go-verkle
 
 go 1.18
 
-require github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc
+require github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808
 
 require golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc h1:mtR7MuscVeP/s0/ERWA2uSr5QOrRYy1pdvZqG1USfXI=
-github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
+github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808 h1:zzhDwbi4il5p8+g4WjfX4nWaIo9A61bBS6Ltj8AkExg=
+github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808 h1:zzhDwbi4il5p8+g4WjfX4nWaIo9A61bBS6Ltj8AkExg=
-github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
+github.com/crate-crypto/go-ipa v0.0.0-20230202201618-2e6f5bfc5401 h1:TSXRL74LZ7R2xWOI1M0mz9E56PiPKGlSw0drgR8g7CE=
+github.com/crate-crypto/go-ipa v0.0.0-20230202201618-2e6f5bfc5401/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tree.go
+++ b/tree.go
@@ -1042,8 +1042,7 @@ func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte
 	// Initialize the top-level polynomial with 1 + stem + C1 + C2
 	poly[0].SetUint64(1)
 	StemFromBytes(&poly[1], n.stem)
-	toFr(&poly[2], n.c1)
-	toFr(&poly[3], n.c2)
+	toFrMultiple([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2})
 
 	// First pass: add top-level elements first
 	var hasC1, hasC2 bool


### PR DESCRIPTION
This PR batches multiple improvements:
- Update to the latest go-ipa which has an improvement regarding memory allocations.
- In proof calculations, leverage the batched-Fr calculations which improves performance.
