### PR TITLE
Proof generation panic bug

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -60,14 +60,10 @@ func (vp *VerkleProof) Copy() *VerkleProof {
 		IPAProof:              &IPAProof{},
 	}
 
-	for i := range vp.OtherStems {
-		ret.OtherStems[i] = vp.OtherStems[i]
-	}
-
+	copy(ret.OtherStems, vp.OtherStems)
 	copy(ret.DepthExtensionPresent, vp.DepthExtensionPresent)
-	for i := range vp.CommitmentsByPath {
-		ret.CommitmentsByPath[i] = vp.CommitmentsByPath[i]
-	}
+	copy(ret.CommitmentsByPath, vp.CommitmentsByPath)
+
 	ret.D = vp.D
 
 	if vp.IPAProof != nil {

--- a/proof_test.go
+++ b/proof_test.go
@@ -950,7 +950,7 @@ func TestProofDeduping(t *testing.T) {
 	root.Insert(key1, fourtyKeyTest, nil)
 	root.Insert(key2, fourtyKeyTest, nil)
 
-	proof, _, _, _, _ := MakeVerkleMultiProof(root, keylist{key1, key2})
+	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keylist{key1, key2}, nil)
 
 	serialized, statediff, err := SerializeProof(proof)
 	if err != nil {
@@ -962,16 +962,16 @@ func TestProofDeduping(t *testing.T) {
 		t.Fatalf("error deserializing proof: %v", err)
 	}
 
-	droot, err := TreeFromProof(dproof, root.Commit())
+	droot, err := PreStateTreeFromProof(dproof, root.Commit())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !Equal(droot.Commit(), root.Commit()) {
+	if !droot.Commit().Equal(root.Commit()) {
 		t.Fatal("differing root commitments")
 	}
 
-	if !Equal(droot.(*InternalNode).children[0].Commit(), root.(*InternalNode).children[0].Commit()) {
+	if !droot.(*InternalNode).children[0].Commit().Equal(root.(*InternalNode).children[0].Commit()) {
 		t.Fatal("differing commitment for child #0")
 	}
 }

--- a/proof_test.go
+++ b/proof_test.go
@@ -909,7 +909,9 @@ func TestProofOfAbsenceBorderCase(t *testing.T) {
 	key2, _ := hex.DecodeString("0001000000000000000000000000000000000000000000000000000000000001")
 
 	// Insert an arbitrary value at key 0000000000000000000000000000000000000000000000000000000000000001
-	root.Insert(key1, fourtyKeyTest, nil)
+	if err := root.Insert(key1, fourtyKeyTest, nil); err != nil {
+		t.Fatalf("could not insert key: %v", err)
+	}
 
 	// Generate a proof for the following keys:
 	// - key1, which is present.

--- a/proof_test.go
+++ b/proof_test.go
@@ -940,38 +940,3 @@ func TestProofOfAbsenceBorderCase(t *testing.T) {
 		t.Fatal("differing commitment for child #0")
 	}
 }
-
-func TestProofDeduping(t *testing.T) {
-	root := New()
-
-	key1, _ := hex.DecodeString("00000000000000000000000000000000000000000000000000000000000000fe")
-	key2, _ := hex.DecodeString("01000000000000000000000000000000000000000000000000000000000000fe")
-
-	root.Insert(key1, fourtyKeyTest, nil)
-	root.Insert(key2, fourtyKeyTest, nil)
-
-	proof, _, _, _, _ := MakeVerkleMultiProof(root, nil, keylist{key1, key2}, nil)
-
-	serialized, statediff, err := SerializeProof(proof)
-	if err != nil {
-		t.Fatalf("could not serialize proof: %v", err)
-	}
-
-	dproof, err := DeserializeProof(serialized, statediff)
-	if err != nil {
-		t.Fatalf("error deserializing proof: %v", err)
-	}
-
-	droot, err := PreStateTreeFromProof(dproof, root.Commit())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !droot.Commit().Equal(root.Commit()) {
-		t.Fatal("differing root commitments")
-	}
-
-	if !droot.(*InternalNode).children[0].Commit().Equal(root.(*InternalNode).children[0].Commit()) {
-		t.Fatal("differing commitment for child #0")
-	}
-}

--- a/tree.go
+++ b/tree.go
@@ -1410,7 +1410,7 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 			if len(esses) == 0 {
 				esses = append(esses, extStatusAbsentOther|(n.depth<<3))
 				poass = append(poass, n.stem)
-				pe.Vals = append(pe.Vals, nil)
+				pe.Vals = append(pe.Vals, nil) // jsign comment: there's the cause.
 			}
 			continue
 		}

--- a/tree.go
+++ b/tree.go
@@ -1410,8 +1410,8 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 			if len(esses) == 0 {
 				esses = append(esses, extStatusAbsentOther|(n.depth<<3))
 				poass = append(poass, n.stem)
-				pe.Vals = append(pe.Vals, nil) // jsign comment: there's the cause.
 			}
+			pe.Vals = append(pe.Vals, nil)
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes a panic in proof generation in one of the border-cases of multiple keys landing in the same leaf node.

It also adds a test that reproduced the panic without the fix.

I found this while doing: https://github.com/gballet/go-verkle/pull/383