### PR TITLE
mod: update to faster go-ipa regarding proof generation/verification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gballet/go-verkle
 
 go 1.18
 
-require github.com/crate-crypto/go-ipa v0.0.0-20230410135559-ce4a96995014
+require github.com/crate-crypto/go-ipa v0.0.0-20230601100809-a49f82a18f8c
 
 require (
 	golang.org/x/sync v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/crate-crypto/go-ipa v0.0.0-20230410135559-ce4a96995014 h1:bbyTlFQ12wkFA6aVL+9HrBZwVl85AN0VS/Bwam7o93U=
-github.com/crate-crypto/go-ipa v0.0.0-20230410135559-ce4a96995014/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
+github.com/crate-crypto/go-ipa v0.0.0-20230601100809-a49f82a18f8c h1:DkylWQczjMdwK+KdPVB4fc6X+PBEF0XFrA9r8a4yaRk=
+github.com/crate-crypto/go-ipa v0.0.0-20230601100809-a49f82a18f8c/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=


### PR DESCRIPTION
This PR updates our `go-ipa` dependency to current `master`. 

It has improved the proving generation and verification speed due to a bunch of PRs:
- https://github.com/crate-crypto/go-ipa/pull/39
- https://github.com/crate-crypto/go-ipa/pull/40
- https://github.com/crate-crypto/go-ipa/pull/41
- https://github.com/crate-crypto/go-ipa/pull/42
- https://github.com/crate-crypto/go-ipa/pull/43
- https://github.com/crate-crypto/go-ipa/pull/45
- https://github.com/crate-crypto/go-ipa/pull/46
- https://github.com/crate-crypto/go-ipa/pull/48
- https://github.com/crate-crypto/go-ipa/pull/49

Here's a "before" and "after" comparison generated by [vkt-proof-bench](https://github.com/jsign/vkt-proof-bench):
- [Before](https://gist.github.com/jsign/3ea6d6d23ee691472c48f45732d31799)
- [After](https://gist.github.com/jsign/f79f87af09ad3a14f0bfcfc5ba4e8c3e)

All applied optimizations were collected in a [more technical doc here](https://hackmd.io/@jsign/vkt-proofs-implementation-notes).

I did the summary above to explain what happened behind the dependency update comprehensively.
For `go-verkle`, this dependency update is transparent since it doesn't affect APIs or require extra assets.