### PR TITLE
Check for all returned errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ run:
 linters:
   disable-all: true
   enable:
+    - errcheck
     - gofmt
     - staticcheck
     - deadcode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - errcheck
     - gofmt
     - staticcheck
-    - deadcode
     - goconst
     - goimports
     - gosimple
@@ -23,7 +22,7 @@ linters:
     - ineffassign
     - misspell
     - unconvert
-    - varcheck
+    - unused
 
 linters-settings:
   gofmt:

--- a/benchs/main.go
+++ b/benchs/main.go
@@ -17,9 +17,9 @@ func main() {
 func benchmarkInsertInExisting() {
 	f, _ := os.Create("cpu.prof")
 	g, _ := os.Create("mem.prof")
-	pprof.StartCPUProfile(f)
+	_ = pprof.StartCPUProfile(f)
 	defer pprof.StopCPUProfile()
-	defer pprof.WriteHeapProfile(g)
+	defer func() { _ = pprof.WriteHeapProfile(g) }()
 	// Number of existing leaves in tree
 	n := 1000000
 	// Leaves to be inserted afterwards
@@ -34,7 +34,9 @@ func benchmarkInsertInExisting() {
 		// Generate set of keys once
 		for i := 0; i < total; i++ {
 			key := make([]byte, 32)
-			rand.Read(key)
+			if _, err := rand.Read(key); err != nil {
+				panic(err)
+			}
 			if i < n {
 				keys[i] = key
 			} else {

--- a/conversion.go
+++ b/conversion.go
@@ -147,7 +147,7 @@ func (n *InternalNode) InsertMigratedLeaves(leaves []LeafNode, resolver NodeReso
 	return nil
 }
 
-func (n *InternalNode) insertMigratedLeavesSubtree(leaves []LeafNode, resolver NodeResolverFn) error {
+func (n *InternalNode) insertMigratedLeavesSubtree(leaves []LeafNode, resolver NodeResolverFn) error { // skipcq: GO-R1005
 	for i := range leaves {
 		ln := leaves[i]
 		parent := n

--- a/conversion.go
+++ b/conversion.go
@@ -55,7 +55,9 @@ func BatchNewLeafNode(nodesValues []BatchNewLeafNodeData) ([]LeafNode, error) {
 					c1c2frs[2*i], c1c2frs[2*i+1] = new(Fr), new(Fr)
 				}
 
-				banderwagon.BatchMapToScalarField(c1c2frs, c1c2points)
+				if err := banderwagon.BatchMapToScalarField(c1c2frs, c1c2points); err != nil {
+					return fmt.Errorf("mapping to scalar field: %s", err)
+				}
 
 				var poly [NodeWidth]Fr
 				poly[0].SetUint64(1)

--- a/debug_test.go
+++ b/debug_test.go
@@ -33,10 +33,18 @@ func TestJSON(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, fourtyKeyTest, nil)
-	root.Insert(oneKeyTest, zeroKeyTest, nil)
-	root.Insert(forkOneKeyTest, zeroKeyTest, nil) // Force an internal node in the first layer.
-	root.Insert(fourtyKeyTest, oneKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, fourtyKeyTest, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := root.Insert(forkOneKeyTest, zeroKeyTest, nil); err != nil { // Force an internal node in the first layer.
+		t.Fatal(err)
+	}
+	if err := root.Insert(fourtyKeyTest, oneKeyTest, nil); err != nil {
+		t.Fatal(err)
+	}
 	root.(*InternalNode).children[152] = HashedNode{}
 	root.Commit()
 

--- a/encoding.go
+++ b/encoding.go
@@ -109,11 +109,17 @@ func parseLeafNode(serialized []byte, depth byte) (VerkleNode, error) {
 		return nil, fmt.Errorf("leaf node commitments are not the correct size, expected at least %d, got %d", 3*banderwagon.UncompressedSize, len(serialized[leafC1CommitmentOffset:]))
 	}
 
-	ln.c1.SetBytesUncompressed(serialized[leafC1CommitmentOffset:leafC1CommitmentOffset+banderwagon.UncompressedSize], true)
+	if err := ln.c1.SetBytesUncompressed(serialized[leafC1CommitmentOffset:leafC1CommitmentOffset+banderwagon.UncompressedSize], true); err != nil {
+		return nil, fmt.Errorf("setting c1 commitment: %w", err)
+	}
 	ln.c2 = new(Point)
-	ln.c2.SetBytesUncompressed(serialized[leafC2CommitmentOffset:leafC2CommitmentOffset+banderwagon.UncompressedSize], true)
+	if err := ln.c2.SetBytesUncompressed(serialized[leafC2CommitmentOffset:leafC2CommitmentOffset+banderwagon.UncompressedSize], true); err != nil {
+		return nil, fmt.Errorf("setting c2 commitment: %w", err)
+	}
 	ln.commitment = new(Point)
-	ln.commitment.SetBytesUncompressed(serialized[leafCommitmentOffset:leafC1CommitmentOffset], true)
+	if err := ln.commitment.SetBytesUncompressed(serialized[leafCommitmentOffset:leafC1CommitmentOffset], true); err != nil {
+		return nil, fmt.Errorf("setting commitment: %w", err)
+	}
 	return ln, nil
 }
 
@@ -145,6 +151,8 @@ func CreateInternalNode(bitlist []byte, raw []byte, depth byte) (*InternalNode, 
 	}
 
 	node.commitment = new(Point)
-	node.commitment.SetBytesUncompressed(raw, true)
+	if err := node.commitment.SetBytesUncompressed(raw, true); err != nil {
+		return nil, fmt.Errorf("setting commitment: %w", err)
+	}
 	return node, nil
 }

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -309,15 +309,21 @@ func DeserializeProof(vp *VerkleProof, statediff StateDiff) (*Proof, error) {
 		commitments[i] = &commitment
 	}
 
-	multipoint.D.SetBytes(vp.D[:])
+	if err := multipoint.D.SetBytes(vp.D[:]); err != nil {
+		return nil, fmt.Errorf("setting D: %w", err)
+	}
 	multipoint.IPA.A_scalar.SetBytes(vp.IPAProof.FinalEvaluation[:])
 	multipoint.IPA.L = make([]Point, IPA_PROOF_DEPTH)
 	for i, b := range vp.IPAProof.CL {
-		multipoint.IPA.L[i].SetBytes(b[:])
+		if err := multipoint.IPA.L[i].SetBytes(b[:]); err != nil {
+			return nil, fmt.Errorf("setting L[%d]: %w", i, err)
+		}
 	}
 	multipoint.IPA.R = make([]Point, IPA_PROOF_DEPTH)
 	for i, b := range vp.IPAProof.CR {
-		multipoint.IPA.R[i].SetBytes(b[:])
+		if err := multipoint.IPA.R[i].SetBytes(b[:]); err != nil {
+			return nil, fmt.Errorf("setting R[%d]: %w", i, err)
+		}
 	}
 
 	// turn statediff into keys and values

--- a/proof_test.go
+++ b/proof_test.go
@@ -857,13 +857,17 @@ func TestProofVerificationWithPostState(t *testing.T) {
 
 			root := New()
 			for i := range data.keys {
-				root.Insert(data.keys[i], data.values[i], nil)
+				if err := root.Insert(data.keys[i], data.values[i], nil); err != nil {
+					t.Fatalf("could not insert key: %v", err)
+				}
 			}
 			rootC := root.Commit()
 
 			postroot := root.Copy()
 			for i := range data.updatekeys {
-				postroot.Insert(data.updatekeys[i], data.updatevalues[i], nil)
+				if err := postroot.Insert(data.updatekeys[i], data.updatevalues[i], nil); err != nil {
+					t.Fatalf("could not insert key: %v", err)
+				}
 			}
 			postroot.Commit()
 

--- a/proof_test.go
+++ b/proof_test.go
@@ -38,9 +38,15 @@ func TestProofVerifyTwoLeaves(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(oneKeyTest, zeroKeyTest, nil)
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, nil, [][]byte{ffx32KeyTest}, nil)
@@ -60,9 +66,13 @@ func TestProofVerifyMultipleLeaves(t *testing.T) {
 	root := New()
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
-		rand.Read(key)
+		if _, err := rand.Read(key); err != nil {
+			t.Fatalf("could not read random bytes: %v", err)
+		}
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 	root.Commit()
 
@@ -83,9 +93,13 @@ func TestMultiProofVerifyMultipleLeaves(t *testing.T) {
 	root := New()
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
-		rand.Read(key)
+		if _, err := rand.Read(key); err != nil {
+			t.Fatalf("could not read random bytes: %v", err)
+		}
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 	root.Commit()
 
@@ -112,7 +126,9 @@ func TestMultiProofVerifyMultipleLeavesWithAbsentStem(t *testing.T) {
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
 		key[2] = byte(i)
-		root.Insert(key, fourtyKeyTest, nil)
+		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 		if i%2 == 0 {
 			keys = append(keys, key)
 		}
@@ -152,9 +168,13 @@ func TestMultiProofVerifyMultipleLeavesCommitmentRedundancy(t *testing.T) {
 	keys := make([][]byte, 2)
 	root := New()
 	keys[0] = zeroKeyTest
-	root.Insert(keys[0], fourtyKeyTest, nil)
+	if err := root.Insert(keys[0], fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	keys[1] = oneKeyTest
-	root.Insert(keys[1], fourtyKeyTest, nil)
+	if err := root.Insert(keys[1], fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keys, nil)
@@ -173,8 +193,12 @@ func TestProofOfAbsenceInternalVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(oneKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err!= nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, nil, [][]byte{ffx32KeyTest}, nil)
@@ -189,8 +213,12 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	if err:=root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil{
+		t.Fatalf("could not insert key: %v", err)
+	}
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	proof, cis, zis, yis, _ := MakeVerkleMultiProof(root, nil, [][]byte{oneKeyTest}, nil)
@@ -204,8 +232,12 @@ func TestProofOfAbsenceLeafVerifyOtherSuffix(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	key := func() []byte {
@@ -225,7 +257,9 @@ func TestProofOfAbsenceStemVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 
 	key := func() []byte {
 		ret, _ := hex.DecodeString("0000000000000000000000000000000000000000100000000000000000000000")
@@ -246,16 +280,22 @@ func BenchmarkProofCalculation(b *testing.B) {
 	root := New()
 	for i := 0; i < 100000; i++ {
 		key := make([]byte, 32)
-		rand.Read(key)
+		if _, err := rand.Read(key); err != nil {
+			b.Fatal(err)
+		}
 		keys[i] = key
-		root.Insert(key, zeroKeyTest, nil)
+		if err := root.Insert(key, zeroKeyTest, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		MakeVerkleMultiProof(root, nil, [][]byte{keys[len(keys)/2]}, nil)
+		if _, _, _, err := MakeVerkleMultiProof(root, nil, [][]byte{keys[len(keys)/2]}, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -264,9 +304,13 @@ func BenchmarkProofVerification(b *testing.B) {
 	root := New()
 	for i := 0; i < 100000; i++ {
 		key := make([]byte, 32)
-		rand.Read(key)
+		if _, err := rand.Read(key); err != nil {
+			b.Fatal(err)
+		}
 		keys[i] = key
-		root.Insert(key, zeroKeyTest, nil)
+		if err := root.Insert(key, zeroKeyTest, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	root.Commit()
@@ -277,7 +321,9 @@ func BenchmarkProofVerification(b *testing.B) {
 
 	cfg := GetConfig()
 	for i := 0; i < b.N; i++ {
-		VerifyVerkleProof(proof, cis, zis, yis, cfg)
+		if ok, err := VerifyVerkleProof(proof, cis, zis, yis, cfg); err != nil || !ok {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -290,9 +336,13 @@ func TestProofSerializationNoAbsentStem(t *testing.T) {
 	root := New()
 	for i := 0; i < leafCount; i++ {
 		key := make([]byte, 32)
-		rand.Read(key)
+		if _, err := rand.Read(key); err != nil {
+			t.Fatalf("could not read random bytes: %v", err)
+		}
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 
 	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, [][]byte{keys[0]}, nil)
@@ -321,7 +371,9 @@ func TestProofSerializationWithAbsentStem(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 	root.Commit()
 
@@ -360,7 +412,9 @@ func TestProofDeserialize(t *testing.T) {
 		key := make([]byte, 32)
 		key[2] = byte(i)
 		keys[i] = key
-		root.Insert(key, fourtyKeyTest, nil)
+		if err := root.Insert(key, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 	root.Commit()
 
@@ -415,7 +469,9 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 	// but does look the same for most of its length.
 	root := New()
 	key, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030000")
-	root.Insert(key, testValue, nil)
+	if err := root.Insert(key, testValue, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
@@ -436,7 +492,9 @@ func TestProofOfAbsenceNoneMultipleStems(t *testing.T) {
 
 	root := New()
 	key, _ := hex.DecodeString("0403030303030303030303030303030303030303030303030303030303030000")
-	root.Insert(key, testValue, nil)
+	if err := root.Insert(key, testValue, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 	root.Commit()
 
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
@@ -619,11 +677,15 @@ func TestStatelessDeserialize(t *testing.T) {
 
 	root := New()
 	for _, k := range [][]byte{zeroKeyTest, oneKeyTest, fourtyKeyTest, ffx32KeyTest} {
-		root.Insert(k, fourtyKeyTest, nil)
+		if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 	root.Commit()
 
-	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keylist{zeroKeyTest, fourtyKeyTest}, nil)
+	if err := proof, _, _, _, err := MakeVerkleMultiProof(root, nil, keylist{zeroKeyTest, fourtyKeyTest}, nil); err != nil {
+		t.Fatalf("could not make proof: %v", err)
+	}
 
 	serialized, statediff, err := SerializeProof(proof)
 	if err != nil {
@@ -659,10 +721,15 @@ func TestStatelessDeserializeMissingChildNode(t *testing.T) {
 
 	root := New()
 	for _, k := range [][]byte{zeroKeyTest, oneKeyTest, ffx32KeyTest} {
-		root.Insert(k, fourtyKeyTest, nil)
+		if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 
-	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keylist{zeroKeyTest, fourtyKeyTest}, nil)
+	proof, _, _, _, err := MakeVerkleMultiProof(root, nil, keylist{zeroKeyTest, fourtyKeyTest}, nil)
+	if err != nil {
+		t.Fatalf("could not make proof: %v", err)
+	}
 
 	serialized, statediff, err := SerializeProof(proof)
 	if err != nil {
@@ -697,7 +764,9 @@ func TestStatelessDeserializeDepth2(t *testing.T) {
 	root := New()
 	key1, _ := hex.DecodeString("0000010000000000000000000000000000000000000000000000000000000000")
 	for _, k := range [][]byte{zeroKeyTest, key1} {
-		root.Insert(k, fourtyKeyTest, nil)
+		if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+			t.Fatalf("could not insert key: %v", err)
+		}
 	}
 	root.Commit()
 

--- a/proof_test.go
+++ b/proof_test.go
@@ -196,7 +196,7 @@ func TestProofOfAbsenceInternalVerify(t *testing.T) {
 	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err!= nil {
+	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	root.Commit()
@@ -213,7 +213,7 @@ func TestProofOfAbsenceLeafVerify(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	if err:=root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil{
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
 	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
@@ -293,7 +293,7 @@ func BenchmarkProofCalculation(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		if _, _, _, err := MakeVerkleMultiProof(root, nil, [][]byte{keys[len(keys)/2]}, nil); err != nil {
+		if _, _, _, _, err := MakeVerkleMultiProof(root, nil, [][]byte{keys[len(keys)/2]}, nil); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -683,7 +683,8 @@ func TestStatelessDeserialize(t *testing.T) {
 	}
 	root.Commit()
 
-	if err := proof, _, _, _, err := MakeVerkleMultiProof(root, nil, keylist{zeroKeyTest, fourtyKeyTest}, nil); err != nil {
+	proof, _, _, _, err := MakeVerkleMultiProof(root, nil, keylist{zeroKeyTest, fourtyKeyTest}, nil)
+	if err != nil {
 		t.Fatalf("could not make proof: %v", err)
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -289,7 +289,9 @@ func NewLeafNode(stem []byte, values [][]byte) (*LeafNode, error) {
 	if err := StemFromBytes(&poly[1], stem); err != nil {
 		return nil, err
 	}
-	banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{c1, c2})
+	if err := banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{c1, c2}); err != nil {
+		return nil, fmt.Errorf("batch mapping to scalar fields: %s", err)
+	}
 
 	return &LeafNode{
 		// depth will be 0, but the commitment calculation
@@ -693,7 +695,10 @@ func (n *InternalNode) Commit() *Point {
 
 		minBatchSize := 4
 		if len(nodes) <= minBatchSize {
-			commitNodesAtLevel(nodes)
+			if err := commitNodesAtLevel(nodes); err != nil {
+				// TODO: make Commit() return an error
+				panic(err)
+			}
 		} else {
 			var wg sync.WaitGroup
 			numBatches := runtime.NumCPU()
@@ -710,7 +715,11 @@ func (n *InternalNode) Commit() *Point {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					commitNodesAtLevel(nodes[start:end])
+					if err := commitNodesAtLevel(nodes[start:end]); err != nil {
+						// TODO: make Commit() return an error
+						panic(err)
+					}
+
 				}()
 			}
 			wg.Wait()
@@ -719,7 +728,7 @@ func (n *InternalNode) Commit() *Point {
 	return n.commitment
 }
 
-func commitNodesAtLevel(nodes []*InternalNode) {
+func commitNodesAtLevel(nodes []*InternalNode) error {
 	points := make([]*Point, 0, 1024)
 	cowIndexes := make([]int, 0, 1024)
 
@@ -741,7 +750,9 @@ func commitNodesAtLevel(nodes []*InternalNode) {
 	}
 
 	// Do a single batch calculation for all the points in this level.
-	banderwagon.BatchMapToScalarField(frs, points)
+	if err := banderwagon.BatchMapToScalarField(frs, points); err != nil {
+		return fmt.Errorf("batch mapping to scalar fields: %s", err)
+	}
 
 	// We calculate the difference between each (new commitment - old commitment) pair, and store it
 	// in the same slice to avoid allocations.
@@ -765,6 +776,8 @@ func commitNodesAtLevel(nodes []*InternalNode) {
 		node.cow = nil
 		node.commitment.Add(node.commitment, cfg.CommitToPoly(poly, 0))
 	}
+
+	return nil
 }
 
 // groupKeys groups a set of keys based on their byte at a given depth.
@@ -845,7 +858,9 @@ func (n *InternalNode) GetProofItems(keys keylist, resolver NodeResolverFn) (*Pr
 			points[i] = new(Point)
 		}
 	}
-	banderwagon.BatchMapToScalarField(fiPtrs[:], points[:])
+	if err := banderwagon.BatchMapToScalarField(fiPtrs[:], points[:]); err != nil {
+		return nil, nil, nil, fmt.Errorf("batch mapping to scalar fields: %s", err)
+	}
 
 	for _, group := range groups {
 		childIdx := offset2key(group[0], n.depth)
@@ -1084,7 +1099,9 @@ func (n *LeafNode) updateLeaf(index byte, value []byte) error {
 
 	// Batch the Fr transformation of the new and old CX.
 	var frs [2]Fr
-	banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{c, &oldC})
+	if err := banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{c, &oldC}); err != nil {
+		return fmt.Errorf("batch mapping to scalar fields: %s", err)
+	}
 
 	// If index is in the first NodeWidth/2 elements, we need to update C1. Otherwise, C2.
 	cxIndex := 2 + int(index)/(NodeWidth/2) // [1, stem, -> C1, C2 <-]
@@ -1137,14 +1154,20 @@ func (n *LeafNode) updateMultipleLeaves(values [][]byte) error {
 	const c2Idx = 3 // [1, stem, C1, ->C2<-]
 
 	if oldC1 != nil && oldC2 != nil { // Case 1.
-		banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1], &frs[2], &frs[3]}, []*Point{n.c1, oldC1, n.c2, oldC2})
+		if err := banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1], &frs[2], &frs[3]}, []*Point{n.c1, oldC1, n.c2, oldC2}); err != nil {
+			return fmt.Errorf("batch mapping to scalar fields: %s", err)
+		}
 		n.updateC(c1Idx, frs[0], frs[1])
 		n.updateC(c2Idx, frs[2], frs[3])
 	} else if oldC1 != nil { // Case 2. (C1 touched)
-		banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c1, oldC1})
+		if err := banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c1, oldC1}); err != nil {
+			return fmt.Errorf("batch mapping to scalar fields: %s", err)
+		}
 		n.updateC(c1Idx, frs[0], frs[1])
 	} else if oldC2 != nil { // Case 2. (C2 touched)
-		banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2})
+		if err := banderwagon.BatchMapToScalarField([]*Fr{&frs[0], &frs[1]}, []*Point{n.c2, oldC2}); err != nil {
+			return fmt.Errorf("batch mapping to scalar fields: %s", err)
+		}
 		n.updateC(c2Idx, frs[0], frs[1])
 	}
 
@@ -1345,7 +1368,9 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 	if err := StemFromBytes(&poly[1], n.stem); err != nil {
 		return nil, nil, nil, fmt.Errorf("error serializing stem '%x': %w", n.stem, err)
 	}
-	banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2})
+	if err := banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2}); err != nil {
+		return nil, nil, nil, fmt.Errorf("batch mapping to scalar fields: %s", err)
+	}
 
 	// First pass: add top-level elements first
 	var hasC1, hasC2 bool

--- a/tree.go
+++ b/tree.go
@@ -1111,7 +1111,7 @@ func (n *LeafNode) updateLeaf(index byte, value []byte) error {
 	return nil
 }
 
-func (n *LeafNode) updateMultipleLeaves(values [][]byte) error {
+func (n *LeafNode) updateMultipleLeaves(values [][]byte) error { // skipcq: GO-R1005
 	var oldC1, oldC2 *Point
 
 	// We iterate the values, and we update the C1 and/or C2 commitments depending on the index.

--- a/tree_test.go
+++ b/tree_test.go
@@ -55,8 +55,7 @@ func TestInsertIntoRoot(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	err := root.Insert(zeroKeyTest, testValue, nil)
-	if err != nil {
+	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
 		t.Fatalf("error inserting: %v", err)
 	}
 
@@ -74,8 +73,12 @@ func TestInsertTwoLeaves(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, testValue, nil)
-	root.Insert(ffx32KeyTest, testValue, nil)
+	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
+	if err := root.Insert(ffx32KeyTest, testValue, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
 
 	leaf0, ok := root.(*InternalNode).children[0].(*LeafNode)
 	if !ok {
@@ -100,8 +103,12 @@ func TestInsertTwoLeavesLastLevel(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, testValue, nil)
-	root.Insert(oneKeyTest, testValue, nil)
+	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
+	if err := root.Insert(oneKeyTest, testValue, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
 
 	leaf, ok := root.(*InternalNode).children[0].(*LeafNode)
 	if !ok {
@@ -120,8 +127,12 @@ func TestGetTwoLeaves(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, testValue, nil)
-	root.Insert(ffx32KeyTest, testValue, nil)
+	if err := root.Insert(zeroKeyTest, testValue, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
+	if err := root.Insert(ffx32KeyTest, testValue, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
 
 	val, err := root.Get(zeroKeyTest, nil)
 	if err != nil {
@@ -161,7 +172,7 @@ func TestFlush1kLeaves(t *testing.T) {
 	t.Parallel()
 
 	n := 1000
-	keys := randomKeysSorted(n)
+	keys := randomKeysSorted(t, n)
 
 	flushCh := make(chan VerkleNode)
 	flush := func(_ []byte, node VerkleNode) {
@@ -170,7 +181,9 @@ func TestFlush1kLeaves(t *testing.T) {
 	go func() {
 		root := New()
 		for _, k := range keys {
-			root.Insert(k, fourtyKeyTest, nil)
+			if err := root.Insert(k, fourtyKeyTest, nil); err != nil {
+				panic(err)
+			}
 		}
 		root.(*InternalNode).Flush(flush)
 		close(flushCh)
@@ -202,19 +215,27 @@ func TestCopy(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	tree.Commit()
 
 	copied := tree.Copy()
 
-	tree.Insert(key3, fourtyKeyTest, nil)
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 
 	if tree.Commit().Equal(copied.Commit()) {
 		t.Fatal("inserting the copy into the original tree updated the copy's commitment")
 	}
 
-	copied.Insert(key3, fourtyKeyTest, nil)
+	if err := copied.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the copy failed: %v", err)
+	}
 
 	if !tree.Commitment().Equal(copied.Commit()) {
 		t.Fatalf("differing final commitments %x != %x", tree.Commitment().Bytes(), copied.Commitment().Bytes())
@@ -229,9 +250,15 @@ func TestCachedCommitment(t *testing.T) {
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	key4, _ := hex.DecodeString("0407000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	oldRoot := tree.Commit().Bytes()
 	oldInternal := tree.(*InternalNode).children[4].(*LeafNode).commitment.Bytes()
 
@@ -239,7 +266,9 @@ func TestCachedCommitment(t *testing.T) {
 		t.Error("root has not cached commitment")
 	}
 
-	tree.Insert(key4, fourtyKeyTest, nil)
+	if err := tree.Insert(key4, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key4 failed: %v", err)
+	}
 	tree.Commit()
 
 	if tree.(*InternalNode).Commitment().Bytes() == oldRoot {
@@ -262,14 +291,24 @@ func TestDelLeaf(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key1p, fourtyKeyTest, nil)
-	tree.Insert(key1pp, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := tree.Insert(key1p, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := tree.Insert(key1pp, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	var init Point
 	init.Set(tree.Commit())
 
-	tree.Insert(key3, fourtyKeyTest, nil)
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	if _, err := tree.Delete(key3, nil); err != nil {
 		t.Error(err)
 	}
@@ -320,8 +359,12 @@ func TestDeleteNonExistent(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key1 failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key2 failed: %v", err)
+	}
 	if _, err := tree.Delete(key3, nil); err != nil {
 		t.Error("should not fail when deleting a non-existent key")
 	}
@@ -336,15 +379,25 @@ func TestDeletePrune(t *testing.T) {
 	key4, _ := hex.DecodeString("0407000000000000000000000000000000000000000000000000000000000000")
 	key5, _ := hex.DecodeString("04070000000000000000000000000000000000000000000000000000000000FF")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key1 failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key2 failed: %v", err)
+	}
 
 	var hashPostKey2, hashPostKey4, completeTreeHash Point
 	hashPostKey2.Set(tree.Commit())
-	tree.Insert(key3, fourtyKeyTest, nil)
-	tree.Insert(key4, fourtyKeyTest, nil)
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key3 failed: %v", err)
+	}
+	if err := tree.Insert(key4, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key4 failed: %v", err)
+	}
 	hashPostKey4.Set(tree.Commit())
-	tree.Insert(key5, fourtyKeyTest, nil)
+	if err := tree.Insert(key5, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key5 failed: %v", err)
+	}
 	completeTreeHash.Set(tree.Commit()) // hash when the tree has received all its keys
 
 	// Delete key5.
@@ -401,9 +454,15 @@ func TestDeleteHash(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key1 failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key2 failed: %v", err)
+	}
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key3 failed: %v", err)
+	}
 	tree.(*InternalNode).FlushAtDepth(0, func(path []byte, vn VerkleNode) {})
 	tree.Commit()
 	if _, err := tree.Delete(key2, nil); err != errDeleteHash {
@@ -418,8 +477,12 @@ func TestDeleteUnequalPath(t *testing.T) {
 	key2, _ := hex.DecodeString("0107000000000000000000000000000000000000000000000000000000000000")
 	key3, _ := hex.DecodeString("0405000000000000000000000000000000000000000000000000000000000000")
 	tree := New()
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key1 failed: %v", err)
+	}
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key3 failed: %v", err)
+	}
 	tree.Commit()
 
 	if _, err := tree.Delete(key2, nil); err != nil {
@@ -439,9 +502,15 @@ func TestDeleteResolve(t *testing.T) {
 	saveNode := func(path []byte, node VerkleNode) {
 		savedNodes[string(path)] = node
 	}
-	tree.Insert(key1, fourtyKeyTest, nil)
-	tree.Insert(key2, fourtyKeyTest, nil)
-	tree.Insert(key3, fourtyKeyTest, nil)
+	if err := tree.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key1 failed: %v", err)
+	}
+	if err := tree.Insert(key2, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key2 failed: %v", err)
+	}
+	if err := tree.Insert(key3, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("inserting into key3 failed: %v", err)
+	}
 	tree.(*InternalNode).FlushAtDepth(0, saveNode)
 	tree.Commit()
 
@@ -478,7 +547,9 @@ func TestConcurrentTrees(t *testing.T) {
 	ch := make(chan *Point)
 	builder := func() {
 		tree := New()
-		tree.Insert(zeroKeyTest, fourtyKeyTest, nil)
+		if err := tree.Insert(zeroKeyTest, fourtyKeyTest, nil); err != nil {
+			panic(err)
+		}
 		ch <- tree.Commit()
 	}
 
@@ -533,8 +604,12 @@ func benchmarkCommitNLeaves(b *testing.B, n int) {
 	for i := 0; i < n; i++ {
 		key := make([]byte, 32)
 		val := make([]byte, 32)
-		rand.Read(key) // skipcq: GSC-G404
-		rand.Read(val) // skipcq: GSC-G404
+		if _, err := rand.Read(key); err != nil {
+			b.Fatalf("failed to generate random key: %v", err)
+		}
+		if _, err := rand.Read(val); err != nil {
+			b.Fatalf("failed to generate random value: %v", err)
+		}
 		kvs[i] = kv{k: key, v: val}
 		sortedKVs[i] = kv{k: key, v: val}
 	}
@@ -571,9 +646,13 @@ func BenchmarkModifyLeaves(b *testing.B) {
 	root := New()
 	for i := 0; i < n; i++ {
 		key := make([]byte, 32)
-		rand.Read(key) // skipcq: GSC-G404
+		if _, err := rand.Read(key); err != nil {
+			b.Fatalf("failed to generate random key: %v", err)
+		}
 		keys[i] = key
-		root.Insert(key, val, nil)
+		if err := root.Insert(key, val, nil); err != nil {
+			b.Fatalf("inserting into key1 failed: %v", err)
+		}
 	}
 	root.Commit()
 
@@ -594,18 +673,20 @@ func BenchmarkModifyLeaves(b *testing.B) {
 	}
 }
 
-func randomKeys(n int) [][]byte {
+func randomKeys(t *testing.T, n int) [][]byte {
 	keys := make([][]byte, n)
 	for i := 0; i < n; i++ {
 		key := make([]byte, 32)
-		rand.Read(key) // skipcq: GSC-G404
+		if _, err := rand.Read(key); err != nil {
+			t.Fatalf("failed to generate random key: %v", err)
+		}
 		keys[i] = key
 	}
 	return keys
 }
 
-func randomKeysSorted(n int) [][]byte {
-	keys := randomKeys(n)
+func randomKeysSorted(t *testing.T, n int) [][]byte {
+	keys := randomKeys(t, n)
 	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
 	return keys
 }
@@ -614,8 +695,12 @@ func TestNodeSerde(t *testing.T) {
 	t.Parallel()
 
 	tree := New()
-	tree.Insert(zeroKeyTest, testValue, nil)
-	tree.Insert(fourtyKeyTest, testValue, nil)
+	if err := tree.Insert(zeroKeyTest, testValue, nil); err != nil {
+		t.Fatalf("inserting into key1 failed: %v", err)
+	}
+	if err := tree.Insert(fourtyKeyTest, testValue, nil); err != nil {
+		t.Fatalf("inserting into key2 failed: %v", err)
+	}
 	origComm := tree.Commit().BytesUncompressed()
 	root := tree.(*InternalNode)
 
@@ -739,11 +824,14 @@ func TestGetResolveFromHash(t *testing.T) {
 		serialized = append(serialized, s...)
 	}
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
-	root.Insert(fourtyKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
+	if err := root.Insert(fourtyKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	root.(*InternalNode).FlushAtDepth(0, flush)
-	err := root.Insert(oneKeyTest, zeroKeyTest, nil)
-	if err != errInsertIntoHash {
+	if err := root.Insert(oneKeyTest, zeroKeyTest, nil); err != errInsertIntoHash {
 		t.Fatal(err)
 	}
 
@@ -793,9 +881,13 @@ func TestInsertIntoHashedNode(t *testing.T) {
 	t.SkipNow()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	root.(*InternalNode).FlushAtDepth(0, func(_ []byte, n VerkleNode) {})
-	root.Insert(fourtyKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(fourtyKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 
 	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != errInsertIntoHash {
 		t.Fatalf("incorrect error type: %v", err)
@@ -840,11 +932,17 @@ func TestToDot(t *testing.T) {
 	//TODO: fix this test when we take a final decision about FlushAtDepth API.
 	t.SkipNow()
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	root.(*InternalNode).FlushAtDepth(0, func(_ []byte, n VerkleNode) {}) // Hash the leaf to ensure HashedNodes display correctly
-	root.Insert(fourtyKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(fourtyKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	fourtytwoKeyTest, _ := hex.DecodeString("4020000000000000000000000000000000000000000000000000000000000000")
-	root.Insert(fourtytwoKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(fourtytwoKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 
 	fmt.Println(ToDot(root))
 
@@ -874,7 +972,9 @@ func TestEmptyCommitment(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(zeroKeyTest, zeroKeyTest, nil)
+	if err := root.Insert(zeroKeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 	root.Commit()
 	pe, _, _, err := root.GetProofItems(keylist{ffx32KeyTest}, nil)
 	if err != nil {
@@ -913,7 +1013,9 @@ func TestLeafToCommsLessThan32(t *testing.T) {
 		value [16]byte
 		p     [2]Fr
 	)
-	leafToComms(p[:], value[:])
+	if err := leafToComms(p[:], value[:]); err != nil {
+		t.Fatalf("error in leafToComms: %v", err)
+	}
 }
 
 func TestLeafToCommsLessThan16(t *testing.T) {
@@ -923,14 +1025,18 @@ func TestLeafToCommsLessThan16(t *testing.T) {
 		value [4]byte
 		p     [2]Fr
 	)
-	leafToComms(p[:], value[:])
+	if err := leafToComms(p[:], value[:]); err != nil {
+		t.Fatalf("error in leafToComms: %v", err)
+	}
 }
 
 func TestGetProofItemsNoPoaIfStemPresent(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(ffx32KeyTest, zeroKeyTest, nil)
+	if err := root.Insert(ffx32KeyTest, zeroKeyTest, nil); err != nil {
+		t.Fatalf("inserting into the original failed: %v", err)
+	}
 
 	// insert two keys that differ from the inserted stem
 	// by one byte.
@@ -995,7 +1101,9 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil)
+	if err := root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil); err != nil {
+		t.Fatalf("error inserting: %s", err)
+	}
 	r1c := root1.Commit()
 
 	var key5, key192 [32]byte
@@ -1003,8 +1111,12 @@ func TestInsertStem(t *testing.T) {
 	copy(key192[:], fourtyKeyTest[:31])
 	key5[31] = 5
 	key192[31] = 192
-	root2.Insert(key5[:], zeroKeyTest, nil)
-	root2.Insert(key192[:], fourtyKeyTest, nil)
+	if err := root2.Insert(key5[:], zeroKeyTest, nil); err != nil {
+		t.Fatalf("error inserting: %s", err)
+	}
+	if err := root2.Insert(key192[:], fourtyKeyTest, nil); err != nil {
+		t.Fatalf("error inserting: %s", err)
+	}
 	r2c := root2.Commit()
 
 	if !r1c.Equal(r2c) {
@@ -1054,7 +1166,9 @@ func TestInsertResolveSplitLeaf(t *testing.T) {
 
 	// Insert a unique leaf and flush it
 	root := New()
-	root.Insert(zeroKeyTest, ffx32KeyTest, nil)
+	if err := root.Insert(zeroKeyTest, ffx32KeyTest, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
 	root.(*InternalNode).Flush(func(_ []byte, node VerkleNode) {
 		l, ok := node.(*LeafNode)
 		if !ok {
@@ -1168,7 +1282,9 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 		}
 
 		v, _ := hex.DecodeString(s)
-		tree.Insert(keys[i], v, nil)
+		if err := tree.Insert(keys[i], v, nil); err != nil {
+			t.Fatalf("error inserting: %v", err)
+		}
 
 		initialVals[string(keys[i])] = v
 	}
@@ -1176,7 +1292,9 @@ func TestRustBanderwagonBlock48(t *testing.T) {
 	// Insert the code chunk that isn't part of the proof
 	missingKey, _ := hex.DecodeString("744f493648c83c5ede1726a0cfbe36d3830fd5b64a820b79ca77fe159335268a")
 	missingVal, _ := hex.DecodeString("133b991f93d230604b1b8daaef64766264736f6c634300080700330000000000")
-	tree.Insert(missingKey, missingVal, nil)
+	if err := tree.Insert(missingKey, missingVal, nil); err != nil {
+		t.Fatalf("error inserting: %v", err)
+	}
 
 	r := tree.Commit()
 
@@ -1438,7 +1556,9 @@ func TestManipulateChildren(t *testing.T) {
 	t.Parallel()
 
 	root := New()
-	root.Insert(ffx32KeyTest, testValue, nil)
+	if err := root.Insert(ffx32KeyTest, testValue, nil); err != nil {
+		t.Fatalf("failed to insert key: %v", err)
+	}
 
 	// Verify that Children() is returning what's expected.
 	ln, ok := root.(*InternalNode).Children()[NodeWidth-1].(*LeafNode)

--- a/tree_test.go
+++ b/tree_test.go
@@ -282,7 +282,7 @@ func TestCachedCommitment(t *testing.T) {
 	}
 }
 
-func TestDelLeaf(t *testing.T) {
+func TestDelLeaf(t *testing.T) { // skipcq: GO-R1005
 	t.Parallel()
 
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")
@@ -370,7 +370,7 @@ func TestDeleteNonExistent(t *testing.T) {
 	}
 }
 
-func TestDeletePrune(t *testing.T) {
+func TestDeletePrune(t *testing.T) { // skipcq: GO-R1005
 	t.Parallel()
 
 	key1, _ := hex.DecodeString("0105000000000000000000000000000000000000000000000000000000000000")


### PR DESCRIPTION
This PR enables the `errcheck` linter, which doesn't allow to ignored returned errors.

Most code changes can be grouped into two buckets:
1. Tests fixes: nothing entirely interesting. I can agree that it can be annoying in some places to make the error checking since some APIs can only fail because of a `resolver`, which is not used in many places. But if these APIs fail for another reason in the future, it suddenly becomes relevant.
2. "Real code" fixes: maybe worth double-checking the code here, but there were many _interesting_ places where errors were ignored.