### PR TITLE
serialization: manage uncompressed point serialization for trusted sources

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,10 +32,11 @@ import (
 const (
 	NodeWidth         = 256
 	NodeBitWidth byte = 8
+	StemSize          = 31
 )
 
 func equalPaths(key1, key2 []byte) bool {
-	return bytes.Equal(key1[:31], key2[:31])
+	return bytes.Equal(key1[:StemSize], key2[:StemSize])
 }
 
 // offset2key extracts the n bits of a key that correspond to the

--- a/encoding.go
+++ b/encoding.go
@@ -44,7 +44,7 @@ func bit(bitlist []byte, nr int) bool {
 var serializedPayloadTooShort = errors.New("verkle payload is too short")
 
 func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
-	if len(serialized) < 1+31+SerializedAffinePointSize {
+	if len(serialized) < 1+StemSize+SerializedAffinePointSize {
 		return nil, serializedPayloadTooShort
 	}
 	switch serialized[0] {
@@ -58,7 +58,7 @@ func ParseNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 }
 
 func ParseStatelessNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
-	if len(serialized) < 1+31+SerializedAffinePointSize {
+	if len(serialized) < 1+StemSize+SerializedAffinePointSize {
 		return nil, serializedPayloadTooShort
 	}
 	switch serialized[0] {
@@ -73,9 +73,9 @@ func ParseStatelessNode(serialized []byte, depth byte, comm []byte) (VerkleNode,
 
 func parseLeafNode(serialized []byte, depth byte, comm []byte) (VerkleNode, error) {
 	var values [NodeWidth][]byte
-	offset := 1 + 31 + 32 + 2*SerializedAffinePointSize
+	offset := 1 + StemSize + 32 + 2*SerializedAffinePointSize
 	for i := 0; i < NodeWidth; i++ {
-		if bit(serialized[1+31:1+31+32], i) {
+		if bit(serialized[1+StemSize:1+StemSize+32], i) {
 			if offset+32 > len(serialized) {
 				return nil, fmt.Errorf("verkle payload is too short, need at least %d and only have %d, payload = %x (%w)", offset+32, len(serialized), serialized, serializedPayloadTooShort)
 			}
@@ -86,12 +86,12 @@ func parseLeafNode(serialized []byte, depth byte, comm []byte) (VerkleNode, erro
 	if NodeWidth != len(values) {
 		return nil, fmt.Errorf("invalid number of nodes in decoded child expected %d, got %d", NodeWidth, len(values))
 	}
-	ln := NewLeafNodeWithNoComms(serialized[1:1+31], values[:])
+	ln := NewLeafNodeWithNoComms(serialized[1:1+StemSize], values[:])
 	ln.setDepth(depth)
 	ln.c1 = new(Point)
-	ln.c1.SetBytesTrusted(serialized[1+31+32 : 1+31+32+SerializedAffinePointSize])
+	ln.c1.SetBytesTrusted(serialized[1+StemSize+32 : 1+StemSize+32+SerializedAffinePointSize])
 	ln.c2 = new(Point)
-	ln.c2.SetBytesTrusted(serialized[1+31+32+SerializedAffinePointSize : 1+31+32+2*SerializedAffinePointSize])
+	ln.c2.SetBytesTrusted(serialized[1+StemSize+32+SerializedAffinePointSize : 1+StemSize+32+2*SerializedAffinePointSize])
 	ln.commitment = new(Point)
 	ln.commitment.SetBytesTrusted(comm)
 	return ln, nil

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -19,7 +19,7 @@ func TestLeafStemLength(t *testing.T) {
 		t.Fatal(err)
 	}
 	// RLP_type + Stem + bitset + 2-commitments
-	if len(ser) != 1+31+NodeWidth/8+2*SerializedAffinePointSize {
+	if len(ser) != 1+StemSize+NodeWidth/8+2*SerializedAffinePointSize {
 		t.Fatalf("invalid serialization when the stem is longer than 31 bytes: %x (%d bytes)", ser, len(ser))
 	}
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -18,7 +18,8 @@ func TestLeafStemLength(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ser) != 128 {
+	// RLP_type + Stem + bitset + 2-commitments
+	if len(ser) != 1+31+NodeWidth/8+2*SerializedAffinePointSize {
 		t.Fatalf("invalid serialization when the stem is longer than 31 bytes: %x (%d bytes)", ser, len(ser))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.18
 require github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc
 
 require golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
+
+replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20230131214742-21080f1193c2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc h1:mtR7MuscVeP/s0/ERWA2uSr5QOrRYy1pdvZqG1USfXI=
-github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
+github.com/jsign/go-ipa v0.0.0-20230131214742-21080f1193c2 h1:hP293epjjgbsvY6J1lURldpb8b+p2mHwAJz0mceHBqw=
+github.com/jsign/go-ipa v0.0.0-20230131214742-21080f1193c2/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/ipa.go
+++ b/ipa.go
@@ -31,9 +31,12 @@ import (
 )
 
 type (
-	Fr    = fr.Element
-	Point = banderwagon.Element
+	Fr                    = fr.Element
+	Point                 = banderwagon.Element
+	SerializedAffinePoint = banderwagon.SerializedAffinePoint
 )
+
+const SerializedAffinePointSize = banderwagon.SerializedAffinePointSize
 
 func CopyFr(dst, src *Fr) {
 	copy(dst[:], src[:])

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -65,8 +65,8 @@ func MakeVerkleMultiProof(root VerkleNode, keys [][]byte, keyvals map[string][]b
 	var vals [][]byte
 	for _, k := range keys {
 		// TODO at the moment, do not include the post-data
-		//val, _ := root.Get(k, nil)
-		//vals = append(vals, val)
+		// val, _ := root.Get(k, nil)
+		// vals = append(vals, val)
 		vals = append(vals, keyvals[string(k)])
 	}
 
@@ -138,7 +138,7 @@ func SerializeProof(proof *Proof) ([]byte, []KeyValuePair, error) {
 
 	binary.Write(&bufProof, binary.LittleEndian, uint32(len(proof.Cs)))
 	for _, C := range proof.Cs {
-		serialized := C.Bytes()
+		serialized := C.BytesCompressed()
 		_, err := bufProof.Write(serialized[:])
 		if err != nil {
 			return nil, nil, err
@@ -215,7 +215,7 @@ func DeserializeProof(proofSerialized []byte, keyvals []KeyValuePair) (*Proof, e
 			return nil, err
 		}
 
-		if err := commitment.SetBytes(commitmentBytes); err != nil {
+		if err := commitment.SetBytesCompressed(commitmentBytes); err != nil {
 			return nil, err
 		}
 

--- a/stateless.go
+++ b/stateless.go
@@ -78,9 +78,7 @@ func NewStateless() *StatelessNode {
 }
 
 func NewStatelessWithCommitment(point *Point) *StatelessNode {
-	var (
-		xfr Fr
-	)
+	var xfr Fr
 	toFr(&xfr, point)
 	return &StatelessNode{
 		children:   make(map[byte]VerkleNode),
@@ -417,7 +415,6 @@ func (n *StatelessNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 	child := n.children[nChild]
 	if child == nil {
 		if n.unresolved[nChild] == nil {
-
 			return nil, nil
 		}
 
@@ -486,9 +483,7 @@ func (n *StatelessNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][
 	)
 
 	if len(n.values) == 0 {
-		var (
-			groups = groupKeys(keys, n.depth)
-		)
+		groups := groupKeys(keys, n.depth)
 
 		for _, group := range groups {
 			childIdx := offset2key(group[0], n.depth)
@@ -741,7 +736,7 @@ func (n *StatelessNode) toDot(parent, path string) string {
 	me := fmt.Sprintf("internal%s", path)
 	var ret string
 	if len(n.values) != 0 {
-		var c1bytes, c2bytes [32]byte
+		var c1bytes, c2bytes SerializedAffinePoint
 		if n.c1 != nil {
 			c1bytes = n.c1.Bytes()
 		}

--- a/tree.go
+++ b/tree.go
@@ -801,7 +801,7 @@ func (n *InternalNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]
 
 func (n *InternalNode) Serialize() ([]byte, error) {
 	var (
-		bitlist, hashlist [32]byte
+		bitlist, hashlist [NodeWidth / 8]byte
 		nhashed           int // number of children who are hashed nodes
 	)
 	commitments := make([]*Point, 0, NodeWidth)
@@ -820,7 +820,7 @@ func (n *InternalNode) Serialize() ([]byte, error) {
 			}
 		}
 	}
-	children := make([]byte, 0, (len(commitments)+nhashed)*32)
+	children := make([]byte, 0, (len(commitments)+nhashed)*SerializedAffinePointSize)
 
 	bytecomms := banderwagon.ElementsToBytes(commitments)
 	consumed := 0
@@ -1255,7 +1255,7 @@ func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte
 }
 
 func (n *LeafNode) Serialize() ([]byte, error) {
-	var bitlist [32]byte
+	var bitlist [NodeWidth / 8]byte
 	children := make([]byte, 0, NodeWidth*32)
 	for i, v := range n.values {
 		if v != nil {

--- a/tree_test.go
+++ b/tree_test.go
@@ -106,7 +106,6 @@ func TestInsertTwoLeavesLastLevel(t *testing.T) {
 	if !bytes.Equal(leaf.values[0], testValue) {
 		t.Fatalf("did not find correct value in trie %x != %x", testValue, leaf.values[0])
 	}
-
 }
 
 func TestGetTwoLeaves(t *testing.T) {
@@ -413,6 +412,7 @@ func TestDeleteUnequalPath(t *testing.T) {
 		t.Fatalf("didn't catch the deletion of non-existing key, err =%v", err)
 	}
 }
+
 func TestDeleteResolve(t *testing.T) {
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
@@ -719,7 +719,7 @@ func isLeafEqual(a, b *LeafNode) bool {
 
 func TestGetResolveFromHash(t *testing.T) {
 	var count uint
-	var dummyError = errors.New("dummy")
+	dummyError := errors.New("dummy")
 	var serialized []byte
 	getter := func([]byte) ([]byte, error) {
 		count++
@@ -813,7 +813,7 @@ func TestInsertIntoHashedNode(t *testing.T) {
 		t.Fatalf("error detecting a decoding error after resolution: %v", err)
 	}
 
-	var randomResolverError = errors.New("'clef' was mispronounced")
+	randomResolverError := errors.New("'clef' was mispronounced")
 	// Check that the proper error is raised if the resolver returns an error
 	erroringResolver := func(h []byte) ([]byte, error) {
 		return nil, randomResolverError
@@ -879,7 +879,6 @@ func TestLeafToCommsLessThan16(*testing.T) {
 }
 
 func TestGetProofItemsNoPoaIfStemPresent(t *testing.T) {
-
 	root := New()
 	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
 
@@ -925,7 +924,7 @@ func TestWithRustCompatibility(t *testing.T) {
 		}
 	}
 
-	commBytes := root.Commit().Bytes()
+	commBytes := root.Commit().BytesCompressed()
 	if !bytes.Equal(commBytes[:], testAccountRootCommRust) {
 		t.Fatalf("rust and golang impl are not compatible rust=%x, go=%x", testAccountRootCommRust, commBytes)
 	}


### PR DESCRIPTION
This PR is an experimental change to avoid persisting compressed EC points in the resolver. 
This will allow parsing nodes to use less CPU since no `Y` coordinate should be calculated from `X`.

While doing this change, I switched multiple places with "magic numbers" with more explicit calculations and constants.

This PR is using a [custom go-ipa version](https://github.com/crate-crypto/go-ipa/pull/33).