### PR TITLE
Update to cleaned up go-ipa APIs

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sort"
 
+	"github.com/crate-crypto/go-ipa/banderwagon"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -54,7 +55,7 @@ func BatchNewLeafNode(nodesValues []BatchNewLeafNodeData) ([]LeafNode, error) {
 					c1c2frs[2*i], c1c2frs[2*i+1] = new(Fr), new(Fr)
 				}
 
-				toFrMultiple(c1c2frs, c1c2points)
+				banderwagon.BatchMapToScalarField(c1c2frs, c1c2points)
 
 				var poly [NodeWidth]Fr
 				poly[0].SetUint64(1)

--- a/empty.go
+++ b/empty.go
@@ -49,7 +49,7 @@ func (n Empty) Commit() *Point {
 
 func (Empty) Commitment() *Point {
 	var id Point
-	id.Identity()
+	id.SetIdentity()
 	return &id
 }
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,6 +1,10 @@
 package verkle
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/crate-crypto/go-ipa/banderwagon"
+)
 
 func TestParseNodeEmptyPayload(t *testing.T) {
 	t.Parallel()
@@ -25,8 +29,8 @@ func TestLeafStemLength(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ser) != nodeTypeSize+StemSize+bitlistSize+3*SerializedPointUncompressedSize {
-		t.Fatalf("invalid serialization when the stem is longer than 31 bytes: %x (%d bytes != %d)", ser, len(ser), nodeTypeSize+StemSize+bitlistSize+2*SerializedPointUncompressedSize)
+	if len(ser) != nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize {
+		t.Fatalf("invalid serialization when the stem is longer than 31 bytes: %x (%d bytes != %d)", ser, len(ser), nodeTypeSize+StemSize+bitlistSize+2*banderwagon.UncompressedSize)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gballet/go-verkle
 go 1.19
 
 require (
-	github.com/crate-crypto/go-ipa v0.0.0-20230901133332-44e6ab66db62
+	github.com/crate-crypto/go-ipa v0.0.0-20230904185759-9f7637e8ddd0
 	golang.org/x/sync v0.1.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gballet/go-verkle
 go 1.19
 
 require (
-	github.com/crate-crypto/go-ipa v0.0.0-20230831204142-34060f3f415e
+	github.com/crate-crypto/go-ipa v0.0.0-20230901133332-44e6ab66db62
 	golang.org/x/sync v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.11.2 h1:GJjjtWJ+db1xGao7vTsOgAOGgjfPe7eRGPL+xxMX0qE=
 github.com/consensys/gnark-crypto v0.11.2/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
-github.com/crate-crypto/go-ipa v0.0.0-20230901133332-44e6ab66db62 h1:LfHpykkkq9KQsqCcU4/M9J/51zBb7mp9aM+yudjePdc=
-github.com/crate-crypto/go-ipa v0.0.0-20230901133332-44e6ab66db62/go.mod h1:7fZtshzGQ3dxVpDpF51K9mX8oziq8Xd5AoM/UT9fF5o=
+github.com/crate-crypto/go-ipa v0.0.0-20230904185759-9f7637e8ddd0 h1:MztzKYOxMeC8HlWGXvq2wizas+QT0FgITjGThfmbh/0=
+github.com/crate-crypto/go-ipa v0.0.0-20230904185759-9f7637e8ddd0/go.mod h1:7fZtshzGQ3dxVpDpF51K9mX8oziq8Xd5AoM/UT9fF5o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.11.2 h1:GJjjtWJ+db1xGao7vTsOgAOGgjfPe7eRGPL+xxMX0qE=
 github.com/consensys/gnark-crypto v0.11.2/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
-github.com/crate-crypto/go-ipa v0.0.0-20230831204142-34060f3f415e h1:M2BwoAiEw0Y77ornI/hCE4Ny8zzV25lES2GmS4hYBFQ=
-github.com/crate-crypto/go-ipa v0.0.0-20230831204142-34060f3f415e/go.mod h1:7fZtshzGQ3dxVpDpF51K9mX8oziq8Xd5AoM/UT9fF5o=
+github.com/crate-crypto/go-ipa v0.0.0-20230901133332-44e6ab66db62 h1:LfHpykkkq9KQsqCcU4/M9J/51zBb7mp9aM+yudjePdc=
+github.com/crate-crypto/go-ipa v0.0.0-20230901133332-44e6ab66db62/go.mod h1:7fZtshzGQ3dxVpDpF51K9mX8oziq8Xd5AoM/UT9fF5o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=

--- a/ipa.go
+++ b/ipa.go
@@ -38,26 +38,6 @@ type (
 	SerializedPointCompressed = []byte
 )
 
-const (
-	SerializedPointUncompressedSize = banderwagon.UncompressedSize
-)
-
-func CopyFr(dst, src *Fr) {
-	copy(dst[:], src[:])
-}
-
-func CopyPoint(dst, src *Point) {
-	dst.Set(src)
-}
-
-func toFr(fr *Fr, p *Point) {
-	p.MapToScalarField(fr)
-}
-
-func toFrMultiple(res []*Fr, ps []*Point) {
-	banderwagon.BatchMapToScalarField(res, ps)
-}
-
 func FromLEBytes(fr *Fr, data []byte) error {
 	if len(data) > 32 {
 		return errors.New("data is too long")
@@ -79,8 +59,4 @@ func FromBytes(fr *Fr, data []byte) {
 	var aligned [32]byte
 	copy(aligned[32-len(data):], data)
 	fr.SetBytes(aligned[:])
-}
-
-func Equal(self *Point, other *Point) bool {
-	return other.Equal(self)
 }

--- a/ipa.go
+++ b/ipa.go
@@ -28,19 +28,18 @@ package verkle
 import (
 	"errors"
 
-	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/crate-crypto/go-ipa/banderwagon"
 )
 
 type (
-	Fr                        = fr.Element
+	Fr                        = banderwagon.Fr
 	Point                     = banderwagon.Element
 	SerializedPoint           = []byte
 	SerializedPointCompressed = []byte
 )
 
 const (
-	SerializedPointUncompressedSize = 64
+	SerializedPointUncompressedSize = banderwagon.UncompressedSize
 )
 
 func CopyFr(dst, src *Fr) {
@@ -56,7 +55,7 @@ func toFr(fr *Fr, p *Point) {
 }
 
 func toFrMultiple(res []*Fr, ps []*Point) {
-	banderwagon.MultiMapToScalarField(res, ps)
+	banderwagon.BatchMapToScalarField(res, ps)
 }
 
 func FromLEBytes(fr *Fr, data []byte) error {

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -230,7 +230,7 @@ func DeserializeProof(vp *VerkleProof, statediff StateDiff) (*Proof, error) {
 	commitments = make([]*Point, len(vp.CommitmentsByPath))
 	for i, commitmentBytes := range vp.CommitmentsByPath {
 		var commitment Point
-		if err := commitment.SetBytesTrusted(commitmentBytes[:]); err != nil {
+		if err := commitment.SetBytesUnsafe(commitmentBytes[:]); err != nil {
 			return nil, err
 		}
 		commitments[i] = &commitment

--- a/proof_test.go
+++ b/proof_test.go
@@ -628,16 +628,16 @@ func TestStatelessDeserialize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !Equal(droot.Commit(), root.Commitment()) {
+	if !droot.Commit().Equal(root.Commitment()) {
 		t.Log(ToDot(droot), ToDot(root))
 		t.Fatalf("differing root commitments %x != %x", droot.Commitment().Bytes(), root.Commitment().Bytes())
 	}
 
-	if !Equal(droot.(*InternalNode).children[0].(*LeafNode).commitment, root.(*InternalNode).children[0].Commit()) {
+	if !droot.(*InternalNode).children[0].(*LeafNode).commitment.Equal(root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 
-	if !Equal(droot.(*InternalNode).children[64].Commit(), root.(*InternalNode).children[64].Commit()) {
+	if !droot.(*InternalNode).children[64].Commit().Equal(root.(*InternalNode).children[64].Commit()) {
 		t.Fatal("differing commitment for child #64")
 	}
 }
@@ -667,10 +667,10 @@ func TestStatelessDeserializeMissingChildNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !Equal(droot.Commit(), root.Commit()) {
+	if !droot.Commit().Equal(root.Commit()) {
 		t.Fatal("differing root commitments")
 	}
-	if !Equal(droot.(*InternalNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
+	if !droot.(*InternalNode).children[0].Commit().Equal(root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 
@@ -705,11 +705,11 @@ func TestStatelessDeserializeDepth2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !Equal(droot.Commit(), root.Commit()) {
+	if !droot.Commit().Equal(root.Commit()) {
 		t.Fatal("differing root commitments")
 	}
 
-	if !Equal(droot.(*InternalNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
+	if !droot.(*InternalNode).children[0].Commit().Equal(root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -227,7 +227,7 @@ func newInternalNode(depth byte) VerkleNode {
 		node.children[idx] = Empty(struct{}{})
 	}
 	node.depth = depth
-	node.commitment = new(Point).Identity()
+	node.commitment = new(Point).SetIdentity()
 	return node
 }
 
@@ -1467,7 +1467,7 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 // Serialize serializes a LeafNode.
 // The format is: <nodeType><stem><bitlist><comm><c1comm><c2comm><children...>
 func (n *LeafNode) Serialize() ([]byte, error) {
-	cBytes := banderwagon.ElementsToBytesUncompressed([]*banderwagon.Element{n.commitment, n.c1, n.c2})
+	cBytes := banderwagon.BatchToBytesUncompressed(n.commitment, n.c1, n.c2)
 	return n.serializeLeafWithUncompressedCommitments(cBytes[0], cBytes[1], cBytes[2]), nil
 }
 
@@ -1577,7 +1577,7 @@ func (n *InternalNode) BatchSerialize() ([]SerializedNode, error) {
 	}
 
 	// Now we do the all transformations in a single-shot.
-	serializedPoints := banderwagon.ElementsToBytesUncompressed(pointsToCompress)
+	serializedPoints := banderwagon.BatchToBytesUncompressed(pointsToCompress...)
 
 	// Now we that we did the heavy CPU work, we have to do the rest of `nodes` serialization
 	// taking the compressed points from this single list.

--- a/tree.go
+++ b/tree.go
@@ -289,7 +289,7 @@ func NewLeafNode(stem []byte, values [][]byte) (*LeafNode, error) {
 	if err := StemFromBytes(&poly[1], stem); err != nil {
 		return nil, err
 	}
-	toFrMultiple([]*Fr{&poly[2], &poly[3]}, []*Point{c1, c2})
+	banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{c1, c2})
 
 	return &LeafNode{
 		// depth will be 0, but the commitment calculation
@@ -336,7 +336,7 @@ func (n *InternalNode) cowChild(index byte) {
 
 	if n.cow[index] == nil {
 		n.cow[index] = new(Point)
-		CopyPoint(n.cow[index], n.children[index].Commitment())
+		n.cow[index].Set(n.children[index].Commitment())
 	}
 }
 
@@ -656,7 +656,7 @@ func (n *InternalNode) Get(key []byte, resolver NodeResolverFn) ([]byte, error) 
 
 func (n *InternalNode) Hash() *Fr {
 	var hash Fr
-	toFr(&hash, n.Commitment())
+	n.Commitment().MapToScalarField(&hash)
 	return &hash
 }
 
@@ -741,7 +741,7 @@ func commitNodesAtLevel(nodes []*InternalNode) {
 	}
 
 	// Do a single batch calculation for all the points in this level.
-	toFrMultiple(frs, points)
+	banderwagon.BatchMapToScalarField(frs, points)
 
 	// We calculate the difference between each (new commitment - old commitment) pair, and store it
 	// in the same slice to avoid allocations.
@@ -842,14 +842,15 @@ func (n *InternalNode) GetProofItems(keys keylist, resolver NodeResolverFn) (*Pr
 			points[i] = new(Point)
 		}
 	}
-	toFrMultiple(fiPtrs[:], points[:])
+	banderwagon.BatchMapToScalarField(fiPtrs[:], points[:])
 
 	for _, group := range groups {
 		childIdx := offset2key(group[0], n.depth)
 
 		// Build the list of elements for this level
 		var yi Fr
-		CopyFr(&yi, &fi[childIdx])
+		yi.Set(&fi[childIdx])
+
 		pe.Cis = append(pe.Cis, n.commitment)
 		pe.Zis = append(pe.Zis, childIdx)
 		pe.Yis = append(pe.Yis, &yi)
@@ -899,7 +900,7 @@ func (n *InternalNode) GetProofItems(keys keylist, resolver NodeResolverFn) (*Pr
 // Serialize returns the serialized form of the internal node.
 // The format is: <nodeType><bitlist><commitment>
 func (n *InternalNode) Serialize() ([]byte, error) {
-	ret := make([]byte, nodeTypeSize+bitlistSize+SerializedPointUncompressedSize)
+	ret := make([]byte, nodeTypeSize+bitlistSize+banderwagon.UncompressedSize)
 
 	// Write the <bitlist>.
 	bitlist := ret[internalBitlistOffset:internalCommitmentOffset]
@@ -931,14 +932,14 @@ func (n *InternalNode) Copy() VerkleNode {
 	}
 
 	if n.commitment != nil {
-		CopyPoint(ret.commitment, n.commitment)
+		ret.commitment.Set(n.commitment)
 	}
 
 	if n.cow != nil {
 		ret.cow = make(map[byte]*Point)
 		for k, v := range n.cow {
 			ret.cow[k] = new(Point)
-			CopyPoint(ret.cow[k], v)
+			ret.cow[k].Set(v)
 		}
 	}
 
@@ -948,7 +949,7 @@ func (n *InternalNode) Copy() VerkleNode {
 func (n *InternalNode) toDot(parent, path string) string {
 	me := fmt.Sprintf("internal%s", path)
 	var hash Fr
-	toFr(&hash, n.commitment)
+	n.commitment.MapToScalarField(&hash)
 	ret := fmt.Sprintf("%s [label=\"I: %x\"]\n", me, hash.BytesLE())
 	if len(parent) > 0 {
 		ret = fmt.Sprintf("%s %s -> %s\n", ret, parent, me)
@@ -1080,7 +1081,7 @@ func (n *LeafNode) updateLeaf(index byte, value []byte) error {
 
 	// Batch the Fr transformation of the new and old CX.
 	var frs [2]Fr
-	toFrMultiple([]*Fr{&frs[0], &frs[1]}, []*Point{c, &oldC})
+	banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{c, &oldC})
 
 	// If index is in the first NodeWidth/2 elements, we need to update C1. Otherwise, C2.
 	cxIndex := 2 + int(index)/(NodeWidth/2) // [1, stem, -> C1, C2 <-]
@@ -1133,14 +1134,14 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) error {
 	const c2Idx = 3 // [1, stem, C1, ->C2<-]
 
 	if oldC1 != nil && oldC2 != nil { // Case 1.
-		toFrMultiple([]*Fr{&frs[0], &frs[1], &frs[2], &frs[3]}, []*Point{n.c1, oldC1, n.c2, oldC2})
+		banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1], &frs[2], &frs[3]}, []*Point{n.c1, oldC1, n.c2, oldC2})
 		n.updateC(c1Idx, frs[0], frs[1])
 		n.updateC(c2Idx, frs[2], frs[3])
 	} else if oldC1 != nil { // Case 2. (C1 touched)
-		toFrMultiple([]*Fr{&frs[0], &frs[1]}, []*Point{n.c1, oldC1})
+		banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c1, oldC1})
 		n.updateC(c1Idx, frs[0], frs[1])
 	} else if oldC2 != nil { // Case 2. (C2 touched)
-		toFrMultiple([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2})
+		banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2})
 		n.updateC(c2Idx, frs[0], frs[1])
 	}
 
@@ -1213,7 +1214,7 @@ func (n *LeafNode) Delete(k []byte, _ NodeResolverFn) (bool, error) {
 		// operation which is slow no matter what, so ensuring correctness
 		// is more important than
 		var poly [4]Fr
-		toFr(&poly[subtreeindex], cn)
+		cn.MapToScalarField(&poly[subtreeindex])
 		n.commitment.Sub(n.commitment, cfg.CommitToPoly(poly[:], 0))
 
 		// Clear the corresponding commitment
@@ -1257,7 +1258,7 @@ func (n *LeafNode) Hash() *Fr {
 	// to reduce complexity.
 	// TODO use n.commitment once all Insert* are diff-inserts
 	var hash Fr
-	toFr(&hash, n.Commitment())
+	n.Commitment().MapToScalarField(&hash)
 	return &hash
 }
 
@@ -1341,7 +1342,7 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 	if err := StemFromBytes(&poly[1], n.stem); err != nil {
 		return nil, nil, nil, err
 	}
-	toFrMultiple([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2})
+	banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2})
 
 	// First pass: add top-level elements first
 	var hasC1, hasC2 bool
@@ -1483,15 +1484,15 @@ func (n *LeafNode) Copy() VerkleNode {
 	}
 	if n.commitment != nil {
 		l.commitment = new(Point)
-		CopyPoint(l.commitment, n.commitment)
+		l.commitment.Set(n.commitment)
 	}
 	if n.c1 != nil {
 		l.c1 = new(Point)
-		CopyPoint(l.c1, n.c1)
+		l.c1.Set(n.c1)
 	}
 	if n.c2 != nil {
 		l.c2 = new(Point)
-		CopyPoint(l.c2, n.c2)
+		l.c2.Set(n.c2)
 	}
 
 	return l
@@ -1513,7 +1514,7 @@ func (n *LeafNode) Value(i int) []byte {
 
 func (n *LeafNode) toDot(parent, path string) string {
 	var hash Fr
-	toFr(&hash, n.Commitment())
+	n.Commitment().MapToScalarField(&hash)
 	ret := fmt.Sprintf("leaf%s [label=\"L: %x\nC: %x\nC₁: %x\nC₂:%x\"]\n%s -> leaf%s\n", path, hash.Bytes(), n.commitment.Bytes(), n.c1.Bytes(), n.c2.Bytes(), parent, path)
 	for i, v := range n.values {
 		if v != nil {
@@ -1546,7 +1547,7 @@ func ToDot(root VerkleNode) string {
 // Providing both allows this library to do more optimizations.
 type SerializedNode struct {
 	Node            VerkleNode
-	CommitmentBytes [SerializedPointUncompressedSize]byte
+	CommitmentBytes [banderwagon.UncompressedSize]byte
 	Path            []byte
 	SerializedBytes []byte
 }
@@ -1635,8 +1636,8 @@ func (n *InternalNode) collectNonHashedNodes(list []VerkleNode, paths [][]byte, 
 }
 
 // unpack one compressed commitment from the list of batch-compressed commitments
-func (n *InternalNode) serializeInternalWithUncompressedCommitment(pointsIdx map[VerkleNode]int, serializedPoints [][SerializedPointUncompressedSize]byte) ([]byte, error) {
-	serialized := make([]byte, nodeTypeSize+bitlistSize+SerializedPointUncompressedSize)
+func (n *InternalNode) serializeInternalWithUncompressedCommitment(pointsIdx map[VerkleNode]int, serializedPoints [][banderwagon.UncompressedSize]byte) ([]byte, error) {
+	serialized := make([]byte, nodeTypeSize+bitlistSize+banderwagon.UncompressedSize)
 	bitlist := serialized[internalBitlistOffset:internalCommitmentOffset]
 	for i, c := range n.children {
 		if _, ok := c.(Empty); !ok {
@@ -1653,7 +1654,7 @@ func (n *InternalNode) serializeInternalWithUncompressedCommitment(pointsIdx map
 	return serialized, nil
 }
 
-func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2Bytes [SerializedPointUncompressedSize]byte) []byte {
+func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2Bytes [banderwagon.UncompressedSize]byte) []byte {
 	// Empty value in LeafNode used for padding.
 	var emptyValue [LeafValueSize]byte
 
@@ -1671,7 +1672,7 @@ func (n *LeafNode) serializeLeafWithUncompressedCommitments(cBytes, c1Bytes, c2B
 	}
 
 	// Create the serialization.
-	result := make([]byte, nodeTypeSize+StemSize+bitlistSize+3*SerializedPointUncompressedSize+len(children))
+	result := make([]byte, nodeTypeSize+StemSize+bitlistSize+3*banderwagon.UncompressedSize+len(children))
 	result[0] = leafRLPType
 	copy(result[leafSteamOffset:], n.stem[:StemSize])
 	copy(result[leafBitlistOffset:], bitlist[:])

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -61,7 +61,7 @@ func extensionAndSuffixOneKey(key, value []byte, ret *Point) {
 
 	leafToComms(vs[:], value)
 	c1.Add(t1.ScalarMul(&srs[2*key[31]], &vs[0]), t2.ScalarMul(&srs[2*key[31]+1], &vs[1]))
-	toFr(&v, &c1)
+	c1.MapToScalarField(&v)
 	stemComm2.ScalarMul(&srs[2], &v)
 
 	v.SetZero()
@@ -92,10 +92,10 @@ func TestInsertKey0Value0(t *testing.T) {
 		t.Fatal("commitment is identity")
 	}
 
-	toFr(&expected, &expectedP)
+	expectedP.MapToScalarField(&expected)
 	expectedP.ScalarMul(&srs[0], &expected)
 
-	if !Equal(comm, &expectedP) {
+	if !comm.Equal(&expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -118,14 +118,14 @@ func TestInsertKey1Value1(t *testing.T) {
 	comm := root.Commit()
 
 	extensionAndSuffixOneKey(key, key, &expectedP)
-	toFr(&v, &expectedP)
+	expectedP.MapToScalarField(&v)
 	expectedP.ScalarMul(&srs[1], &v)
 
 	if expectedP.Equal(identity) {
 		t.Fatal("commitment is identity")
 	}
 
-	if !Equal(comm, &expectedP) {
+	if !comm.Equal(&expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -163,25 +163,25 @@ func TestInsertSameStemTwoLeaves(t *testing.T) {
 
 	leafToComms(vs[:], key_a)
 	c1.Add(t1.ScalarMul(&srs[64], &vs[0]), t2.ScalarMul(&srs[65], &vs[1]))
-	toFr(&v, &c1)
+	c1.MapToScalarField(&v)
 	stemComm2.ScalarMul(&srs[2], &v)
 
 	leafToComms(vs[:], key_b)
 	c2.Add(t1.ScalarMul(&srs[0], &vs[0]), t2.ScalarMul(&srs[1], &vs[1]))
-	toFr(&v, &c2)
+	c2.MapToScalarField(&v)
 	stemComm3.ScalarMul(&srs[3], &v)
 
 	t1.Add(&stemComm0, &stemComm1)
 	t2.Add(&stemComm2, &stemComm3)
 	expectedP.Add(&t1, &t2)
-	toFr(&v, &expectedP)
+	expectedP.MapToScalarField(&v)
 	expectedP.ScalarMul(&srs[1], &v)
 
 	if expectedP.Equal(identity) {
 		t.Fatal("commitment is identity")
 	}
 
-	if !Equal(comm, &expectedP) {
+	if !comm.Equal(&expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -203,19 +203,19 @@ func TestInsertKey1Val1Key2Val2(t *testing.T) {
 	fmt.Println(root.toDot("", ""))
 
 	extensionAndSuffixOneKey(zeroKeyTest, zeroKeyTest, &t1)
-	toFr(&v1, &t1)
+	t1.MapToScalarField(&v1)
 
 	extensionAndSuffixOneKey(key_b, key_b, &t2)
-	toFr(&v2, &t2)
+	t2.MapToScalarField(&v2)
 
 	expectedP.Add(t1.ScalarMul(&srs[0], &v1), t2.ScalarMul(&srs[1], &v2))
-	toFr(&v, &expectedP)
+	expectedP.MapToScalarField(&v)
 
 	if expectedP.Equal(identity) {
 		t.Fatal("commitment is identity")
 	}
 
-	if !Equal(comm, &expectedP) {
+	if !comm.Equal(&expectedP) {
 		t.Fatalf("invalid root commitment %v != %v", comm, &expected)
 	}
 }
@@ -236,7 +236,7 @@ func TestGroupToField(t *testing.T) {
 
 	point := banderwagon.Generator
 	var v Fr
-	toFr(&v, &point)
+	point.MapToScalarField(&v)
 	bytes := v.BytesLE()
 	hexStr := hex.EncodeToString(bytes[:])
 	if hexStr != "d1e7de2aaea9603d5bc6c208d319596376556ecd8336671ba7670c2139772d14" {
@@ -249,7 +249,7 @@ func BenchmarkGroupToField(b *testing.B) {
 		point := banderwagon.Generator
 		var v Fr
 		for i := 0; i < b.N; i++ {
-			toFr(&v, &point)
+			point.MapToScalarField(&v)
 		}
 	})
 
@@ -272,7 +272,7 @@ func BenchmarkGroupToField(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for k := 0; k < b.N; k++ {
-					toFrMultiple(ptrs, points)
+					banderwagon.BatchMapToScalarField(ptrs, points)
 				}
 				b.ReportMetric(float64(time.Since(now).Nanoseconds()/int64(i))/float64(b.N), "ns/value")
 				_ = sink

--- a/tree_ipa_test.go
+++ b/tree_ipa_test.go
@@ -39,7 +39,7 @@ var identity *Point
 
 func init() {
 	var id Point
-	id.Identity()
+	id.SetIdentity()
 	identity = &id
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -210,13 +210,13 @@ func TestCopy(t *testing.T) {
 
 	tree.Insert(key3, fourtyKeyTest, nil)
 
-	if Equal(tree.Commit(), copied.Commit()) {
+	if tree.Commit().Equal(copied.Commit()) {
 		t.Fatal("inserting the copy into the original tree updated the copy's commitment")
 	}
 
 	copied.Insert(key3, fourtyKeyTest, nil)
 
-	if !Equal(tree.Commitment(), copied.Commit()) {
+	if !tree.Commitment().Equal(copied.Commit()) {
 		t.Fatalf("differing final commitments %x != %x", tree.Commitment().Bytes(), copied.Commitment().Bytes())
 	}
 }
@@ -267,7 +267,7 @@ func TestDelLeaf(t *testing.T) {
 	tree.Insert(key1pp, fourtyKeyTest, nil)
 	tree.Insert(key2, fourtyKeyTest, nil)
 	var init Point
-	CopyPoint(&init, tree.Commit())
+	init.Set(tree.Commit())
 
 	tree.Insert(key3, fourtyKeyTest, nil)
 	if _, err := tree.Delete(key3, nil); err != nil {
@@ -278,7 +278,7 @@ func TestDelLeaf(t *testing.T) {
 	// as deleting a value means replacing it with a 0 in verkle
 	// trees.
 	postHash := tree.Commit()
-	if !Equal(&init, postHash) {
+	if !init.Equal(postHash) {
 		t.Errorf("deleting leaf resulted in unexpected tree %x %x", init.Bytes(), postHash.Bytes())
 	}
 
@@ -340,12 +340,12 @@ func TestDeletePrune(t *testing.T) {
 	tree.Insert(key2, fourtyKeyTest, nil)
 
 	var hashPostKey2, hashPostKey4, completeTreeHash Point
-	CopyPoint(&hashPostKey2, tree.Commit())
+	hashPostKey2.Set(tree.Commit())
 	tree.Insert(key3, fourtyKeyTest, nil)
 	tree.Insert(key4, fourtyKeyTest, nil)
-	CopyPoint(&hashPostKey4, tree.Commit())
+	hashPostKey4.Set(tree.Commit())
 	tree.Insert(key5, fourtyKeyTest, nil)
-	CopyPoint(&completeTreeHash, tree.Commit()) // hash when the tree has received all its keys
+	completeTreeHash.Set(tree.Commit()) // hash when the tree has received all its keys
 
 	// Delete key5.
 	if _, err := tree.Delete(key5, nil); err != nil {
@@ -354,11 +354,11 @@ func TestDeletePrune(t *testing.T) {
 	postHash := tree.Commit()
 	// Check that the deletion updated the root hash and that it's not
 	// the same as the pre-deletion hash.
-	if Equal(&completeTreeHash, postHash) {
+	if completeTreeHash.Equal(postHash) {
 		t.Fatalf("deletion did not update the hash %x == %x", completeTreeHash, postHash)
 	}
 	// The post deletion hash should be the same as the post key4 hash.
-	if !Equal(&hashPostKey4, postHash) {
+	if !hashPostKey4.Equal(postHash) {
 		t.Error("deleting leaf #5 resulted in unexpected tree")
 	}
 	res, err := tree.Get(key5, nil)
@@ -378,7 +378,7 @@ func TestDeletePrune(t *testing.T) {
 	}
 	postHash = tree.Commit()
 	// The post deletion hash should be different from the post key2 hash.
-	if !Equal(&hashPostKey2, postHash) {
+	if !hashPostKey2.Equal(postHash) {
 		t.Error("deleting leaf #3 resulted in unexpected tree")
 	}
 	res, err = tree.Get(key3, nil)
@@ -488,7 +488,7 @@ func TestConcurrentTrees(t *testing.T) {
 
 	for i := 0; i < threads; i++ {
 		root := <-ch
-		if !Equal(root, expected) {
+		if !root.Equal(expected) {
 			t.Error("Incorrect root")
 		}
 	}
@@ -1007,7 +1007,7 @@ func TestInsertStem(t *testing.T) {
 	root2.Insert(key192[:], fourtyKeyTest, nil)
 	r2c := root2.Commit()
 
-	if !Equal(r1c, r2c) {
+	if !r1c.Equal(r2c) {
 		t.Fatalf("differing commitments %x != %x %s %s", r1c.Bytes(), r2c.Bytes(), ToDot(root1), ToDot(root2))
 	}
 }

--- a/unknown.go
+++ b/unknown.go
@@ -47,7 +47,7 @@ func (n UnknownNode) Commit() *Point {
 
 func (UnknownNode) Commitment() *Point {
 	var id Point
-	id.Identity()
+	id.SetIdentity()
 	return &id
 }
 

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -17,7 +17,7 @@ func TestUnknownFuncs(t *testing.T) {
 		t.Errorf("got %v, want nil", err)
 	}
 	var identity Point
-	identity.Identity()
+	identity.SetIdentity()
 	if comm := un.Commit(); !comm.Equal(&identity) {
 		t.Errorf("got %v, want identity", comm)
 	}


### PR DESCRIPTION
This PR is updating `go-ipa` to a (tentative) cleaned-up version of APIs and other improvements.
https://github.com/crate-crypto/go-ipa/pull/55

For now, this PR has minimal changes to comply with the changes, but I'd like to gather some feedback about eliminating some extra proxies that we have too.

TODO:
- [x] Update go.mod with the final new `go-ipa@master` when [underlying PR](https://github.com/crate-crypto/go-ipa/pull/55) is merged.