### PR TITLE
Cache EmptyCode hash point in polynomial commitment

### DIFF
--- a/config_ipa.go
+++ b/config_ipa.go
@@ -26,9 +26,24 @@
 package verkle
 
 import (
+	"encoding/hex"
 	"os"
 
 	"github.com/crate-crypto/go-ipa/ipa"
+)
+
+// emptyCodeHashPoint is a cached point that is used to represent an empty code hash.
+// This value is initialized once in GetConfig().
+var (
+	emptyCodeHashPoint           *Point
+	emptyCodeHashFirstHalfValue  Fr
+	emptyCodeHashSecondHalfValue Fr
+)
+
+const (
+	codeHashVectorPosition     = 3 // Defined by the spec.
+	emptyCodeHashFirstHalfIdx  = codeHashVectorPosition * 2
+	emptyCodeHashSecondHalfIdx = emptyCodeHashFirstHalfIdx + 1
 )
 
 type IPAConfig struct {
@@ -38,7 +53,23 @@ type IPAConfig struct {
 type Config = IPAConfig
 
 func (ipac *IPAConfig) CommitToPoly(poly []Fr, _ int) *Point {
+	containsEmptyCodeHash := len(poly) >= emptyCodeHashSecondHalfIdx &&
+		poly[emptyCodeHashFirstHalfIdx].Equal(&emptyCodeHashFirstHalfValue) &&
+		poly[emptyCodeHashSecondHalfIdx].Equal(&emptyCodeHashSecondHalfValue)
+
+	if containsEmptyCodeHash {
+		poly[emptyCodeHashFirstHalfIdx] = FrZero
+		poly[emptyCodeHashSecondHalfIdx] = FrZero
+	}
+
 	ret := ipac.conf.Commit(poly)
+
+	if containsEmptyCodeHash {
+		ret.Add(&ret, emptyCodeHashPoint)
+		poly[emptyCodeHashFirstHalfIdx] = emptyCodeHashFirstHalfValue
+		poly[emptyCodeHashSecondHalfIdx] = emptyCodeHashSecondHalfValue
+	}
+
 	return &ret
 }
 
@@ -54,7 +85,7 @@ func GetConfig() *Config {
 			serialized, err := ipacfg.SRSPrecompPoints.SerializeSRSPrecomp()
 			if err != nil {
 				panic("error writing serialized precomputed Lagrange points:" + err.Error())
-			} else if err = os.WriteFile(precompFileName, serialized, 0666); err != nil {
+			} else if err = os.WriteFile(precompFileName, serialized, 0o666); err != nil {
 				panic("error saving the precomp: " + err.Error())
 			}
 		} else {
@@ -65,12 +96,24 @@ func GetConfig() *Config {
 			ipacfg = ipa.NewIPASettingsWithSRSPrecomp(srs)
 		}
 		cfg = &IPAConfig{conf: ipacfg}
+
+		emptyHashCode, _ := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+		values := make([][]byte, 256)
+		values[codeHashVectorPosition] = emptyHashCode[:]
+		var c1poly [256]Fr
+		fillSuffixTreePoly(c1poly[:], values[:128])
+		emptyCodeHashPoint = cfg.CommitToPoly(c1poly[:], 0)
+		emptyCodeHashFirstHalfValue = c1poly[emptyCodeHashFirstHalfIdx]
+		emptyCodeHashSecondHalfValue = c1poly[emptyCodeHashSecondHalfIdx]
+
 	}
 	return cfg
 }
 
-var FrZero Fr
-var FrOne Fr
+var (
+	FrZero Fr
+	FrOne  Fr
+)
 
 func init() {
 	FrZero.SetZero()

--- a/config_ipa.go
+++ b/config_ipa.go
@@ -85,7 +85,7 @@ func GetConfig() *Config {
 			serialized, err := ipacfg.SRSPrecompPoints.SerializeSRSPrecomp()
 			if err != nil {
 				panic("error writing serialized precomputed Lagrange points:" + err.Error())
-			} else if err = os.WriteFile(precompFileName, serialized, 0o666); err != nil {
+			} else if err = os.WriteFile(precompFileName, serialized, 0666); err != nil {
 				panic("error saving the precomp: " + err.Error())
 			}
 		} else {

--- a/config_ipa.go
+++ b/config_ipa.go
@@ -83,7 +83,7 @@ func GetConfig() *Config {
 
 		emptyHashCode, _ := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 		values := make([][]byte, NodeWidth)
-		values[CodeHashVectorPosition] = emptyHashCode[:]
+		values[CodeHashVectorPosition] = emptyHashCode
 		var c1poly [NodeWidth]Fr
 		fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
 		EmptyCodeHashPoint = cfg.CommitToPoly(c1poly[:], 0)

--- a/config_ipa.go
+++ b/config_ipa.go
@@ -98,10 +98,10 @@ func GetConfig() *Config {
 		cfg = &IPAConfig{conf: ipacfg}
 
 		emptyHashCode, _ := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
-		values := make([][]byte, 256)
+		values := make([][]byte, NodeWidth)
 		values[codeHashVectorPosition] = emptyHashCode[:]
-		var c1poly [256]Fr
-		fillSuffixTreePoly(c1poly[:], values[:128])
+		var c1poly [NodeWidth]Fr
+		fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
 		emptyCodeHashPoint = cfg.CommitToPoly(c1poly[:], 0)
 		emptyCodeHashFirstHalfValue = c1poly[emptyCodeHashFirstHalfIdx]
 		emptyCodeHashSecondHalfValue = c1poly[emptyCodeHashSecondHalfIdx]

--- a/config_ipa.go
+++ b/config_ipa.go
@@ -32,18 +32,18 @@ import (
 	"github.com/crate-crypto/go-ipa/ipa"
 )
 
-// emptyCodeHashPoint is a cached point that is used to represent an empty code hash.
+// EmptyCodeHashPoint is a cached point that is used to represent an empty code hash.
 // This value is initialized once in GetConfig().
 var (
-	emptyCodeHashPoint           *Point
-	emptyCodeHashFirstHalfValue  Fr
-	emptyCodeHashSecondHalfValue Fr
+	EmptyCodeHashPoint           *Point
+	EmptyCodeHashFirstHalfValue  Fr
+	EmptyCodeHashSecondHalfValue Fr
 )
 
 const (
-	codeHashVectorPosition     = 3 // Defined by the spec.
-	emptyCodeHashFirstHalfIdx  = codeHashVectorPosition * 2
-	emptyCodeHashSecondHalfIdx = emptyCodeHashFirstHalfIdx + 1
+	CodeHashVectorPosition     = 3 // Defined by the spec.
+	EmptyCodeHashFirstHalfIdx  = CodeHashVectorPosition * 2
+	EmptyCodeHashSecondHalfIdx = EmptyCodeHashFirstHalfIdx + 1
 )
 
 type IPAConfig struct {
@@ -53,23 +53,7 @@ type IPAConfig struct {
 type Config = IPAConfig
 
 func (ipac *IPAConfig) CommitToPoly(poly []Fr, _ int) *Point {
-	containsEmptyCodeHash := len(poly) >= emptyCodeHashSecondHalfIdx &&
-		poly[emptyCodeHashFirstHalfIdx].Equal(&emptyCodeHashFirstHalfValue) &&
-		poly[emptyCodeHashSecondHalfIdx].Equal(&emptyCodeHashSecondHalfValue)
-
-	if containsEmptyCodeHash {
-		poly[emptyCodeHashFirstHalfIdx] = FrZero
-		poly[emptyCodeHashSecondHalfIdx] = FrZero
-	}
-
 	ret := ipac.conf.Commit(poly)
-
-	if containsEmptyCodeHash {
-		ret.Add(&ret, emptyCodeHashPoint)
-		poly[emptyCodeHashFirstHalfIdx] = emptyCodeHashFirstHalfValue
-		poly[emptyCodeHashSecondHalfIdx] = emptyCodeHashSecondHalfValue
-	}
-
 	return &ret
 }
 
@@ -99,12 +83,12 @@ func GetConfig() *Config {
 
 		emptyHashCode, _ := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 		values := make([][]byte, NodeWidth)
-		values[codeHashVectorPosition] = emptyHashCode[:]
+		values[CodeHashVectorPosition] = emptyHashCode[:]
 		var c1poly [NodeWidth]Fr
 		fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
-		emptyCodeHashPoint = cfg.CommitToPoly(c1poly[:], 0)
-		emptyCodeHashFirstHalfValue = c1poly[emptyCodeHashFirstHalfIdx]
-		emptyCodeHashSecondHalfValue = c1poly[emptyCodeHashSecondHalfIdx]
+		EmptyCodeHashPoint = cfg.CommitToPoly(c1poly[:], 0)
+		EmptyCodeHashFirstHalfValue = c1poly[EmptyCodeHashFirstHalfIdx]
+		EmptyCodeHashSecondHalfValue = c1poly[EmptyCodeHashSecondHalfIdx]
 
 	}
 	return cfg

--- a/tree_test.go
+++ b/tree_test.go
@@ -1210,10 +1210,10 @@ func TestEmptyHashCodeCachedPoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to decode empty hash code: %v", err)
 	}
-	values := make([][]byte, 256)
-	values[codeHashVectorPosition] = emptyHashCode[:]
-	var c1poly [256]Fr
-	fillSuffixTreePoly(c1poly[:], values[:128])
+	values := make([][]byte, NodeWidth)
+	values[codeHashVectorPosition] = emptyHashCode
+	var c1poly [NodeWidth]Fr
+	fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
 	p := cfg.CommitToPoly(c1poly[:], 0)
 
 	// Compare the result (which used the cached point) with the expected result which was

--- a/tree_test.go
+++ b/tree_test.go
@@ -1169,7 +1169,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 	}
 }
 
-func BenchmarkEmptyHashCode(b *testing.B) {
+func BenchmarkEmptyHashCodeCachedPoint(b *testing.B) {
 	_ = GetConfig()
 	const codeHashVectorPosition = 3 // Defined by the spec.
 
@@ -1199,5 +1199,31 @@ func BenchmarkEmptyHashCode(b *testing.B) {
 				cfg.CommitToPoly(c1poly[:], 0)
 			}
 		})
+	}
+}
+
+func TestEmptyHashCodeCachedPoint(t *testing.T) {
+	_ = GetConfig()
+
+	// Calculate the polynomial commitment of a vector only with the empty code hash.
+	emptyHashCode, err := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+	if err != nil {
+		t.Fatalf("failed to decode empty hash code: %v", err)
+	}
+	values := make([][]byte, 256)
+	values[codeHashVectorPosition] = emptyHashCode[:]
+	var c1poly [256]Fr
+	fillSuffixTreePoly(c1poly[:], values[:128])
+	p := cfg.CommitToPoly(c1poly[:], 0)
+
+	// Compare the result (which used the cached point) with the expected result which was
+	// calculated by a previous version of the library that didn't use a cached point.
+	correctPointHex, _ := hex.DecodeString("02cc97eafa76087f079d21792f051561d5f14212d75df1e812b8214bc044bb0f")
+	var correctPoint Point
+	if err := correctPoint.SetBytes(correctPointHex); err != nil {
+		t.Fatal(err)
+	}
+	if !p.Equal(&correctPoint) {
+		t.Fatalf("expected %v, got %v", correctPoint, p)
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -1168,3 +1168,24 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 		t.Fatal("deserialized proof didn't verify")
 	}
 }
+
+func BenchmarkEmptyHashCode(b *testing.B) {
+	_ = GetConfig()
+
+	const codeHashVectorPosition = 3 // Defined by the spec.
+	emptyHashCode, err := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+	if err != nil {
+		b.Fatalf("failed to decode empty hash code: %v", err)
+	}
+
+	values := make([][]byte, 256)
+	values[codeHashVectorPosition] = emptyHashCode[:]
+	var c1poly [256]Fr
+	fillSuffixTreePoly(c1poly[:], values[:128])
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg.CommitToPoly(c1poly[:], 0)
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1190,13 +1190,11 @@ func BenchmarkEmptyHashCodeCachedPoint(b *testing.B) {
 
 			values := make([][]byte, 256)
 			values[codeHashVectorPosition] = emptyHashCode[:]
-			var c1poly [256]Fr
-			fillSuffixTreePoly(c1poly[:], values[:128])
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				cfg.CommitToPoly(c1poly[:], 0)
+				_ = NewLeafNode(zeroKeyTest, values)
 			}
 		})
 	}
