### PR TITLE
remove post-state openings in proof

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -138,50 +138,27 @@ func getProofElementsFromTree(preroot, postroot VerkleNode, keys [][]byte, resol
 		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error getting pre-state proof data: %w", err)
 	}
 
-	// List of points and vectors and indices used to generate the IPA proof
-	// If only a pre-state root is available, it's a simple copy, but if both
-	// pre- and post-state root are present, it's merging the two lists.
-	var (
-		proof_cis []*Point
-		proof_fs  [][]Fr
-		proof_zs  []uint8
-		proof_ys  []*Fr
-		postvals  = make([][]byte, len(keys))
-	)
-	for i := range pe.Cis {
-		proof_cis = append(proof_cis, pe.Cis[i])
-		proof_fs = append(proof_fs, pe.Fis[i])
-		proof_ys = append(proof_ys, pe.Yis[i])
-		proof_zs = append(proof_zs, pe.Zis[i])
-	}
-
 	// if a post-state tree is present, merge its proof elements with
 	// those of the pre-state tree, so that they can be proved together.
+	postvals := make([][]byte, len(keys))
 	if postroot != nil {
-		pe_post, _, _, err := GetCommitmentsForMultiproof(postroot, keys, resolver)
-		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error getting post-state proof data: %w", err)
-		}
-
-		for i := range pe_post.Cis {
-			proof_cis = append(proof_cis, pe_post.Cis[i])
-			proof_fs = append(proof_fs, pe_post.Fis[i])
-			proof_ys = append(proof_ys, pe_post.Yis[i])
-			proof_zs = append(proof_zs, pe_post.Zis[i])
-		}
-
+		// keys were sorted already in the above GetcommitmentsForMultiproof.
 		// Set the post values, if they are untouched, leave them `nil`
-		for i, v := range pe.Vals {
-			if !bytes.Equal(v, pe_post.Vals[i]) {
-				postvals[i] = pe_post.Vals[i]
+		for i := range keys {
+			val, err := postroot.Get(keys[i], resolver)
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error getting post-state value for key %x: %w", keys[i], err)
+			}
+			if !bytes.Equal(pe.Vals[i], val) {
+				postvals[i] = val
 			}
 		}
 	}
 
 	// [0:3]: proof elements of the pre-state trie for serialization,
 	// 3: values to be inserted in the post-state trie for serialization
