### PR TITLE
tree: getproofitems replace children with resolved node

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -873,6 +873,7 @@ func (n *InternalNode) GetProofItems(keys keylist, resolver NodeResolverFn) (*Pr
 				if err != nil {
 					return nil, nil, nil, err
 				}
+				n.children[i] = c
 			} else {
 				c = child
 			}


### PR DESCRIPTION
This PR makes the resolved nodes from `GetProofItems` replace the `HashedNodes`.

If we don't do this, this method can fail for unresolved nodes despite technically receiving a `resolver` via params. I'll point out the exact situation in the PR comment.