### PR TITLE
README: fix precomp file referencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Node width is set to 256 children.
 
 ### Setup
 
-Download the [precomputed Lagrange point file](https://github.com/gballet/go-verkle/releases/download/banderwagonv2/precomp) available in [this release](https://github.com/gballet/go-verkle/releases/tag/banderwagonv2), and place it in the directory that you will run the program from. While not strictly required (it will be generated upon startup if not present), this will save a lot of startup time when running the tests.
+Download the precomputed Lagrange point file from the [latest release](https://github.com/gballet/go-verkle/releases), and place it in the directory that you will run the program from. While not strictly required (it will be generated upon startup if not present), this will save a lot of startup time when running the tests.
 
 ### Running the tests
 


### PR DESCRIPTION
The current readme was still directed to an old release. I changed a bit the sentence to avoid remembering to update this link.
If we want to still keep the concrete link in the README, I can change it (no strong opinion on that).