-	// [4:8]: aggregated pre+post elements for proving
-	return pe, es, poas, postvals, proof_cis, proof_fs, proof_ys, proof_zs, nil
+	// [4:8]: aggregated elements for proving
+	return pe, es, poas, postvals, pe.Cis, pe.Fis, pe.Yis, pe.Zis, nil
 }
 
 func MakeVerkleMultiProof(preroot, postroot VerkleNode, keys [][]byte, resolver NodeResolverFn) (*Proof, []*Point, []byte, []*Fr, error) {
@@ -226,10 +203,9 @@ func MakeVerkleMultiProof(preroot, postroot VerkleNode, keys [][]byte, resolver 
 	return proof, pe.Cis, pe.Zis, pe.Yis, nil
 }
 
-// VerifyVerkleProofWithPreAndPostTrie takes a pre-state trie, a post-state trie and a list of keys, and verifies that
-// the provided proof verifies. If the post-state trie is `nil`, the behavior is the same as `VerifyVerkleProof`.
-func VerifyVerkleProofWithPreAndPostTrie(proof *Proof, preroot, postroot VerkleNode) error {
-	_, _, _, _, proof_cis, _, proof_ys, proof_zs, err := getProofElementsFromTree(preroot, postroot, proof.Keys, nil)
+// VerifyVerkleProofWithPreState takes a proof and a trusted tree root and verifies that the proof is valid.
+func VerifyVerkleProofWithPreState(proof *Proof, preroot VerkleNode) error {
+	_, _, _, _, proof_cis, _, proof_ys, proof_zs, err := getProofElementsFromTree(preroot, nil, proof.Keys, nil)
 	if err != nil {
 		return fmt.Errorf("error getting proof elements: %w", err)
 	}

--- a/proof_test.go
+++ b/proof_test.go
@@ -914,6 +914,33 @@ func TestProofVerificationWithPostState(t *testing.T) {
 
 			proof, _, _, _, _ := MakeVerkleMultiProof(root, postroot, data.keystoprove, nil)
 
+		keys:
+			for i := range proof.Keys {
+				// Check that the pre-state value is the one that we originally inserted.
+				for j := range data.keys {
+					if bytes.Equal(proof.Keys[i], data.keys[j]) {
+						if !bytes.Equal(proof.PreValues[i], data.values[j]) {
+							t.Fatalf("pre-state value mismatch for key %x: %x != %x", data.keys[j], proof.PreValues[i], data.values[j])
+						}
+						break
+					}
+				}
+
+				for j := range data.updatekeys {
+					// The the key was updated then check that the post-state value is the updated value.
+					if bytes.Equal(proof.Keys[i], data.updatekeys[j]) {
+						if !bytes.Equal(proof.PostValues[i], data.updatevalues[j]) {
+							t.Fatalf("post-state value mismatch for key %x: %x != %x", data.updatekeys[j], proof.PostValues[i], data.updatevalues[j])
+						}
+						continue keys
+					}
+				}
+				// If the key was not updated then check that the post-state value is null.
+				if proof.PostValues[i] != nil {
+					t.Fatalf("post-state value mismatch for key %x: %x != nil", proof.Keys[i], proof.PostValues[i])
+				}
+			}
+
 			p, diff, err := SerializeProof(proof)
 			if err != nil {
 				t.Fatalf("error serializing proof: %v", err)
@@ -937,6 +964,11 @@ func TestProofVerificationWithPostState(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error recreating post tree: %v", err)
 			}
+			// Check that the reconstructed post-state tree root matches the real tree.
+			if !postroot.Commitment().Equal(dpostroot.Commitment()) {
+				t.Fatalf("differing root commitments %x != %x", dpostroot.Commitment().Bytes(), postroot.Commitment().Bytes())
+			}
+
 			if err = VerifyVerkleProofWithPreState(dproof, dpreroot); err != nil {
 				t.Fatalf("could not verify verkle proof: %v, original: %s reconstructed: %s", err, ToDot(dpreroot), ToDot(dpostroot))
 			}

--- a/proof_test.go
+++ b/proof_test.go
@@ -924,7 +924,7 @@ func TestProofVerificationWithPostState(t *testing.T) {
 				t.Fatalf("error deserializing proof: %v", err)
 			}
 
-			if err = VerifyVerkleProofWithPreAndPostTrie(dproof, root, postroot); err != nil {
+			if err = VerifyVerkleProofWithPreState(dproof, root); err != nil {
 				t.Fatalf("could not verify verkle proof: %v, original: %s reconstructed: %s", err, ToDot(root), ToDot(postroot))
 			}
 
@@ -937,7 +937,7 @@ func TestProofVerificationWithPostState(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error recreating post tree: %v", err)
 			}
-			if err = VerifyVerkleProofWithPreAndPostTrie(dproof, dpreroot, dpostroot); err != nil {
+			if err = VerifyVerkleProofWithPreState(dproof, dpreroot); err != nil {
 				t.Fatalf("could not verify verkle proof: %v, original: %s reconstructed: %s", err, ToDot(dpreroot), ToDot(dpostroot))
 			}
 		})

--- a/proof_test.go
+++ b/proof_test.go
@@ -838,7 +838,7 @@ func TestStatelessDeserializeDepth2(t *testing.T) {
 	}
 }
 
-func TestProofVerificationWithPostState(t *testing.T) {
+func TestProofVerificationWithPostState(t *testing.T) { // skipcq: GO-R1005
 	t.Parallel()
 
 	testlist := []struct {


### PR DESCRIPTION
This PR changes the proof generation to avoid including post-state value openings in Multiproofs.