### PR TITLE
tree: make HashedNode non-pointer and fieldless

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -89,7 +89,7 @@ func (n *InternalNode) InsertMigratedLeaves(leaves []LeafNode, resolver NodeReso
 
 		// Look for the appropriate parent for the leaf node.
 		for {
-			if _, ok := parent.children[ln.stem[parent.depth]].(*HashedNode); ok {
+			if _, ok := parent.children[ln.stem[parent.depth]].(HashedNode); ok {
 				serialized, err := resolver(ln.stem[:parent.depth+1])
 				if err != nil {
 					return fmt.Errorf("resolving node path=%x: %w", ln.stem[:parent.depth+1], err)

--- a/debug_test.go
+++ b/debug_test.go
@@ -35,7 +35,7 @@ func TestJSON(t *testing.T) {
 	root.Insert(oneKeyTest, zeroKeyTest, nil)
 	root.Insert(forkOneKeyTest, zeroKeyTest, nil) // Force an internal node in the first layer.
 	root.Insert(fourtyKeyTest, oneKeyTest, nil)
-	root.(*InternalNode).children[152] = &HashedNode{commitment: []byte{1, 2, 3, 4}}
+	root.(*InternalNode).children[152] = HashedNode{}
 	root.Commit()
 
 	output, err := root.(*InternalNode).ToJSON()

--- a/encoding.go
+++ b/encoding.go
@@ -130,7 +130,7 @@ func CreateInternalNode(bitlist []byte, raw []byte, depth byte) (*InternalNode, 
 	for i, b := range bitlist {
 		for j := 0; j < 8; j++ {
 			if b&mask[j] != 0 {
-				node.children[8*i+j] = &HashedNode{}
+				node.children[8*i+j] = HashedNode{}
 			} else {
 
 				node.children[8*i+j] = Empty(struct{}{})

--- a/hashednode.go
+++ b/hashednode.go
@@ -45,6 +45,12 @@ func (HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {
 }
 
 func (HashedNode) Commit() *Point {
+	// TODO: we should reconsider what to do with the VerkleNode interface and how
+	//       HashedNode fits into the picture, since Commit(), Commitment() and Hash()
+	//	     now panics. Despite these calls must not happen at runtime, it is still
+	//	     quite risky. The reason we end up in this place is because PBSS came quite
+	//	     recently compared with the VerkleNode interface design. We should probably
+	//	     reconsider splitting the interface or find some safer workaround.
 	panic("can not commit a hash node")
 }
 

--- a/hashednode.go
+++ b/hashednode.go
@@ -30,69 +30,48 @@ import (
 	"fmt"
 )
 
-type HashedNode struct {
-	commitment  []byte
-	cachedPoint *Point
-}
+type HashedNode struct{}
 
-func (*HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
+func (HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 	return errInsertIntoHash
 }
 
-func (*HashedNode) Delete([]byte, NodeResolverFn) (bool, error) {
+func (HashedNode) Delete([]byte, NodeResolverFn) (bool, error) {
 	return false, errors.New("cant delete a hashed node in-place")
 }
 
-func (*HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {
+func (HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {
 	return nil, errors.New("can not read from a hash node")
 }
 
-func (n *HashedNode) Commit() *Point {
-	if n.commitment == nil {
-		panic("nil commitment")
-	}
-	if n.cachedPoint == nil {
-		n.cachedPoint = new(Point)
-		n.cachedPoint.SetBytesUncompressed(n.commitment, true)
-	}
-	return n.cachedPoint
+func (HashedNode) Commit() *Point {
+	panic("can not commit a hash node")
 }
 
-func (n *HashedNode) Commitment() *Point {
-	if n.commitment == nil {
-		panic("nil commitment")
-	}
-	return n.Commit()
+func (HashedNode) Commitment() *Point {
+	panic("can not get commitment of a hash node")
 }
 
-func (*HashedNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte, error) {
+func (HashedNode) GetProofItems(keylist) (*ProofElements, []byte, [][]byte, error) {
 	return nil, nil, nil, errors.New("can not get the full path, and there is no proof of absence")
 }
 
-func (*HashedNode) Serialize() ([]byte, error) {
+func (HashedNode) Serialize() ([]byte, error) {
 	return nil, errSerializeHashedNode
 }
 
-func (n *HashedNode) Copy() VerkleNode {
-	if n.commitment == nil {
-		panic("nil commitment")
-	}
-	c := &HashedNode{commitment: make([]byte, len(n.commitment))}
-	copy(c.commitment, n.commitment)
-	return c
+func (HashedNode) Copy() VerkleNode {
+	return HashedNode{}
 }
 
-func (n *HashedNode) toDot(parent, path string) string {
-	return fmt.Sprintf("hash%s [label=\"H: %x\"]\n%s -> hash%s\n", path, n.commitment, parent, path)
+func (n HashedNode) toDot(parent, path string) string {
+	return fmt.Sprintf("hash%s \n%s -> hash%s\n", path, parent, path)
 }
 
-func (*HashedNode) setDepth(_ byte) {
+func (HashedNode) setDepth(_ byte) {
 	// do nothing
 }
 
-func (n *HashedNode) Hash() *Fr {
-	comm := n.Commitment()
-	hash := new(Fr)
-	toFr(hash, comm)
-	return hash
+func (n HashedNode) Hash() *Fr {
+	panic("can not hash a hashed node")
 }

--- a/hashednode.go
+++ b/hashednode.go
@@ -71,7 +71,7 @@ func (HashedNode) Copy() VerkleNode {
 }
 
 func (HashedNode) toDot(parent, path string) string {
-	return fmt.Sprintf("hash%s \n%s -> hash%s\n", path, parent, path)
+	return fmt.Sprintf("hash%s [label=\"unresolved\"]\n%s -> hash%s\n", path, parent, path)
 }
 
 func (HashedNode) setDepth(_ byte) {

--- a/hashednode.go
+++ b/hashednode.go
@@ -64,7 +64,7 @@ func (HashedNode) Copy() VerkleNode {
 	return HashedNode{}
 }
 
-func (n HashedNode) toDot(parent, path string) string {
+func (HashedNode) toDot(parent, path string) string {
 	return fmt.Sprintf("hash%s \n%s -> hash%s\n", path, parent, path)
 }
 
@@ -72,6 +72,6 @@ func (HashedNode) setDepth(_ byte) {
 	// do nothing
 }
 
-func (n HashedNode) Hash() *Fr {
+func (HashedNode) Hash() *Fr {
 	panic("can not hash a hashed node")
 }

--- a/hashednode_test.go
+++ b/hashednode_test.go
@@ -28,8 +28,7 @@ package verkle
 import "testing"
 
 func TestHashedNodeFuncs(t *testing.T) {
-	fakeCommitment := EmptyCodeHashPoint.Bytes()
-	e := HashedNode{commitment: fakeCommitment[:]}
+	e := HashedNode{}
 	err := e.Insert(zeroKeyTest, zeroKeyTest, nil)
 	if err != errInsertIntoHash {
 		t.Fatal("got nil error when inserting into a hashed node")
@@ -50,8 +49,5 @@ func TestHashedNodeFuncs(t *testing.T) {
 	}
 	if _, err := e.Serialize(); err != errSerializeHashedNode {
 		t.Fatal("got nil error when serializing a hashed node")
-	}
-	if hash := e.Hash(); hash == nil {
-		t.Fatal("got nil hash when hashing a hashed node")
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -195,7 +195,7 @@ func (n *InternalNode) toExportable() *ExportableInternalNode {
 		switch child := n.children[i].(type) {
 		case Empty:
 			exportable.Children[i] = nil
-		case *HashedNode:
+		case HashedNode:
 			exportable.Children[i] = n.commitment.Bytes()
 		case *InternalNode:
 			exportable.Children[i] = child.toExportable()
@@ -346,7 +346,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 		n.cowChild(nChild)
 		n.children[nChild] = NewLeafNode(stem, values)
 		n.children[nChild].setDepth(n.depth + 1)
-	case *HashedNode:
+	case HashedNode:
 		if resolver == nil {
 			return errInsertIntoHash
 		}
@@ -480,7 +480,7 @@ func (n *InternalNode) GetStem(stem []byte, resolver NodeResolverFn) ([][]byte, 
 		return nil, errMissingNodeInStateless
 	case Empty:
 		return nil, nil
-	case *HashedNode:
+	case HashedNode:
 		if resolver == nil {
 			return nil, fmt.Errorf("hashed node %x at depth %d along stem %x could not be resolved: %w", child.Commitment().Bytes(), n.depth, stem, errReadFromInvalid)
 		}
@@ -508,20 +508,12 @@ func (n *InternalNode) GetStem(stem []byte, resolver NodeResolverFn) ([][]byte, 
 	}
 }
 
-func (n *InternalNode) toHashedNode() *HashedNode {
-	if n.commitment == nil {
-		panic("nil commitment")
-	}
-	comm := n.commitment.BytesUncompressed()
-	return &HashedNode{commitment: comm[:]}
-}
-
 func (n *InternalNode) Delete(key []byte, resolver NodeResolverFn) (bool, error) {
 	nChild := offset2key(key, n.depth)
 	switch child := n.children[nChild].(type) {
 	case Empty:
 		return false, nil
-	case *HashedNode:
+	case HashedNode:
 		if resolver == nil {
 			return false, errDeleteHash
 		}
@@ -586,11 +578,11 @@ func (n *InternalNode) Flush(flush NodeFlushFn) {
 		if c, ok := child.(*InternalNode); ok {
 			c.Commit()
 			c.Flush(flushAndCapturePath)
-			n.children[i] = c.toHashedNode()
+			n.children[i] = HashedNode{}
 		} else if c, ok := child.(*LeafNode); ok {
 			c.Commit()
 			flushAndCapturePath(c.stem[:n.depth+1], n.children[i])
-			n.children[i] = c.ToHashedNode()
+			n.children[i] = HashedNode{}
 		}
 	}
 	flush(path, n)
@@ -607,7 +599,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 			if c, ok := child.(*LeafNode); ok {
 				c.Commit()
 				flush(c.stem[:c.depth], c)
-				n.children[i] = c.ToHashedNode()
+				n.children[i] = HashedNode{}
 			}
 			continue
 		}
@@ -620,7 +612,7 @@ func (n *InternalNode) FlushAtDepth(depth uint8, flush NodeFlushFn) {
 
 		child.Commit()
 		c.Flush(flush)
-		n.children[i] = c.toHashedNode()
+		n.children[i] = HashedNode{}
 	}
 }
 
@@ -939,14 +931,6 @@ func MergeTrees(subroots []*InternalNode) VerkleNode {
 // root commitment can be computed.
 func (n *InternalNode) touchCoW(index byte) {
 	n.cowChild(index)
-}
-
-func (n *LeafNode) ToHashedNode() *HashedNode {
-	if n.commitment == nil {
-		panic("nil commitment")
-	}
-	comm := n.commitment.BytesUncompressed()
-	return &HashedNode{commitment: comm[:]}
 }
 
 func (n *LeafNode) Insert(key []byte, value []byte, _ NodeResolverFn) error {
@@ -1543,10 +1527,9 @@ func (n *InternalNode) BatchSerialize() ([]SerializedNode, error) {
 	//       the current influx PBSS effort, there're still calls to Commit() storage tries
 	//       which in VKT doesn't make sense anymore. This changes makes those calls a ~noop.
 	for i := range n.children {
-		if ch, ok := n.children[i].(*InternalNode); ok {
-			n.children[i] = ch.toHashedNode()
-		} else if ch, ok := n.children[i].(*LeafNode); ok {
-			n.children[i] = ch.ToHashedNode()
+		switch n.children[i].(type) {
+		case *InternalNode, *LeafNode:
+			n.children[i] = HashedNode{}
 		}
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -372,6 +372,9 @@ func TestDeletePrune(t *testing.T) {
 // their hashed values. It then tries to delete the hashed values, which should
 // fail.
 func TestDeleteHash(t *testing.T) {
+	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	t.SkipNow()
+
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
@@ -401,6 +404,9 @@ func TestDeleteUnequalPath(t *testing.T) {
 }
 
 func TestDeleteResolve(t *testing.T) {
+	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	t.SkipNow()
+
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
@@ -642,12 +648,8 @@ func isInternalEqual(a, b *InternalNode) bool {
 			if _, ok := b.children[i].(Empty); !ok {
 				return false
 			}
-		case *HashedNode:
-			hn, ok := b.children[i].(*HashedNode)
-			if !ok {
-				return false
-			}
-			if !Equal(c.(*HashedNode).Commitment(), hn.Commitment()) {
+		case HashedNode:
+			if _, ok := b.children[i].(HashedNode); !ok {
 				return false
 			}
 		case *LeafNode:
@@ -687,6 +689,9 @@ func isLeafEqual(a, b *LeafNode) bool {
 }
 
 func TestGetResolveFromHash(t *testing.T) {
+	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	t.SkipNow()
+
 	var count uint
 	dummyError := errors.New("dummy")
 	var serialized []byte
@@ -754,6 +759,9 @@ func TestGetKey(t *testing.T) {
 }
 
 func TestInsertIntoHashedNode(t *testing.T) {
+	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	t.SkipNow()
+
 	root := New()
 	root.Insert(zeroKeyTest, zeroKeyTest, nil)
 	root.(*InternalNode).FlushAtDepth(0, func(_ []byte, n VerkleNode) {})
@@ -798,7 +806,9 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	}
 }
 
-func TestToDot(*testing.T) {
+func TestToDot(t *testing.T) {
+	//TODO: fix this test when we take a final decision about FlushAtDepth API.
+	t.SkipNow()
 	root := New()
 	root.Insert(zeroKeyTest, zeroKeyTest, nil)
 	root.(*InternalNode).FlushAtDepth(0, func(_ []byte, n VerkleNode) {}) // Hash the leaf to ensure HashedNodes display correctly
@@ -1010,7 +1020,7 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 	})
 
 	// check that the leafnode is now a hashed node
-	if _, ok := root.(*InternalNode).children[0].(*HashedNode); !ok {
+	if _, ok := root.(*InternalNode).children[0].(HashedNode); !ok {
 		t.Fatal("flush didn't produce a hashed node")
 	}
 


### PR DESCRIPTION
This PR exploits that in PBSS, HashedNodes can be interpreted as marker nodes of existing nodes not yet loaded in memory. 

The change in this PR makes `HashedNode`:
1. Satisfy the `VerkleNode` interface for `HashedNode` compared to the previous `*HashedNode`.
2. Remove all the existing fields having a similar (equivalent) shape of `Empty` nodes.

These points give us the following benefits (confirmed with benchmarks):
- Avoiding pointers doesn't bias the compiler into assuming these structs escape to the heap.
- Now that the total size of HashedNode is 0 (very small); it triggers a known optimization from the Go compiler that allows to interpret it as `VerkleNode` without forcing a heap allocation since it can embed the value.

Avoiding heap allocations in HeapNode is very important since many HashedNodes exist in a typical in-memory VKT while executing a block. If each existing/unloaded child results in a memory allocation, that adds up.

As a reminder of why making `HashedNode` fieldless works: in PBSS, the `HashedNode` path can be inferred by where it lives in the tree, which is the only thing we know to know the key to ask the `resolver` to load it from disk.

---

The only drawback of this PR is that it makes `FlushAtDepth` API obsolete. Flushing at an arbitrary depth means that `HashedNodes` would need to store the `Commitment` to assist top layers in future flushing. Top layers (not flushed at the selected depth), still have their `cows` marked to be recomputed. Some of their children now `HashedNodes`, and they need to know which is the `Commitment`.  

This isn't a big deal in our current strategy in Geth since we aren't relying on `FlushAtDepth` API in geth for VKTs. This API was useful for the full-tree conversion strategy that is not now the main strategy. We need to confirm that after fully discarding performance problems in low-end ARM machines, which we will probably do soon after doing other work.

This means the repo that some tests that rely on `FlushAtDepth` are temporarily marked as skipped. They were mostly checking if that API was working correctly, so in the end, we'll remove those tests or adjust them to use the full serialization API if they're adding some value to cover any other angle in logic.

I also mention in a PR comment a further tension point of `VerkleNode` and what that means for `HashedNode`.