### PR TITLE
remove panics in StemFromBytes and FromLEBytes

### DIFF
--- a/config_ipa.go
+++ b/config_ipa.go
@@ -85,7 +85,9 @@ func GetConfig() *Config {
 		values := make([][]byte, NodeWidth)
 		values[CodeHashVectorPosition] = emptyHashCode
 		var c1poly [NodeWidth]Fr
-		fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
+		if _, err := fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2]); err != nil {
+			panic(err)
+		}
 		EmptyCodeHashPoint = *cfg.CommitToPoly(c1poly[:], 0)
 		EmptyCodeHashFirstHalfValue = c1poly[EmptyCodeHashFirstHalfIdx]
 		EmptyCodeHashSecondHalfValue = c1poly[EmptyCodeHashSecondHalfIdx]

--- a/conversion.go
+++ b/conversion.go
@@ -138,7 +138,7 @@ func (n *InternalNode) InsertMigratedLeaves(leaves []LeafNode, resolver NodeReso
 				}
 
 				if err := node.updateMultipleLeaves(nonPresentValues); err != nil {
-					return nil
+					return fmt.Errorf("updating leaves: %s", err)
 				}
 				continue
 			}

--- a/conversion.go
+++ b/conversion.go
@@ -2,10 +2,12 @@ package verkle
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"runtime"
 	"sort"
