### PR TITLE
revert the hashing of nodes in commit

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1571,17 +1571,6 @@ func (n *InternalNode) BatchSerialize() ([]SerializedNode, error) {
 		}
 	}
 
-	// TODO: we transform nodes in the first layer to HashedNodes, to avoid further calls
-	//       to this method to do double-work. This is a temporary change for geth since in
-	//       the current influx PBSS effort, there're still calls to Commit() storage tries
-	//       which in VKT doesn't make sense anymore. This changes makes those calls a ~noop.
-	for i := range n.children {
-		switch n.children[i].(type) {
-		case *InternalNode, *LeafNode:
-			n.children[i] = HashedNode{}
-		}
-	}
-
 	return ret, nil
 }
 


### PR DESCRIPTION
This reverts a workaround in which children of `InternalNode`s whose commitment were updated, were replaced by `HashedNode`s. This meant that any further access to these nodes would require a node resolution, and this causes a lot of problems e.g. with proof creation, as a tree whose root hash was computed required loading the tree structure from disk in order to get proof items.

The initial performance problem has been fixed in gballet/go-ethereum#242 and so this can be reverted.