### PR TITLE
Add two new serializations formats for internal nodes

### DIFF
--- a/stateless.go
+++ b/stateless.go
@@ -78,9 +78,7 @@ func NewStateless() *StatelessNode {
 }
 
 func NewStatelessWithCommitment(point *Point) *StatelessNode {
-	var (
-		xfr Fr
-	)
+	var xfr Fr
 	toFr(&xfr, point)
 	return &StatelessNode{
 		children:   make(map[byte]VerkleNode),
@@ -417,7 +415,6 @@ func (n *StatelessNode) Get(k []byte, getter NodeResolverFn) ([]byte, error) {
 	child := n.children[nChild]
 	if child == nil {
 		if n.unresolved[nChild] == nil {
-
 			return nil, nil
 		}
 
@@ -486,9 +483,7 @@ func (n *StatelessNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][
 	)
 
 	if len(n.values) == 0 {
-		var (
-			groups = groupKeys(keys, n.depth)
-		)
+		groups := groupKeys(keys, n.depth)
 
 		for _, group := range groups {
 			childIdx := offset2key(group[0], n.depth)
@@ -686,7 +681,7 @@ func (n *StatelessNode) Serialize() ([]byte, error) {
 		}
 	}
 
-	return append(append([]byte{internalRLPType}, bitlist[:]...), children...), nil
+	return append(append([]byte{internalRLPTypeBitmap}, bitlist[:]...), children...), nil
 }
 
 func (n *StatelessNode) Copy() VerkleNode {


### PR DESCRIPTION
This PR introduces two new serializations for internal nodes, so we have three ones now:
- "Bitmap": is the only one we have had up to now; we use a 32-byte bitmap to mark the index of the serialized children.
- "Full": doesn't have a 32-byte bitmap or any overhead since it's assumed **all** 256 children are non-zero.
- "Offset": doesn't use a 32-byte bitlist. But encodes each child as `<1-byte-offset><children-0><1-byte-offset><children-1>...` (e.g: `<12><32-byte-compressed-point><24><32-byte-compressed-point>` means that the first child is index 12, and second index 24). 1-byte for the offset is enough since the index is at most 255.

The strategy to decide which serialization to use is the following:
- If all the children are non-zero, use "Full" serialization.
- If the number of non-zero children is <32, use "Offset" serialization.
- If none of the above holds, use the usual "Bitmap" serialization.

There's a different idea to try, too: doing the "inverse inclusion" (i.e: mark which children **aren't** set).

This PR doesn't touch leaf node serialization.