### PR TITLE
fix: stateless PoA stem insertion in TreeFromProof

### DIFF
--- a/hashednode.go
+++ b/hashednode.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 )
 
+var ErrReadFromHashedNode = errors.New("can not read from a hash node")
+
 type HashedNode struct {
 	commitment  []byte
 	cachedPoint *Point
@@ -48,7 +50,7 @@ func (*HashedNode) Delete([]byte, NodeResolverFn) error {
 }
 
 func (*HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {
-	return nil, errors.New("can not read from a hash node")
+	return nil, ErrReadFromHashedNode
 }
 
 func (n *HashedNode) Commit() *Point {

--- a/stateless.go
+++ b/stateless.go
@@ -340,6 +340,9 @@ func (n *StatelessNode) insertStem(path []byte, stemInfo stemInfo, comms []*Poin
 			// nothing to do
 		case extStatusAbsentOther:
 			// insert poa stem
+			serialized := comms[0].Bytes()
+			n.children[path[0]] = &HashedNode{commitment: serialized[:], cachedPoint: comms[0]}
+			comms = comms[1:]
 		case extStatusPresent:
 			// insert stem
 			newchild := NewStatelessWithCommitment(comms[0])


### PR DESCRIPTION
This is the first part of a fix to gballet/go-ethereum#162 : when a proof-of-absence stem was present, it was not included in the rebuilt tree.

There is still an issue with this, since `GetProofItems` will break as a result.