### PR TITLE
add stem to UnkownNode to allow for insertion in proof-of-absence leaf

### DIFF
--- a/unknown.go
+++ b/unknown.go
@@ -43,7 +43,7 @@ func (UnknownNode) Delete([]byte, NodeResolverFn) (bool, error) {
 }
 
 func (un UnknownNode) Get(key []byte, _ NodeResolverFn) ([]byte, error) {
-	if bytes.Equal(un.stem, key[:31]) {
+	if len(un.stem) != 0 && bytes.Equal(un.stem, key[:31]) {
 		return nil, errMissingNodeInStateless
 	}
 	return nil, nil

--- a/unknown.go
+++ b/unknown.go
@@ -31,7 +31,8 @@ import (
 )
 
 type UnknownNode struct {
-	stem []byte // optional stem used for storing an "other" stem in case of a proof of absence
+	stem       []byte // optional stem used for storing an "other" stem in case of a proof of absence
+	commitment *Point
 }
 
 func (UnknownNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -53,7 +54,10 @@ func (n UnknownNode) Commit() *Point {
 	return n.Commitment()
 }
 
-func (UnknownNode) Commitment() *Point {
+func (n UnknownNode) Commitment() *Point {
+	if len(n.stem) != 0 {
+		return n.commitment
+	}
 	var id Point
 	id.SetIdentity()
 	return &id

--- a/unknown_test.go
+++ b/unknown_test.go
@@ -30,9 +30,6 @@ func TestUnknownFuncs(t *testing.T) {
 	if _, err := un.Serialize(); err == nil {
 		t.Errorf("got nil error when serializing a hashed node")
 	}
-	if un != un.Copy() {
-		t.Errorf("copy returned a different node")
-	}
 	if un.toDot("", "") != "" {
 		t.Errorf("toDot returned a non-empty string")
 	}


### PR DESCRIPTION
This is a different approach from #401, but I'm not completely sure that it fixes the exact same bug. TLDR: when PBSS was introduced, we started using `UnknownNode` since there can no longer be a reference to the child in the parent.
Notably, this replaced `HashedNode`s containing a commitment and a stem, which could be used in the event a key `[a, b, c, d, ...]` was read/written to a proof-of-absence stem `[a, b, c, e, ...]`. This can happen during the re-execution of a block, in which a new leaf is created, that shares a prefix with a proof-of-absence stem.

If the `UnkownNode` no longer exists, reading/writing this new key no longer works. To fix this, this PR introduces an optional `stem` field in `UnkownNode`, which purpose is to hold this "proof of absence stem" that is currently missing from the tree, so that one can detect if a read/write is invalid execution, or should return `nil`/insert a new `LeafNode`.

This PR comes with a test, that should be moved to #400.