### PR TITLE
fix absent keys in proofs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -35,6 +35,7 @@ var (
 	errInsertIntoOtherStem    = errors.New("insert splits a stem where it should not happen")
 	errUnknownNodeType        = errors.New("unknown node type detected")
 	errMissingNodeInStateless = errors.New("trying to access a node that is missing from the stateless view")
+	errIsPOAStub              = errors.New("trying to read/write a proof of absence leaf node")
 )
 
 const (

--- a/proof_test.go
+++ b/proof_test.go
@@ -32,6 +32,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/crate-crypto/go-ipa/common"
 )
 
 func TestProofVerifyTwoLeaves(t *testing.T) {
@@ -472,7 +474,7 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 	if err := root.Insert(key, testValue, nil); err != nil {
 		t.Fatalf("could not insert key: %v", err)
 	}
-	root.Commit()
+	rootC := root.Commit()
 
 	ret1, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030300")
 	ret2, _ := hex.DecodeString("0303030303030303030303030303030303030303030303030303030303030301")
@@ -484,6 +486,45 @@ func TestProofOfAbsenceOtherMultipleLeaves(t *testing.T) {
 
 	if len(proof.PoaStems) > 1 {
 		t.Fatalf("invalid number of proof-of-absence stems: %d", len(proof.PoaStems))
+	}
+
+	deserialized, err := PreStateTreeFromProof(proof, rootC)
+	if err != nil {
+		t.Fatalf("error deserializing %v", err)
+	}
+
+	got, err := deserialized.Get(ret1, nil)
+	if err != nil {
+		t.Fatalf("error while trying to read missing value: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("should have returned nil, got: %v", got)
+	}
+
+	// simulate the execution of a tx that creates a leaf at an address that isn't the one that is
+	// proven for absence, but needs to be inserted in the proof-of-absence stem.
+	// It differs from the poa stem here: 🠃
+	ret3, _ := hex.DecodeString("0303030304030303030303030303030303030303030303030303030303030300")
+	err = deserialized.Insert(ret3, testValue, nil)
+	if err != nil {
+		t.Fatalf("error inserting value in proof-of-asbsence stem: %v", err)
+	}
+
+	// check that there are splits up to depth 4
+	node := deserialized.(*InternalNode)
+	for node.depth < 4 {
+		child, ok := node.children[ret3[node.depth]].(*InternalNode)
+		if !ok {
+			t.Fatalf("expected Internal node at depth %d, trie = %s", node.depth, ToDot(deserialized))
+		}
+		node = child
+	}
+
+	if _, ok := node.children[ret3[4]].(*LeafNode); !ok {
+		t.Fatalf("expected leaf node at depth 5, got %v", node.children[ret3[4]])
+	}
+	if ln, ok := node.children[key[4]].(*LeafNode); !ok || !ln.isPOAStub {
+		t.Fatalf("expected unknown node at depth 5, got %v", node.children[key[4]])
 	}
 }
 
@@ -989,5 +1030,29 @@ func TestGenerateProofWithOnlyAbsentKeys(t *testing.T) {
 	// It must pass.
 	if ok, err := VerifyVerkleProof(dproof, pe.Cis, pe.Zis, pe.Yis, cfg); !ok || err != nil {
 		t.Fatalf("reconstructed proof didn't verify: %v", err)
+	}
+
+	// Double-check that if we try to access any key in 40000000000000000000000000000000000000000000000000000000000000{XX}
+	// in the reconstructed tree, we get an error. This LeafNode is only supposed to prove
+	// the absence of 40100000000000000000000000000000000000000000000000000000000000{YY}, so
+	// we don't know anything about any value for slots XX.
+	for i := 0; i < common.VectorLength; i++ {
+		var key [32]byte
+		copy(key[:], presentKey)
+		key[31] = byte(i)
+		if _, err := droot.Get(key[:], nil); err != errIsPOAStub {
+			t.Fatalf("expected ErrPOALeafValue, got %v", err)
+		}
+	}
+
+	// The same applies to trying to insert values in this LeafNode, this shouldn't be allowed since we don't know
+	// anything about C1 or C2 to do a proper updating.
+	for i := 0; i < common.VectorLength; i++ {
+		var key [32]byte
+		copy(key[:], presentKey)
+		key[31] = byte(i)
+		if err := droot.Insert(key[:], zeroKeyTest, nil); err != errIsPOAStub {
+			t.Fatalf("expected ErrPOALeafValue, got %v", err)
+		}
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -385,14 +385,15 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 		// splits.
 		return n.InsertStem(stem, values, resolver)
 	case *LeafNode:
-		if child.isPOAStub {
-			return errIsPOAStub
-		}
-
-		n.cowChild(nChild)
 		if equalPaths(child.stem, stem) {
+			// We can't insert anything into a POA leaf node.
+			if child.isPOAStub {
+				return errIsPOAStub
+			}
+			n.cowChild(nChild)
 			return child.insertMultiple(stem, values)
 		}
+		n.cowChild(nChild)
 
 		// A new branch node has to be inserted. Depending
 		// on the next word in both keys, a recursion into
@@ -535,10 +536,12 @@ func (n *InternalNode) GetStem(stem []byte, resolver NodeResolverFn) ([][]byte, 
 		// splits.
 		return n.GetStem(stem, resolver)
 	case *LeafNode:
-		if child.isPOAStub {
-			return nil, errIsPOAStub
-		}
 		if equalPaths(child.stem, stem) {
+			// We can't return the values since it's a POA leaf node, so we know nothing
+			// about its values.
+			if child.isPOAStub {
+				return nil, errIsPOAStub
+			}
 			return child.values, nil
 		}
 		return nil, nil

--- a/tree.go
+++ b/tree.go
@@ -1419,13 +1419,12 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 		if err := banderwagon.BatchMapToScalarField([]*Fr{&poly[2], &poly[3]}, []*Point{n.c1, n.c2}); err != nil {
 			return nil, nil, nil, fmt.Errorf("batch mapping to scalar fields: %s", err)
 		}
-	} else {
-		if hasC1 {
-			n.c1.MapToScalarField(&poly[2])
-		}
-		if hasC2 {
-			n.c2.MapToScalarField(&poly[3])
-		}
+	} else if hasC1 || hasC2 || n.c1 != nil || n.c2 != nil {
+		// This LeafNode is a proof of absence stub. It must be true that
+		// both c1 and c2 are nil, and that hasC1 and hasC2 are false.
+		// Let's just check that to be sure, since the code below can't use
+		// poly[2] or poly[3].
+		return nil, nil, nil, fmt.Errorf("invalid proof of absence stub")
 	}
 
 	if hasC1 {

--- a/tree.go
+++ b/tree.go
@@ -386,7 +386,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 		return n.InsertStem(stem, values, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
-			// We can't insert anything into a POA leaf node.
+			// We can't insert any values into a POA leaf node.
 			if child.isPOAStub {
 				return errIsPOAStub
 			}


### PR DESCRIPTION
This PR proposes a fix to https://github.com/gballet/go-verkle/pull/400.

It fixes two things:
1. Verifier fix: rebuilding the tree from a proof that has an absent key (other) case.
2. Prover fix: leaf nodes shouldn't open C1/C2 for keys that don't match the leaf steam.