### PR TITLE
proof: fix copying slice bug

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -332,7 +332,8 @@ func DeserializeProof(vp *VerkleProof, statediff StateDiff) (*Proof, error) {
 
 	poaStems = make([][]byte, len(vp.OtherStems))
 	for i, poaStem := range vp.OtherStems {
-		poaStems[i] = poaStem[:]
+		poaStems[i] = make([]byte, len(poaStem))
+		copy(poaStems[i], poaStem[:])
 	}
 
 	extStatus = vp.DepthExtensionPresent


### PR DESCRIPTION
This PR fixes a bug in the proof serialization code.