### PR TITLE
fix: set nodes known to be absent to Empty, to differentiate from unknown nodes

### DIFF
--- a/proof_test.go
+++ b/proof_test.go
@@ -637,8 +637,8 @@ func TestStatelessDeserializeMissginChildNode(t *testing.T) {
 		t.Fatal("differing commitment for child #0")
 	}
 
-	if droot.(*InternalNode).children[64] != UnknownNode(struct{}{}) {
-		t.Fatalf("non-nil child #64: %v", droot.(*InternalNode).children[64])
+	if droot.(*InternalNode).children[64] != Empty(struct{}{}) {
+		t.Fatalf("non-empty child #64: %v", droot.(*InternalNode).children[64])
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -409,7 +409,10 @@ func (n *InternalNode) CreatePath(path []byte, stemInfo stemInfo, comms []*Point
 	if len(path) == 1 {
 		switch stemInfo.stemType & 3 {
 		case extStatusAbsentEmpty:
-			// nothing to do
+			// Set child to Empty so that, in a stateless context,
+			// a node known to be absent is differentiated from an
+			// unknown node.
+			n.children[path[0]] = Empty{}
 		case extStatusAbsentOther:
 			// insert poa stem
 		case extStatusPresent:


### PR DESCRIPTION
A reconstructed stateless tree would not set its (known) absent values to `Empty` but to `Unknown` which caused `GetProofItems` to error. Set the reconstructed 'absent' tree to `Empty` to fix this problem.