### PR TITLE
tree: transform first layer to hashed nodes after serializing

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1538,6 +1538,14 @@ func (n *InternalNode) BatchSerialize() ([]SerializedNode, error) {
 		}
 	}
 
+	for i := range n.children {
+		if ch, ok := n.children[i].(*InternalNode); ok {
+			n.children[i] = ch.toHashedNode()
+		} else if ch, ok := n.children[i].(*LeafNode); ok {
+			n.children[i] = ch.ToHashedNode()
+		}
+	}
+
 	return ret, nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -1538,6 +1538,10 @@ func (n *InternalNode) BatchSerialize() ([]SerializedNode, error) {
 		}
 	}
 
+	// TODO: we transform nodes in the first layer to HashedNodes, to avoid further calls
+	//       to this method to do double-work. This is a temporary change for geth since in
+	//       the current influx PBSS effort, there're still calls to Commit() storage tries
+	//       which in VKT doesn't make sense anymore. This changes makes those calls a ~noop.
 	for i := range n.children {
 		if ch, ok := n.children[i].(*InternalNode); ok {
 			n.children[i] = ch.toHashedNode()


### PR DESCRIPTION
This PR makes `BatchSerialize(...)` transform the first layer of Internal/Leaf nodes to HashedNodes.
This prevents further commitments to serialize the whole tree again. This has a big impact on our overlay-tree benchmarks.