@@ -1211,10 +1209,8 @@ func TestEmptyHashCodeCachedPoint(t *testing.T) {
 		t.Fatalf("failed to decode empty hash code: %v", err)
 	}
 	values := make([][]byte, NodeWidth)
-	values[codeHashVectorPosition] = emptyHashCode
-	var c1poly [NodeWidth]Fr
-	fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
-	p := cfg.CommitToPoly(c1poly[:], 0)
+	values[CodeHashVectorPosition] = emptyHashCode
+	ln := NewLeafNode(zeroKeyTest, values)
 
 	// Compare the result (which used the cached point) with the expected result which was
 	// calculated by a previous version of the library that didn't use a cached point.
@@ -1223,7 +1219,7 @@ func TestEmptyHashCodeCachedPoint(t *testing.T) {
 	if err := correctPoint.SetBytes(correctPointHex); err != nil {
 		t.Fatal(err)
 	}
-	if !p.Equal(&correctPoint) {
-		t.Fatalf("expected %v, got %v", correctPoint, p)
+	if !ln.c1.Equal(&correctPoint) {
+		t.Fatalf("expected %v, got %v", correctPoint, ln.c1)
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -1189,7 +1189,7 @@ func BenchmarkEmptyHashCodeCachedPoint(b *testing.B) {
 			}
 
 			values := make([][]byte, 256)
-			values[codeHashVectorPosition] = emptyHashCode[:]
+			values[codeHashVectorPosition] = emptyHashCode
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/tree_test.go
+++ b/tree_test.go
@@ -1121,7 +1121,7 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 		"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
 		"0000000000000000000000000000000000000000000000000000000000000000",
 	}
-	var initialVals = map[string][]byte{}
+	initialVals := map[string][]byte{}
 
 	for i, s := range valStrings {
 		if s == "" {
@@ -1171,21 +1171,33 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 
 func BenchmarkEmptyHashCode(b *testing.B) {
 	_ = GetConfig()
-
 	const codeHashVectorPosition = 3 // Defined by the spec.
-	emptyHashCode, err := hex.DecodeString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
-	if err != nil {
-		b.Fatalf("failed to decode empty hash code: %v", err)
+
+	testCases := []struct {
+		name     string
+		hashCode string
+	}{
+		{name: "emptyHash", hashCode: "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"},
+		{name: "nonEmptyHash", hashCode: "4242420186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"},
 	}
 
-	values := make([][]byte, 256)
-	values[codeHashVectorPosition] = emptyHashCode[:]
-	var c1poly [256]Fr
-	fillSuffixTreePoly(c1poly[:], values[:128])
+	for _, test := range testCases {
+		b.Run(test.name, func(b *testing.B) {
+			emptyHashCode, err := hex.DecodeString(test.hashCode)
+			if err != nil {
+				b.Fatalf("failed to decode empty hash code: %v", err)
+			}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		cfg.CommitToPoly(c1poly[:], 0)
+			values := make([][]byte, 256)
+			values[codeHashVectorPosition] = emptyHashCode[:]
+			var c1poly [256]Fr
+			fillSuffixTreePoly(c1poly[:], values[:128])
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cfg.CommitToPoly(c1poly[:], 0)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR implements an optimization suggested by Guillaume around empty code hashes.

The rationale is that EOA addresses must store an “empty code” hash; thus, a reasonable amount of “account headers” will have this particular value in the “code hash” slot.

I decided to do this optimization in this repository since go-ipa is a more general cryptographic library. This kind of optimization is closer to exploiting a fact about the domain, not a “cryptography” optimization.

The way this works is quite simple: in the init phase, the empty code hash is precomputed. The overhead is 7 microseconds and 64 bytes of RAM, so it sounds light to be considered part of a precomp file and introduce complexity (which involves a separate repo BTW).

I also included a new benchmark to compare the optimized case vs any other case:

```bash
goos: linux
goarch: amd64
pkg: github.com/gballet/go-verkle
cpu: AMD Ryzen 7 3800XT 8-Core Processor            
BenchmarkEmptyHashCodeCachedPoint/emptyHash-16              2518101               471.5 ns/op            96 B/op          1 allocs/op
BenchmarkEmptyHashCodeCachedPoint/nonEmptyHash-16            160844              7073 ns/op              96 B/op          1 allocs/op
PASS
ok      github.com/gballet/go-verkle    4.185s
```

This is benchmarking a 256-vector with all zero elements but the code hash slots. The speedup is significant but can be made irrelevant by a vector with other nonzero values. Saying it differently, we’re saving 6 microseconds per “account header” computation; that’s a better way to think about it.

I ran our current replay benchmark with this optimization and didn’t see a relevant difference in total running time. So, those CPU savings are there, but in the grand scheme of things, these 7 microseconds per account header didn’t seem to be noticeable (e.g: db compactions have some order of magnitude more difference in wallclock time).

In any case, I think it’s a reasonable optimization to keep since it isn’t too complex and might become more impactful in maybe other scenarios which are more strictly CPU bound than importing a chain or doing a migration.

To be sure about correctness, an extra test compares the result using the current cached point optimization against a result obtained from current `master`.