### PR TITLE
deleting from a missing node is a noop

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,6 @@ import "errors"
 
 var (
 	errInsertIntoHash          = errors.New("trying to insert into hashed node")
-	errDeleteNonExistent       = errors.New("trying to delete non-existent leaf")
 	errDeleteHash              = errors.New("trying to delete from a hashed subtree")
 	errReadFromInvalid         = errors.New("trying to read from an invalid child")
 	errSerializeHashedNode     = errors.New("trying to serialize a hashed internal node")

--- a/tree.go
+++ b/tree.go
@@ -516,7 +516,7 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) error {
 	nChild := offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
 	case Empty:
-		return errDeleteNonExistent
+		return nil
 	case *HashedNode:
 		if resolver == nil {
 			return errDeleteHash
@@ -1073,7 +1073,7 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
-		return errDeleteNonExistent
+		return nil
 	}
 
 	var zero [32]byte

--- a/tree_test.go
+++ b/tree_test.go
@@ -275,8 +275,8 @@ func TestDeleteNonExistent(t *testing.T) {
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
-	if err := tree.Delete(key3, nil); err != errDeleteNonExistent {
-		t.Error("should fail to delete non-existent key")
+	if err := tree.Delete(key3, nil); err != nil {
+		t.Error("should not fail when deleting a non-existent key")
 	}
 }
 
@@ -354,8 +354,8 @@ func TestDeleteUnequalPath(t *testing.T) {
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.Commit()
 
-	if err := tree.Delete(key2, nil); err != errDeleteNonExistent {
-		t.Fatalf("didn't catch the deletion of non-existing key, err =%v", err)
+	if err := tree.Delete(key2, nil); err != nil {
+		t.Fatalf("errored during the deletion of non-existing key, err =%v", err)
 	}
 }
 


### PR DESCRIPTION
This is probably not the root cause why the translated replay fails, but deleting a location that does not exist should work as it does in the MPT.