### PR TITLE
use nil in InternalNode to turn it into a stateless node

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -36,6 +36,7 @@ var (
 	errNotSupportedInStateless = errors.New("not implemented in stateless")
 	errInsertIntoOtherStem     = errors.New("insert splits a stem where it should not happen")
 	errStatelessAndStatefulMix = errors.New("a stateless node should not be found in a stateful tree")
+	errMissingNodeInStateless  = errors.New("trying to access a node that is missing from the stateless view")
 )
 
 const (

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -250,6 +250,7 @@ func TestStatelessToDot(t *testing.T) {
 	}
 }
 
+// TODO move this to proof_test
 func TestStatelessDeserialize(t *testing.T) {
 	root := New()
 	for _, k := range [][]byte{zeroKeyTest, oneKeyTest, fourtyKeyTest, ffx32KeyTest} {
@@ -278,11 +279,11 @@ func TestStatelessDeserialize(t *testing.T) {
 		t.Fatalf("differing root commitments %x != %x", droot.Commitment().Bytes(), root.Commitment().Bytes())
 	}
 
-	if !Equal(droot.(*StatelessNode).children[0].(*StatelessNode).commitment, root.(*InternalNode).children[0].Commit()) {
+	if !Equal(droot.(*InternalNode).children[0].(*LeafNode).commitment, root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 
-	if !Equal(droot.(*StatelessNode).children[64].Commit(), root.(*InternalNode).children[64].Commit()) {
+	if !Equal(droot.(*InternalNode).children[64].Commit(), root.(*InternalNode).children[64].Commit()) {
 		t.Fatal("differing commitment for child #64")
 	}
 }
@@ -313,13 +314,14 @@ func TestStatelessDeserializeMissginChildNode(t *testing.T) {
 	if !Equal(droot.Commit(), root.Commit()) {
 		t.Fatal("differing root commitments")
 	}
-
-	if !Equal(droot.(*StatelessNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
+	t.Log(ToDot(root))
+	t.Log(ToDot(droot))
+	if !Equal(droot.(*InternalNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 
-	if droot.(*StatelessNode).children[64] != nil {
-		t.Fatal("non-nil child #64")
+	if droot.(*InternalNode).children[64] != nil {
+		t.Fatalf("non-nil child #64: %v", droot.(*InternalNode).children[64])
 	}
 }
 
@@ -351,7 +353,7 @@ func TestStatelessDeserializeDepth2(t *testing.T) {
 		t.Fatal("differing root commitments")
 	}
 
-	if !Equal(droot.(*StatelessNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
+	if !Equal(droot.(*InternalNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 }


### PR DESCRIPTION
This is a first attempt at getting rid of `StatlessNode` in order to simplify the code and be able to use all the optimizations that were made recently, in a statless context.

Currently the idea is to use `nil` to signal that a subtree of an `InternalNode` is missing from the stateless view.

I think this should be replaced with `type StatelessSubtree struct{}` or something like that, for safety. I'll sleep on it.