### PR TITLE
proof: fix statediff copy bug

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -109,6 +109,10 @@ func (sd StateDiff) Copy() StateDiff {
 				ret[i].SuffixDiffs[j].CurrentValue = &[32]byte{}
 				copy((*ret[i].SuffixDiffs[j].CurrentValue)[:], (*sd[i].SuffixDiffs[j].CurrentValue)[:])
 			}
+			if sd[i].SuffixDiffs[j].NewValue != nil {
+				ret[i].SuffixDiffs[j].NewValue = &[32]byte{}
+				copy((*ret[i].SuffixDiffs[j].NewValue)[:], (*sd[i].SuffixDiffs[j].NewValue)[:])
+			}
 		}
 	}
 	return ret


### PR DESCRIPTION
The `Copy()` function missed copying the `newValue` field.

When merged, I'll create a PR in geth kaustinen branch to update `go-verkle`.