-	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // BatchNewLeafNodeData is a struct that contains the data needed to create a new leaf node.
@@ -23,56 +25,56 @@ func BatchNewLeafNode(nodesValues []BatchNewLeafNodeData) ([]LeafNode, error) {
 	numBatches := runtime.NumCPU()
 	batchSize := len(nodesValues) / numBatches
 
-	var (
-		wg  sync.WaitGroup
-		err error
-	)
-	wg.Add(numBatches)
+	group, _ := errgroup.WithContext(context.Background())
 	for i := 0; i < numBatches; i++ {
 		start := i * batchSize
 		end := (i + 1) * batchSize
 		if i == numBatches-1 {
 			end = len(nodesValues)
 		}
-		go func(ret []LeafNode, nodesValues []BatchNewLeafNodeData) {
-			defer wg.Done()
 
-			c1c2points := make([]*Point, 2*len(nodesValues))
-			c1c2frs := make([]*Fr, 2*len(nodesValues))
-			for i, nv := range nodesValues {
-				valsslice := make([][]byte, NodeWidth)
-				for idx := range nv.Values {
-					valsslice[idx] = nv.Values[idx]
+		work := func(ret []LeafNode, nodesValues []BatchNewLeafNodeData) func() error {
+			return func() error {
+				c1c2points := make([]*Point, 2*len(nodesValues))
+				c1c2frs := make([]*Fr, 2*len(nodesValues))
+				for i, nv := range nodesValues {
+					valsslice := make([][]byte, NodeWidth)
+					for idx := range nv.Values {
+						valsslice[idx] = nv.Values[idx]
+					}
+
+					var leaf *LeafNode
+					leaf, err := NewLeafNode(nv.Stem, valsslice)
+					if err != nil {
+						return err
+					}
+					ret[i] = *leaf
+
+					c1c2points[2*i], c1c2points[2*i+1] = ret[i].c1, ret[i].c2
+					c1c2frs[2*i], c1c2frs[2*i+1] = new(Fr), new(Fr)
 				}
 
-				var leaf *LeafNode
-				leaf, err = NewLeafNode(nv.Stem, valsslice)
-				if err != nil {
-					return
-				}
-				ret[i] = *leaf
+				toFrMultiple(c1c2frs, c1c2points)
 
-				c1c2points[2*i], c1c2points[2*i+1] = ret[i].c1, ret[i].c2
-				c1c2frs[2*i], c1c2frs[2*i+1] = new(Fr), new(Fr)
+				var poly [NodeWidth]Fr
+				poly[0].SetUint64(1)
+				for i, nv := range nodesValues {
+					if err := StemFromBytes(&poly[1], nv.Stem); err != nil {
+						return err
+					}
+					poly[2] = *c1c2frs[2*i]
+					poly[3] = *c1c2frs[2*i+1]
+
+					ret[i].commitment = cfg.CommitToPoly(poly[:], 252)
+				}
+				return nil
 			}
-
-			toFrMultiple(c1c2frs, c1c2points)
-
-			var poly [NodeWidth]Fr
-			poly[0].SetUint64(1)
-			for i, nv := range nodesValues {
-				if err = StemFromBytes(&poly[1], nv.Stem); err != nil {
-					return
-				}
-				poly[2] = *c1c2frs[2*i]
-				poly[3] = *c1c2frs[2*i+1]
-
-				ret[i].commitment = cfg.CommitToPoly(poly[:], 252)
-			}
-
-		}(ret[start:end], nodesValues[start:end])
+		}
+		group.Go(work(ret[start:end], nodesValues[start:end]))
 	}
-	wg.Wait()
+	if err := group.Wait(); err != nil {
+		return nil, fmt.Errorf("creating leaf node: %s", err)
+	}
 
 	sort.Slice(ret, func(i, j int) bool {
 		return bytes.Compare(ret[i].stem, ret[j].stem) < 0

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -13,7 +13,10 @@ func TestLeafStemLength(t *testing.T) {
 	// Serialize a leaf with no values, but whose stem is 32 bytes. The
 	// serialization should trim the extra byte.
 	toolong := make([]byte, 32)
-	leaf := NewLeafNode(toolong, make([][]byte, NodeWidth))
+	leaf, err := NewLeafNode(toolong, make([][]byte, NodeWidth))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ser, err := leaf.Serialize()
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +35,10 @@ func TestInvalidNodeEncoding(t *testing.T) {
 	// Test an invalid node type.
 	values := make([][]byte, NodeWidth)
 	values[42] = testValue
-	ln := NewLeafNode(ffx32KeyTest, values)
+	ln, err := NewLeafNode(ffx32KeyTest, values)
+	if err != nil {
+		t.Fatal(err)
+	}
 	lnbytes, err := ln.Serialize()
 	if err != nil {
 		t.Fatalf("serializing leaf node: %v", err)

--- a/ipa.go
+++ b/ipa.go
@@ -26,6 +26,8 @@
 package verkle
 
 import (
+	"errors"
+
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/crate-crypto/go-ipa/banderwagon"
 )
@@ -57,20 +59,21 @@ func toFrMultiple(res []*Fr, ps []*Point) {
 	banderwagon.MultiMapToScalarField(res, ps)
 }
 
-func FromLEBytes(fr *Fr, data []byte) {
+func FromLEBytes(fr *Fr, data []byte) error {
 	if len(data) > 32 {
-		panic("data is too long")
+		return errors.New("data is too long")
 	}
 	var aligned [32]byte
 	copy(aligned[:], data)
 	fr.SetBytesLE(aligned[:])
+	return nil
 }
 
-func StemFromBytes(fr *Fr, data []byte) {
+func StemFromBytes(fr *Fr, data []byte) error {
 	if len(data) != StemSize {
-		panic("data length must be StemSize")
+		return errors.New("data length must be StemSize")
 	}
-	FromLEBytes(fr, data)
+	return FromLEBytes(fr, data)
 }
 
 func FromBytes(fr *Fr, data []byte) {

--- a/tree.go
+++ b/tree.go
@@ -247,13 +247,16 @@ func NewStatelessInternal(depth byte, comm *Point) VerkleNode {
 }
 
 // New creates a new leaf node
-func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
+func NewLeafNode(stem []byte, values [][]byte) (*LeafNode, error) {
 	cfg := GetConfig()
 
 	// C1.
 	var c1poly [NodeWidth]Fr
 	var c1 *Point
-	count := fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
+	count, err := fillSuffixTreePoly(c1poly[:], values[:NodeWidth/2])
+	if err != nil {
+		return nil, err
+	}
 	containsEmptyCodeHash := len(c1poly) >= EmptyCodeHashSecondHalfIdx &&
 		c1poly[EmptyCodeHashFirstHalfIdx].Equal(&EmptyCodeHashFirstHalfValue) &&
 		c1poly[EmptyCodeHashSecondHalfIdx].Equal(&EmptyCodeHashSecondHalfValue)
@@ -271,14 +274,19 @@ func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
 
 	// C2.
 	var c2poly [NodeWidth]Fr
-	count = fillSuffixTreePoly(c2poly[:], values[NodeWidth/2:])
+	count, err = fillSuffixTreePoly(c2poly[:], values[NodeWidth/2:])
+	if err != nil {
+		return nil, err
+	}
 	c2 := cfg.CommitToPoly(c2poly[:], NodeWidth-count)
 
 	// Root commitment preparation for calculation.
 	stem = stem[:StemSize] // enforce a 31-byte length
 	var poly [NodeWidth]Fr
 	poly[0].SetUint64(1)
-	StemFromBytes(&poly[1], stem)
+	if err := StemFromBytes(&poly[1], stem); err != nil {
+		return nil, err
+	}
 	toFrMultiple([]*Fr{&poly[2], &poly[3]}, []*Point{c1, c2})
 
 	return &LeafNode{
@@ -289,7 +297,7 @@ func NewLeafNode(stem []byte, values [][]byte) *LeafNode {
 		commitment: cfg.CommitToPoly(poly[:], NodeWidth-4),
 		c1:         c1,
 		c2:         c2,
-	}
+	}, nil
 }
 
 // NewLeafNodeWithNoComms create a leaf node but does compute its
@@ -344,7 +352,11 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 	case UnknownNode:
 		return errMissingNodeInStateless
 	case Empty:
-		n.children[nChild] = NewLeafNode(stem, values)
+		var err error
+		n.children[nChild], err = NewLeafNode(stem, values)
+		if err != nil {
+			return err
+		}
 		n.children[nChild].setDepth(n.depth + 1)
 	case *HashedNode:
 		if resolver == nil {
@@ -385,7 +397,10 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 
 		// Next word differs, so this was the last level.
 		// Insert it directly into its final slot.
-		leaf := NewLeafNode(stem, values)
+		leaf, err := NewLeafNode(stem, values)
+		if err != nil {
+			return err
+		}
 		leaf.setDepth(n.depth + 2)
 		newBranch.cowChild(nextWordInInsertedKey)
 		newBranch.children[nextWordInInsertedKey] = leaf
@@ -980,9 +995,7 @@ func (n *LeafNode) insertMultiple(stem []byte, values [][]byte) error {
 		return errInsertIntoOtherStem
 	}
 
-	n.updateMultipleLeaves(values)
-
-	return nil
+	return n.updateMultipleLeaves(values)
 }
 
 func (n *LeafNode) updateC(cxIndex int, newC Fr, oldC Fr) {
@@ -998,7 +1011,7 @@ func (n *LeafNode) updateC(cxIndex int, newC Fr, oldC Fr) {
 	n.commitment.Add(n.commitment, cfg.CommitToPoly(poly[:], 0))
 }
 
-func (n *LeafNode) updateCn(index byte, value []byte, c *Point) {
+func (n *LeafNode) updateCn(index byte, value []byte, c *Point) error {
 	var (
 		old, newH [2]Fr
 		diff      Point
@@ -1011,8 +1024,14 @@ func (n *LeafNode) updateCn(index byte, value []byte, c *Point) {
 	// do not include it. The result should be the same,
 	// but the computation time should be faster as one doesn't need to
 	// compute 1 - 1 mod N.
-	leafToComms(old[:], n.values[index])
-	leafToComms(newH[:], value)
+	err := leafToComms(old[:], n.values[index])
+	if err != nil {
+		return err
+	}
+	err = leafToComms(newH[:], value)
+	if err != nil {
+		return err
+	}
 
 	newH[0].Sub(&newH[0], &old[0])
 	poly[2*(index%128)] = newH[0]
@@ -1024,9 +1043,11 @@ func (n *LeafNode) updateCn(index byte, value []byte, c *Point) {
 	poly[2*(index%128)+1] = newH[1]
 	diff = cfg.conf.Commit(poly[:])
 	c.Add(c, &diff)
+
+	return nil
 }
 
-func (n *LeafNode) updateLeaf(index byte, value []byte) {
+func (n *LeafNode) updateLeaf(index byte, value []byte) error {
 	// Update the corresponding C1 or C2 commitment.
 	var c *Point
 	var oldC Point
@@ -1037,7 +1058,9 @@ func (n *LeafNode) updateLeaf(index byte, value []byte) {
 		c = n.c2
 		oldC = *n.c2
 	}
-	n.updateCn(index, value, c)
+	if err := n.updateCn(index, value, c); err != nil {
+		return err
+	}
 
 	// Batch the Fr transformation of the new and old CX.
 	var frs [2]Fr
@@ -1048,9 +1071,10 @@ func (n *LeafNode) updateLeaf(index byte, value []byte) {
 	n.updateC(cxIndex, frs[0], frs[1])
 
 	n.values[index] = value
+	return nil
 }
 
-func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
+func (n *LeafNode) updateMultipleLeaves(values [][]byte) error {
 	var oldC1, oldC2 *Point
 
 	// We iterate the values, and we update the C1 and/or C2 commitments depending on the index.
@@ -1066,7 +1090,9 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 					oldC1.Set(n.c1)
 				}
 				// We update C1 directly in `n`. We have our original copy in oldC1.
-				n.updateCn(byte(i), v, n.c1)
+				if err := n.updateCn(byte(i), v, n.c1); err != nil {
+					return err
+				}
 			} else {
 				// First time we touch C2? Save the original point for later.
 				if oldC2 == nil {
@@ -1074,7 +1100,9 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 					oldC2.Set(n.c2)
 				}
 				// We update C2 directly in `n`. We have our original copy in oldC2.
-				n.updateCn(byte(i), v, n.c2)
+				if err := n.updateCn(byte(i), v, n.c2); err != nil {
+					return err
+				}
 			}
 			n.values[i] = v
 		}
@@ -1099,6 +1127,8 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) {
 		toFrMultiple([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2})
 		n.updateC(c2Idx, frs[0], frs[1])
 	}
+
+	return nil
 }
 
 // Delete deletes a value from the leaf, return `true` as a second
@@ -1191,8 +1221,7 @@ func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) (bool, error) {
 	// the method, as it needs the original
 	// value to compute the commitment diffs.
 	n.values[k[31]] = original
-	n.updateLeaf(k[31], nil)
-	return false, nil
+	return false, n.updateLeaf(k[31], nil)
 }
 
 func (n *LeafNode) Get(k []byte, _ NodeResolverFn) ([]byte, error) {
@@ -1230,7 +1259,7 @@ func (n *LeafNode) Commit() *Point {
 // fillSuffixTreePoly takes one of the two suffix tree and
 // builds the associated polynomial, to be used to compute
 // the corresponding C{1,2} commitment.
-func fillSuffixTreePoly(poly []Fr, values [][]byte) int {
+func fillSuffixTreePoly(poly []Fr, values [][]byte) (int, error) {
 	count := 0
 	for idx, val := range values {
 		if val == nil {
@@ -1238,33 +1267,40 @@ func fillSuffixTreePoly(poly []Fr, values [][]byte) int {
 		}
 		count++
 
-		leafToComms(poly[(idx<<1)&0xFF:], val)
+		err := leafToComms(poly[(idx<<1)&0xFF:], val)
+		if err != nil {
+			return 0, err
+		}
 	}
-	return count
+	return count, nil
 }
 
 // leafToComms turns a leaf into two commitments of the suffix
 // and extension tree.
-func leafToComms(poly []Fr, val []byte) {
+func leafToComms(poly []Fr, val []byte) error {
 	if len(val) == 0 {
-		return
+		return nil
 	}
 	if len(val) > 32 {
-		panic(fmt.Sprintf("invalid leaf length %d, %v", len(val), val))
+		return fmt.Errorf("invalid leaf length %d, %v", len(val), val)
 	}
 	var (
 		valLoWithMarker [17]byte
 		loEnd           = 16
+		err             error
 	)
 	if len(val) < loEnd {
 		loEnd = len(val)
 	}
 	copy(valLoWithMarker[:loEnd], val[:loEnd])
 	valLoWithMarker[16] = 1 // 2**128
-	FromLEBytes(&poly[0], valLoWithMarker[:])
-	if len(val) >= 16 {
-		FromLEBytes(&poly[1], val[16:])
+	if err = FromLEBytes(&poly[0], valLoWithMarker[:]); err != nil {
+		return err
 	}
+	if len(val) >= 16 {
+		err = FromLEBytes(&poly[1], val[16:])
+	}
+	return err
 }
 
 func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte, error) {
@@ -1285,7 +1321,10 @@ func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte
 
 	// Initialize the top-level polynomial with 1 + stem + C1 + C2
 	poly[0].SetUint64(1)
-	StemFromBytes(&poly[1], n.stem)
+	err := StemFromBytes(&poly[1], n.stem)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	toFrMultiple([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2})
 
 	// First pass: add top-level elements first
@@ -1344,11 +1383,18 @@ func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte
 			suffix   = key[31]
 			suffPoly [NodeWidth]Fr // suffix-level polynomial
 			count    int
+			err      error
 		)
 		if suffix >= 128 {
-			count = fillSuffixTreePoly(suffPoly[:], n.values[128:])
+			count, err = fillSuffixTreePoly(suffPoly[:], n.values[128:])
+			if err != nil {
+				return nil, nil, nil, err
+			}
 		} else {
-			count = fillSuffixTreePoly(suffPoly[:], n.values[:128])
+			count, err = fillSuffixTreePoly(suffPoly[:], n.values[:128])
+			if err != nil {
+				return nil, nil, nil, err
+			}
 		}
 
 		// Proof of absence: case of a missing suffix tree.

--- a/tree.go
+++ b/tree.go
@@ -1028,8 +1028,7 @@ func (n *LeafNode) updateCn(index byte, value []byte, c *Point) error {
 	if err != nil {
 		return err
 	}
-	err = leafToComms(newH[:], value)
-	if err != nil {
+	if err = leafToComms(newH[:], value); err != nil {
 		return err
 	}
 
@@ -1267,8 +1266,7 @@ func fillSuffixTreePoly(poly []Fr, values [][]byte) (int, error) {
 		}
 		count++
 
-		err := leafToComms(poly[(idx<<1)&0xFF:], val)
-		if err != nil {
+		if err := leafToComms(poly[(idx<<1)&0xFF:], val); err != nil {
 			return 0, err
 		}
 	}
@@ -1298,9 +1296,11 @@ func leafToComms(poly []Fr, val []byte) error {
 		return err
 	}
 	if len(val) >= 16 {
-		err = FromLEBytes(&poly[1], val[16:])
+		if err = FromLEBytes(&poly[1], val[16:]); err != nil {
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte, error) {
@@ -1321,8 +1321,7 @@ func (n *LeafNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]byte
 
 	// Initialize the top-level polynomial with 1 + stem + C1 + C2
 	poly[0].SetUint64(1)
-	err := StemFromBytes(&poly[1], n.stem)
-	if err != nil {
+	if err := StemFromBytes(&poly[1], n.stem); err != nil {
 		return nil, nil, nil, err
 	}
 	toFrMultiple([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2})

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -53,7 +53,10 @@ func extensionAndSuffixOneKey(key, value []byte, ret *Point) {
 		t1, t2, c1                      Point
 	)
 	stemComm0 := srs[0]
-	StemFromBytes(&v, key[:31])
+	err := StemFromBytes(&v, key[:31])
+	if err != nil {
+		panic(err)
+	}
 	stemComm1.ScalarMul(&srs[1], &v)
 
 	leafToComms(vs[:], value)
@@ -146,7 +149,10 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 	comm := root.Commit()
 
 	stemComm0 := srs[0]
-	StemFromBytes(&v, key_a[:31])
+	err := StemFromBytes(&v, key_a[:31])
+	if err != nil {
+		t.Fatal(err)
+	}
 	stemComm1.ScalarMul(&srs[1], &v)
 
 	leafToComms(vs[:], key_a)
@@ -265,9 +271,14 @@ func BenchmarkGroupToField(b *testing.B) {
 
 func TestPaddingInFromLEBytes(t *testing.T) {
 	var fr1, fr2 Fr
-	FromLEBytes(&fr1, ffx32KeyTest[:16])
+	if err := FromLEBytes(&fr1, ffx32KeyTest[:16]); err != nil {
+		t.Fatal(err)
+	}
 	key, _ := hex.DecodeString("ffffffffffffffffffffffffffffffff00000000000000000000000000000000")
-	StemFromBytes(&fr2, key[:StemSize])
+	err := StemFromBytes(&fr2, key[:StemSize])
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !fr1.Equal(&fr2) {
 		t.Fatal("byte alignment")


### PR DESCRIPTION
This is part (but not all) of the fix for #351, stopping here because the diff is already quite large.