### PR TITLE
proof: check poas slice usage exhaustion

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -449,6 +449,10 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 		}
 	}
 
+	if len(poas) != 0 {
+		return nil, fmt.Errorf("not all proof of absence stems were used: %d", len(poas))
+	}
+
 	root := NewStatelessInternal(0, rootC).(*InternalNode)
 	comms := proof.Cs
 	for _, p := range paths {


### PR DESCRIPTION
This PR adds an extra check when reconstructing the pre-state tree.

The tree reconstruction must exhaust using all the proof of absence stem list, if that isn't the case it means that the proof contains unused stems which must signal an invalid proof.