### PR TITLE
tree: fix global pointer mutation

### DIFF
--- a/config_ipa.go
+++ b/config_ipa.go
@@ -35,7 +35,7 @@ import (
 // EmptyCodeHashPoint is a cached point that is used to represent an empty code hash.
 // This value is initialized once in GetConfig().
 var (
-	EmptyCodeHashPoint           *Point
+	EmptyCodeHashPoint           Point
 	EmptyCodeHashFirstHalfValue  Fr
 	EmptyCodeHashSecondHalfValue Fr
 )
@@ -86,7 +86,7 @@ func GetConfig() *Config {
 		values[CodeHashVectorPosition] = emptyHashCode
 		var c1poly [NodeWidth]Fr
 		fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
-		EmptyCodeHashPoint = cfg.CommitToPoly(c1poly[:], 0)
+		EmptyCodeHashPoint = *cfg.CommitToPoly(c1poly[:], 0)
 		EmptyCodeHashFirstHalfValue = c1poly[EmptyCodeHashFirstHalfIdx]
 		EmptyCodeHashSecondHalfValue = c1poly[EmptyCodeHashSecondHalfIdx]
 

--- a/tree.go
+++ b/tree.go
@@ -208,14 +208,13 @@ func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
 		c1poly[EmptyCodeHashFirstHalfIdx].Equal(&EmptyCodeHashFirstHalfValue) &&
 		c1poly[EmptyCodeHashSecondHalfIdx].Equal(&EmptyCodeHashSecondHalfValue)
 	if containsEmptyCodeHash {
-		// We start c1 with the empty code hash point.
-		c1 = EmptyCodeHashPoint
 		// Clear out values of the cached point.
 		c1poly[EmptyCodeHashFirstHalfIdx] = FrZero
 		c1poly[EmptyCodeHashSecondHalfIdx] = FrZero
 		// Calculate the remaining part of c1 and add to the base value.
 		partialc1 := cfg.CommitToPoly(c1poly[:], NodeWidth-count-2)
-		c1.Add(c1, partialc1)
+		c1 = new(Point)
+		c1.Add(&EmptyCodeHashPoint, partialc1)
 	} else {
 		c1 = cfg.CommitToPoly(c1poly[:], NodeWidth-count)
 	}


### PR DESCRIPTION
This PR fixes a bug in an unwanted pointer copy and mutation of a global var which should be read only.