### PR TITLE
do not error when deleting non-existing leaves

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -432,7 +432,7 @@ func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) error {
 	nChild := offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
 	case Empty:
-		return errDeleteNonExistent
+		return nil
 	case *HashedNode:
 		if resolver == nil {
 			return errDeleteHash
@@ -974,7 +974,7 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) error {
 	// Sanity check: ensure the key header is the same:
 	if !equalPaths(k, n.stem) {
-		return errDeleteNonExistent
+		return nil //errDeleteNonExistent
 	}
 
 	var zero [32]byte


### PR DESCRIPTION
Because of the way the overlay transition has been coded, it can happen that an attempt is made to delete from the overlay tree. This occurs when an account has not been fully translated, and that the calling code will try to delete one of its values. The code will first try to delete the data from the overlay tree, and then from the MPT (which isn't allowed).

:thinking: come to think of it, this is probably the wrong thing to do: a zero value should be inserted instead, so that the MPT is never hit and that there is a record that the value got deleted.  I will attempt to fix it in a different PR, but in the meantime this PR fixes the replay issue.