### PR TITLE
implement proper node deletion in tree

### DIFF
--- a/empty.go
+++ b/empty.go
@@ -35,8 +35,8 @@ func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
 	return errDirectInsertIntoEmptyNode
 }
 
-func (Empty) Delete([]byte, NodeResolverFn) error {
-	return errors.New("cant delete an empty node")
+func (Empty) Delete([]byte, NodeResolverFn) (error, bool) {
+	return errors.New("cant delete an empty node"), false
 }
 
 func (Empty) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/empty.go
+++ b/empty.go
@@ -35,8 +35,8 @@ func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
 	return errDirectInsertIntoEmptyNode
 }
 
-func (Empty) Delete([]byte, NodeResolverFn) (error, bool) {
-	return errors.New("cant delete an empty node"), false
+func (Empty) Delete([]byte, NodeResolverFn) (bool, error) {
+	return false, errors.New("cant delete an empty node")
 }
 
 func (Empty) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/empty_test.go
+++ b/empty_test.go
@@ -33,7 +33,7 @@ func TestEmptyFuncs(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error when inserting into empty")
 	}
-	err, _ = e.Delete(zeroKeyTest, nil)
+	_, err = e.Delete(zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from empty")
 	}

--- a/empty_test.go
+++ b/empty_test.go
@@ -33,7 +33,7 @@ func TestEmptyFuncs(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error when inserting into empty")
 	}
-	err = e.Delete(zeroKeyTest, nil)
+	err, _ = e.Delete(zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from empty")
 	}

--- a/hashednode.go
+++ b/hashednode.go
@@ -39,8 +39,8 @@ func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
-func (*HashedNode) Delete([]byte, NodeResolverFn) (error, bool) {
-	return errors.New("cant delete a hashed node in-place"), false
+func (*HashedNode) Delete([]byte, NodeResolverFn) (bool, error) {
+	return false, errors.New("cant delete a hashed node in-place")
 }
 
 func (*HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/hashednode.go
+++ b/hashednode.go
@@ -39,8 +39,8 @@ func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
-func (*HashedNode) Delete([]byte, NodeResolverFn) error {
-	return errors.New("cant delete a hashed node in-place")
+func (*HashedNode) Delete([]byte, NodeResolverFn) (error, bool) {
+	return errors.New("cant delete a hashed node in-place"), false
 }
 
 func (*HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -34,7 +34,7 @@ func TestHashedNodeFuncs(t *testing.T) {
 	if err != errInsertIntoHash {
 		t.Fatal("got nil error when inserting into a hashed node")
 	}
-	err, _ = e.Delete(zeroKeyTest, nil)
+	_, err = e.Delete(zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from a hashed node")
 	}

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -34,7 +34,7 @@ func TestHashedNodeFuncs(t *testing.T) {
 	if err != errInsertIntoHash {
 		t.Fatal("got nil error when inserting into a hashed node")
 	}
-	err = e.Delete(zeroKeyTest, nil)
+	err, _ = e.Delete(zeroKeyTest, nil)
 	if err == nil {
 		t.Fatal("got nil error when deleting from a hashed node")
 	}

--- a/tree.go
+++ b/tree.go
@@ -1167,7 +1167,11 @@ func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) (bool, error) {
 		n.commitment.Sub(n.commitment, cfg.CommitToPoly(poly[:], 0))
 
 		// Clear the corresponding commitment
-		cn.SetBytes(nil)
+		if k[31] < 128 {
+			n.c1 = nil
+		} else {
+			n.c2 = nil
+		}
 
 		return false, nil
 	}

--- a/tree.go
+++ b/tree.go
@@ -542,7 +542,7 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) (bool, error)
 		}
 
 		// delete the entire child if instructed to by
-		// the recursive algorightm.
+		// the recursive algorigthm.
 		if del {
 			n.children[nChild] = Empty{}
 

--- a/tree.go
+++ b/tree.go
@@ -536,14 +536,14 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) (error, bool)
 		return n.Delete(key, resolver)
 	default:
 		n.cowChild(nChild)
-		err, delete := child.Delete(key, resolver)
+		err, del := child.Delete(key, resolver)
 		if err != nil {
 			return err, false
 		}
 
 		// delete the entire child if instructed to by
 		// the recursive algorightm.
-		if delete {
+		if del {
 			n.children[nChild] = Empty{}
 
 			// Check if all children are gone, if so
@@ -1123,15 +1123,15 @@ func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) (error, bool) {
 				isCnempty = false
 				isCempty = false
 				break
-			} else {
-				// i and k[31] were in a different subtree,
-				// so all we can say at this stage, is that
-				// the whole tree isn't empty.
-				// TODO if i < 128, then k[31] >= 128 and
-				// we could skip to 128, but that's an
-				// optimization for later.
-				isCempty = false
 			}
+
+			// i and k[31] were in a different subtree,
+			// so all we can say at this stage, is that
+			// the whole tree isn't empty.
+			// TODO if i < 128, then k[31] >= 128 and
+			// we could skip to 128, but that's an
+			// optimization for later.
+			isCempty = false
 		}
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -317,21 +317,26 @@ func TestDeletePrune(t *testing.T) {
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 
-	var hashPostKey2, hashPostKey4 Point
+	var hashPostKey2, hashPostKey4, completeTreeHash Point
 	CopyPoint(&hashPostKey2, tree.Commit())
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.Insert(key4, fourtyKeyTest, nil)
 	CopyPoint(&hashPostKey4, tree.Commit())
 	tree.Insert(key5, fourtyKeyTest, nil)
-	tree.Commit()
+	CopyPoint(&completeTreeHash, tree.Commit()) // hash when the tree has received all its keys
 
 	// Delete key5.
 	if _, err := tree.Delete(key5, nil); err != nil {
 		t.Error(err)
 	}
 	postHash := tree.Commit()
-	// The post deletion hash should be different from the post key4 hash.
-	if Equal(&hashPostKey4, postHash) {
+	// Check that the deletion updated the root hash and that it's not
+	// the same as the pre-deletion hash.
+	if Equal(&completeTreeHash, postHash) {
+		t.Fatalf("deletion did not update the hash %x == %x", completeTreeHash, postHash)
+	}
+	// The post deletion hash should be the same as the post key4 hash.
+	if !Equal(&hashPostKey4, postHash) {
 		t.Error("deleting leaf #5 resulted in unexpected tree")
 	}
 	res, err := tree.Get(key5, nil)

--- a/tree_test.go
+++ b/tree_test.go
@@ -239,10 +239,14 @@ func TestCachedCommitment(t *testing.T) {
 
 func TestDelLeaf(t *testing.T) {
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
+	key1p, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000001")  // same Cn group as key1
+	key1pp, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000081") // Other Cn group as key1
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
+	tree.Insert(key1p, fourtyKeyTest, nil)
+	tree.Insert(key1pp, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 	var init Point
 	CopyPoint(&init, tree.Commit())
@@ -261,6 +265,28 @@ func TestDelLeaf(t *testing.T) {
 	}
 
 	res, err := tree.Get(key3, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) > 0 {
+		t.Error("leaf hasnt been deleted")
+	}
+
+	if err, _ := tree.Delete(key1pp, nil); err != nil {
+		t.Fatal(err)
+	}
+	res, err = tree.Get(key1pp, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) > 0 {
+		t.Error("leaf hasnt been deleted")
+	}
+
+	if err, _ := tree.Delete(key1p, nil); err != nil {
+		t.Fatal(err)
+	}
+	res, err = tree.Get(key1p, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -252,7 +252,7 @@ func TestDelLeaf(t *testing.T) {
 	CopyPoint(&init, tree.Commit())
 
 	tree.Insert(key3, fourtyKeyTest, nil)
-	if err, _ := tree.Delete(key3, nil); err != nil {
+	if _, err := tree.Delete(key3, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -272,7 +272,7 @@ func TestDelLeaf(t *testing.T) {
 		t.Error("leaf hasnt been deleted")
 	}
 
-	if err, _ := tree.Delete(key1pp, nil); err != nil {
+	if _, err := tree.Delete(key1pp, nil); err != nil {
 		t.Fatal(err)
 	}
 	res, err = tree.Get(key1pp, nil)
@@ -283,7 +283,7 @@ func TestDelLeaf(t *testing.T) {
 		t.Error("leaf hasnt been deleted")
 	}
 
-	if err, _ := tree.Delete(key1p, nil); err != nil {
+	if _, err := tree.Delete(key1p, nil); err != nil {
 		t.Fatal(err)
 	}
 	res, err = tree.Get(key1p, nil)
@@ -302,7 +302,7 @@ func TestDeleteNonExistent(t *testing.T) {
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
-	if err, _ := tree.Delete(key3, nil); err != nil {
+	if _, err := tree.Delete(key3, nil); err != nil {
 		t.Error("should not fail when deleting a non-existent key")
 	}
 }
@@ -326,7 +326,7 @@ func TestDeletePrune(t *testing.T) {
 	tree.Commit()
 
 	// Delete key5.
-	if err, _ := tree.Delete(key5, nil); err != nil {
+	if _, err := tree.Delete(key5, nil); err != nil {
 		t.Error(err)
 	}
 	postHash := tree.Commit()
@@ -343,10 +343,10 @@ func TestDeletePrune(t *testing.T) {
 	}
 
 	// Delete key4 and key3.
-	if err, _ := tree.Delete(key4, nil); err != nil {
+	if _, err := tree.Delete(key4, nil); err != nil {
 		t.Error(err)
 	}
-	if err, _ := tree.Delete(key3, nil); err != nil {
+	if _, err := tree.Delete(key3, nil); err != nil {
 		t.Error(err)
 	}
 	postHash = tree.Commit()
@@ -376,7 +376,7 @@ func TestDeleteHash(t *testing.T) {
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.(*InternalNode).FlushAtDepth(0, func(vn VerkleNode) {})
 	tree.Commit()
-	if err, _ := tree.Delete(key2, nil); err != errDeleteHash {
+	if _, err := tree.Delete(key2, nil); err != errDeleteHash {
 		t.Fatalf("did not report the correct error while deleting from a hash: %v", err)
 	}
 }
@@ -390,7 +390,7 @@ func TestDeleteUnequalPath(t *testing.T) {
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.Commit()
 
-	if err, _ := tree.Delete(key2, nil); err != nil {
+	if _, err := tree.Delete(key2, nil); err != nil {
 		t.Fatalf("errored during the deletion of non-existing key, err =%v", err)
 	}
 }
@@ -411,7 +411,7 @@ func TestDeleteResolve(t *testing.T) {
 	tree.Commit()
 
 	var called bool
-	err, _ := tree.Delete(key2, func(comm []byte) ([]byte, error) {
+	_, err := tree.Delete(key2, func(comm []byte) ([]byte, error) {
 		called = true
 		for _, node := range savedNodes {
 			c := node.Commit().Bytes()

--- a/tree_test.go
+++ b/tree_test.go
@@ -248,7 +248,7 @@ func TestDelLeaf(t *testing.T) {
 	CopyPoint(&init, tree.Commit())
 
 	tree.Insert(key3, fourtyKeyTest, nil)
-	if err := tree.Delete(key3, nil); err != nil {
+	if err, _ := tree.Delete(key3, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -276,7 +276,7 @@ func TestDeleteNonExistent(t *testing.T) {
 	tree := New()
 	tree.Insert(key1, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
-	if err := tree.Delete(key3, nil); err != nil {
+	if err, _ := tree.Delete(key3, nil); err != nil {
 		t.Error("should not fail when deleting a non-existent key")
 	}
 }
@@ -300,7 +300,7 @@ func TestDeletePrune(t *testing.T) {
 	tree.Commit()
 
 	// Delete key5.
-	if err := tree.Delete(key5, nil); err != nil {
+	if err, _ := tree.Delete(key5, nil); err != nil {
 		t.Error(err)
 	}
 	postHash := tree.Commit()
@@ -317,10 +317,10 @@ func TestDeletePrune(t *testing.T) {
 	}
 
 	// Delete key4 and key3.
-	if err := tree.Delete(key4, nil); err != nil {
+	if err, _ := tree.Delete(key4, nil); err != nil {
 		t.Error(err)
 	}
-	if err := tree.Delete(key3, nil); err != nil {
+	if err, _ := tree.Delete(key3, nil); err != nil {
 		t.Error(err)
 	}
 	postHash = tree.Commit()
@@ -350,7 +350,7 @@ func TestDeleteHash(t *testing.T) {
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.(*InternalNode).FlushAtDepth(0, func(vn VerkleNode) {})
 	tree.Commit()
-	if err := tree.Delete(key2, nil); err != errDeleteHash {
+	if err, _ := tree.Delete(key2, nil); err != errDeleteHash {
 		t.Fatalf("did not report the correct error while deleting from a hash: %v", err)
 	}
 }
@@ -364,7 +364,7 @@ func TestDeleteUnequalPath(t *testing.T) {
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.Commit()
 
-	if err := tree.Delete(key2, nil); err != nil {
+	if err, _ := tree.Delete(key2, nil); err != nil {
 		t.Fatalf("errored during the deletion of non-existing key, err =%v", err)
 	}
 }
@@ -385,7 +385,7 @@ func TestDeleteResolve(t *testing.T) {
 	tree.Commit()
 
 	var called bool
-	err := tree.Delete(key2, func(comm []byte) ([]byte, error) {
+	err, _ := tree.Delete(key2, func(comm []byte) ([]byte, error) {
 		called = true
 		for _, node := range savedNodes {
 			c := node.Commit().Bytes()

--- a/tree_test.go
+++ b/tree_test.go
@@ -256,7 +256,7 @@ func TestDelLeaf(t *testing.T) {
 	// as deleting a value means replacing it with a 0 in verkle
 	// trees.
 	postHash := tree.Commit()
-	if Equal(&init, postHash) {
+	if !Equal(&init, postHash) {
 		t.Errorf("deleting leaf resulted in unexpected tree %x %x", init.Bytes(), postHash.Bytes())
 	}
 
@@ -264,7 +264,7 @@ func TestDelLeaf(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(res, zeroKeyTest) {
+	if len(res) > 0 {
 		t.Error("leaf hasnt been deleted")
 	}
 }
@@ -312,7 +312,7 @@ func TestDeletePrune(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(res, zeroKeyTest) {
+	if len(res) > 0 {
 		t.Error("leaf #5 hasn't been deleted")
 	}
 
@@ -325,14 +325,14 @@ func TestDeletePrune(t *testing.T) {
 	}
 	postHash = tree.Commit()
 	// The post deletion hash should be different from the post key2 hash.
-	if Equal(&hashPostKey2, postHash) {
+	if !Equal(&hashPostKey2, postHash) {
 		t.Error("deleting leaf #3 resulted in unexpected tree")
 	}
 	res, err = tree.Get(key3, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(res, zeroKeyTest) {
+	if len(res) > 0 {
 		t.Error("leaf hasnt been deleted")
 	}
 }

--- a/unknown.go
+++ b/unknown.go
@@ -33,8 +33,8 @@ func (UnknownNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errMissingNodeInStateless
 }
 
-func (UnknownNode) Delete([]byte, NodeResolverFn) (error, bool) {
-	return errors.New("cant delete in a subtree missing form a stateless view"), false
+func (UnknownNode) Delete([]byte, NodeResolverFn) (bool, error) {
+	return false, errors.New("cant delete in a subtree missing form a stateless view")
 }
 
 func (UnknownNode) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/unknown.go
+++ b/unknown.go
@@ -33,8 +33,8 @@ func (UnknownNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errMissingNodeInStateless
 }
 
-func (UnknownNode) Delete([]byte, NodeResolverFn) error {
-	return errors.New("cant delete in a subtree missing form a stateless view")
+func (UnknownNode) Delete([]byte, NodeResolverFn) (error, bool) {
+	return errors.New("cant delete in a subtree missing form a stateless view"), false
 }
 
 func (UnknownNode) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -8,7 +8,7 @@ func TestUnknownFuncs(t *testing.T) {
 	if err := un.Insert(nil, nil, nil); err != errMissingNodeInStateless {
 		t.Errorf("got %v, want %v", err, errMissingNodeInStateless)
 	}
-	if err := un.Delete(nil, nil); err == nil {
+	if err, _ := un.Delete(nil, nil); err == nil {
 		t.Errorf("got nil error when deleting from a hashed node")
 	}
 	if _, err := un.Get(nil, nil); err != nil {

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -8,7 +8,7 @@ func TestUnknownFuncs(t *testing.T) {
 	if err := un.Insert(nil, nil, nil); err != errMissingNodeInStateless {
 		t.Errorf("got %v, want %v", err, errMissingNodeInStateless)
 	}
-	if err, _ := un.Delete(nil, nil); err == nil {
+	if _, err := un.Delete(nil, nil); err == nil {
 		t.Errorf("got nil error when deleting from a hashed node")
 	}
 	if _, err := un.Get(nil, nil); err != nil {


### PR DESCRIPTION
The PBSS scheme uses reverse-diffs to handle reorgs past the persistent disk layer. For this to work with verkle, `Delete` must be able to completely delete the nodes that were inserted from one tree to the next.

TODO

 * [x] complete leaf deletion to correctly update the commitments
 * [x] fix existing tests
 * [x] add tests to ensure children corner cases are covered
 * [x] swap `delete` and `err`