### PR TITLE
mod: update go-ipa

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/gballet/go-verkle
 
 go 1.19
 
-require github.com/crate-crypto/go-ipa v0.0.0-20230626131944-6a9b06cf26df
-
 require (
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
+	github.com/crate-crypto/go-ipa v0.0.0-20230710183535-d5eb1c4661bd
+	golang.org/x/sync v0.1.0
 )
+
+require golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/crate-crypto/go-ipa v0.0.0-20230626131944-6a9b06cf26df h1:MV8zGEpmkuAocFqFclIJ3zUz1+6rv0T5QYWD9UDDRVE=
-github.com/crate-crypto/go-ipa v0.0.0-20230626131944-6a9b06cf26df/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
+github.com/crate-crypto/go-ipa v0.0.0-20230710183535-d5eb1c4661bd h1:jgf65Q4+jHFuLlhVApaVfTUwcU7dAdXK+GESow2UlaI=
+github.com/crate-crypto/go-ipa v0.0.0-20230710183535-d5eb1c4661bd/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=


### PR DESCRIPTION
Update go-ipa to the latest `master` to stop relying on a non-master branch.

It now officializes the [uncompressed method helpers](https://github.com/crate-crypto/go-ipa/pull/52) that we're using.