### PR TITLE
fix: after keyvals param removal, GetProofItem returns one nil value per stem

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -834,7 +834,10 @@ func (n *InternalNode) GetProofItems(keys keylist) (*ProofElements, []byte, [][]
 			// repeated as many times? It would be wasteful, so the
 			// decoding code has to be aware of this corner case.
 			esses = append(esses, extStatusAbsentEmpty|((n.depth+1)<<3))
-			pe.Vals = append(pe.Vals, nil)
+			for _ = range group {
+				// Append one nil value per key in this missing stem
+				pe.Vals = append(pe.Vals, nil)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Until recently, the proof construction was using a "keyvals" map to check if a key had a value that was present in the tree. This has been removed, so now `GetProofItems` needs to retun one `nil` value for every key corresponding to a missing stem.

@jsign there must be a way in terms of memory allocations that is more efficient, feel free to update that PR.