### PR TITLE
remove all references to InsertOrdered

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -35,10 +35,6 @@ func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
 	return errDirectInsertIntoEmptyNode
 }
 
-func (e Empty) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {
-	return e.Insert(key, value, nil)
-}
-
 func (Empty) Delete([]byte, NodeResolverFn) error {
 	return errors.New("cant delete an empty node")
 }

--- a/empty_test.go
+++ b/empty_test.go
@@ -33,10 +33,6 @@ func TestEmptyFuncs(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error when inserting into empty")
 	}
-	err = e.InsertOrdered(zeroKeyTest, zeroKeyTest, nil)
-	if err == nil {
-		t.Fatal("got nil error when inserting into empty")
-	}
 	err = e.Delete(zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from empty")

--- a/hashednode.go
+++ b/hashednode.go
@@ -39,10 +39,6 @@ func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
-func (*HashedNode) InsertOrdered([]byte, []byte, NodeFlushFn) error {
-	return errInsertIntoHash
-}
-
 func (*HashedNode) Delete([]byte, NodeResolverFn) error {
 	return errors.New("cant delete a hashed node in-place")
 }

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -33,10 +33,6 @@ func TestHashedNodeFuncs(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error when inserting into a hashed node")
 	}
-	err = e.InsertOrdered(zeroKeyTest, zeroKeyTest, nil)
-	if err == nil {
-		t.Fatal("got nil error when inserting into a hashed node")
-	}
 	err = e.Delete(zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from a hashed node")

--- a/stateless.go
+++ b/stateless.go
@@ -391,10 +391,6 @@ func (n *StatelessNode) insertValue(key, value []byte) error {
 	return nil
 }
 
-func (*StatelessNode) InsertOrdered([]byte, []byte, NodeFlushFn) error {
-	return errNotSupportedInStateless
-}
-
 // Delete writes the value `0` at `key` since verkle trees need to distinguish
 // between a node that used to be present and was then deleted, and a node that
 // was never present.

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -172,14 +172,6 @@ func TestStatelessInsertLeafIntoInternal(t *testing.T) {
 	}
 }
 
-func TestStatelessInsertOrdered(t *testing.T) {
-	root := NewStateless()
-	err := root.InsertOrdered(zeroKeyTest, fourtyKeyTest, nil)
-	if err != errNotSupportedInStateless {
-		t.Fatalf("got the wrong error: expected %v, got %v", errNotSupportedInStateless, err)
-	}
-}
-
 func TestStatelessCopy(t *testing.T) {
 	root := NewStateless()
 	root.Insert(zeroKeyTest, fourtyKeyTest, nil)

--- a/tree.go
+++ b/tree.go
@@ -56,12 +56,6 @@ type VerkleNode interface {
 	// Insert or Update value into the tree
 	Insert([]byte, []byte, NodeResolverFn) error
 
-	// Insert "à la" Stacktrie. Same thing as insert, except that
-	// values are expected to be ordered, and the commitments and
-	// hashes for each subtrie are computed online, as soon as it
-	// is clear that no more values will be inserted in there.
-	InsertOrdered([]byte, []byte, NodeFlushFn) error
-
 	// Delete a leaf with the given key
 	Delete([]byte, NodeResolverFn) error
 
@@ -383,107 +377,6 @@ func (n *InternalNode) toHashedNode() *HashedNode {
 	return &HashedNode{commitment: comm[:]}
 }
 
-func (n *InternalNode) InsertOrdered(key []byte, value []byte, flush NodeFlushFn) error {
-	values := make([][]byte, NodeWidth)
-	values[key[31]] = value
-	return n.InsertStemOrdered(key[:31], values, flush)
-}
-
-// InsertStemOrdered does the same thing as InsertOrdered but is meant to insert a pre-build
-// LeafNode at a given stem, instead of individual leaves.
-func (n *InternalNode) InsertStemOrdered(key []byte, values [][]byte, flush NodeFlushFn) error {
-	nChild := offset2key(key, n.depth)
-	n.cowChild(nChild)
-
-	switch child := n.children[nChild].(type) {
-	case Empty:
-		// Insert into a new subtrie, which means that the
-		// subtree directly preceding this new one, can
-		// safely be flushed.
-	searchFirstNonEmptyChild:
-		for i := int(nChild) - 1; i >= 0; i-- {
-			switch child := n.children[i].(type) {
-			case Empty:
-				continue
-			case *LeafNode:
-				child.Commit()
-				if flush != nil {
-					flush(child)
-				}
-				n.children[i] = child.ToHashedNode()
-				break searchFirstNonEmptyChild
-			case *HashedNode:
-				break searchFirstNonEmptyChild
-			case *InternalNode:
-				n.children[i].Commit()
-				if flush != nil {
-					child.Flush(flush)
-				}
-				n.children[i] = child.toHashedNode()
-				break searchFirstNonEmptyChild
-			}
-		}
-
-		// NOTE: these allocations are inducing a noticeable slowdown
-		lastNode := NewLeafNode(key[:31], values)
-		lastNode.setDepth(n.depth + 1)
-		n.children[nChild] = lastNode
-
-		// If the node was already created, then there was at least one
-		// child. As a result, inserting this new leaf means there are
-		// now more than one child in this node.
-	case *HashedNode:
-		return errInsertIntoHash
-	case *LeafNode:
-		// Need to add a new branch node to differentiate
-		// between two keys, if the keys are different.
-		// Otherwise, just update the key.
-		if equalPaths(child.stem, key) {
-			// TODO when LeafNode no longer updates on insert,
-			// just set the values here.
-			child.updateMultipleLeaves(values)
-		} else {
-			// A new branch node has to be inserted. Depending
-			// on the next word in both keys, a recursion into
-			// the moved leaf node can occur.
-			nextWordInExistingKey := offset2key(child.stem, n.depth+1)
-			newBranch := newInternalNode(n.depth + 1).(*InternalNode)
-			newBranch.cowChild(nextWordInExistingKey)
-			n.children[nChild] = newBranch
-
-			nextWordInInsertedKey := offset2key(key, n.depth+1)
-			if nextWordInInsertedKey != nextWordInExistingKey {
-				// Directly hash the (left) node that was already
-				// inserted. In case the commitment update should
-				// not be updated, the left node's commitment has
-				// to be calculated anyways, in order to flush it
-				// to disk.
-				child.Commit()
-				if flush != nil {
-					flush(child)
-				}
-				newBranch.children[nextWordInExistingKey] = child.ToHashedNode()
-
-				// Next word differs, so this was the last level.
-				// Insert it directly into its final slot.
-				lastNode := NewLeafNode(key[:31], values)
-				lastNode.setDepth(n.depth + 1)
-				newBranch.cowChild(nextWordInInsertedKey)
-				newBranch.children[nextWordInInsertedKey] = lastNode
-			} else {
-				// Reinsert the leaf in order to recurse
-				newBranch.children[nextWordInExistingKey] = child
-				return newBranch.InsertStemOrdered(key, values, flush)
-			}
-		}
-	case *InternalNode: // InternalNode
-		return child.InsertStemOrdered(key, values, flush)
-	default: // StatelessNode
-		return errStatelessAndStatefulMix
-	}
-	return nil
-}
-
 func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) error {
 	nChild := offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
@@ -537,6 +430,11 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 		// Skip non-internal nodes
 		c, ok := child.(*InternalNode)
 		if !ok {
+			if c, ok := child.(*LeafNode); ok {
+				c.Commit()
+				flush(c)
+				n.children[i] = c.ToHashedNode()
+			}
 			continue
 		}
 
@@ -1020,13 +918,6 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 		toFrMultiple([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2})
 		n.updateC(c2Idx, frs[0], frs[1])
 	}
-}
-
-func (n *LeafNode) InsertOrdered(key []byte, value []byte, _ NodeFlushFn) error {
-	// In the previous version, this value used to be flushed on insert.
-	// This is no longer the case, as all values at the last level get
-	// flushed at the same time.
-	return n.Insert(key, value, nil)
 }
 
 func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) error {


### PR DESCRIPTION
The `InsertOrdered` model does not work as well for the verkle conversion, as it doesn't take advantage of the per-level deserialization. This will make the process slower. It also makes things more difficult if the stateful and stateless code are to be merged: that method would have to be supported in a stateless context. Finally, it also contains a lot of duplicated code compared to `Insert`, which is wasteful.

This PR:
 * Removes all references to `InsertOrdered`;
 * In unit tests where it was used to enforce the hashing of nodes, `FlushAtDepth` is used. Note that the semantics of `FlushAtDepth` are changed to also hash leaf nodes. This would make things more expensive if we were to use it for the conversion method, but this method is falling out of favor;
 * It also improves the ToDot unit test in a stateful context.