### PR TITLE
LeafNode Copy() fix

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -1571,6 +1571,7 @@ func (n *LeafNode) Copy() VerkleNode {
 		l.c2 = new(Point)
 		l.c2.Set(n.c2)
 	}
+	l.isPOAStub = n.isPOAStub
 
 	return l
 }


### PR DESCRIPTION
The new field from #400 was missing in the `Copy()` function, creating some problems when building the stateless state tree. (i.e: when we use `Copy()` for pre-post state trees in Geth).