### PR TITLE
rename InsertStem and GetStem

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -494,7 +494,7 @@ func PostStateTreeFromStateDiff(preroot VerkleNode, statediff StateDiff) (Verkle
 
 		for _, suffixdiff := range stemstatediff.SuffixDiffs {
 			if /* len(suffixdiff.NewValue) > 0 - this only works for a slice */ suffixdiff.NewValue != nil {
-				// if this value is non-nil, it means InsertStem should be
+				// if this value is non-nil, it means InsertLeafAtStem should be
 				// called, otherwise, skip updating the tree.
 				overwrites = true
 				values[suffixdiff.Suffix] = suffixdiff.NewValue[:]
@@ -504,7 +504,7 @@ func PostStateTreeFromStateDiff(preroot VerkleNode, statediff StateDiff) (Verkle
 		if overwrites {
 			var stem [31]byte
 			copy(stem[:31], stemstatediff.Stem[:])
-			if err := postroot.(*InternalNode).InsertStem(stem[:], values, nil); err != nil {
+			if err := postroot.(*InternalNode).InsertLeafAtStem(stem[:], values, nil); err != nil {
 				return nil, fmt.Errorf("error overwriting value in post state: %w", err)
 			}
 		}

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -494,7 +494,7 @@ func PostStateTreeFromStateDiff(preroot VerkleNode, statediff StateDiff) (Verkle
 
 		for _, suffixdiff := range stemstatediff.SuffixDiffs {
 			if /* len(suffixdiff.NewValue) > 0 - this only works for a slice */ suffixdiff.NewValue != nil {
-				// if this value is non-nil, it means InsertLeafAtStem should be
+				// if this value is non-nil, it means InsertValuesAtStem should be
 				// called, otherwise, skip updating the tree.
 				overwrites = true
 				values[suffixdiff.Suffix] = suffixdiff.NewValue[:]
@@ -504,7 +504,7 @@ func PostStateTreeFromStateDiff(preroot VerkleNode, statediff StateDiff) (Verkle
 		if overwrites {
 			var stem [31]byte
 			copy(stem[:31], stemstatediff.Stem[:])
-			if err := postroot.(*InternalNode).InsertLeafAtStem(stem[:], values, nil); err != nil {
+			if err := postroot.(*InternalNode).InsertValuesAtStem(stem[:], values, nil); err != nil {
 				return nil, fmt.Errorf("error overwriting value in post state: %w", err)
 			}
 		}

--- a/tree.go
+++ b/tree.go
@@ -350,10 +350,10 @@ func (n *InternalNode) cowChild(index byte) {
 func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
 	values := make([][]byte, NodeWidth)
 	values[key[31]] = value
-	return n.InsertLeafAtStem(key[:31], values, resolver)
+	return n.InsertValuesAtStem(key[:31], values, resolver)
 }
 
-func (n *InternalNode) InsertLeafAtStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
+func (n *InternalNode) InsertValuesAtStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
 	nChild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
 
 	switch child := n.children[nChild].(type) {
@@ -383,7 +383,7 @@ func (n *InternalNode) InsertLeafAtStem(stem []byte, values [][]byte, resolver N
 		n.cowChild(nChild)
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.InsertLeafAtStem(stem, values, resolver)
+		return n.InsertValuesAtStem(stem, values, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
 			// We can't insert any values into a POA leaf node.
@@ -407,7 +407,7 @@ func (n *InternalNode) InsertLeafAtStem(stem []byte, values [][]byte, resolver N
 
 		nextWordInInsertedKey := offset2key(stem, n.depth+1)
 		if nextWordInInsertedKey == nextWordInExistingKey {
-			return newBranch.InsertLeafAtStem(stem, values, resolver)
+			return newBranch.InsertValuesAtStem(stem, values, resolver)
 		}
 
 		// Next word differs, so this was the last level.
@@ -421,7 +421,7 @@ func (n *InternalNode) InsertLeafAtStem(stem []byte, values [][]byte, resolver N
 		newBranch.children[nextWordInInsertedKey] = leaf
 	case *InternalNode:
 		n.cowChild(nChild)
-		return child.InsertLeafAtStem(stem, values, resolver)
+		return child.InsertValuesAtStem(stem, values, resolver)
 	default: // It should be an UknownNode.
 		return errUnknownNodeType
 	}
@@ -509,10 +509,10 @@ func (n *InternalNode) CreatePath(path []byte, stemInfo stemInfo, comms []*Point
 	return child.CreatePath(path[1:], stemInfo, comms, values)
 }
 
-// GetLeafAtStem returns the all NodeWidth values of the stem.
+// GetValuesAtStem returns the all NodeWidth values of the stem.
 // The returned slice is internal to the tree, so it *must* be considered readonly
 // for callers.
-func (n *InternalNode) GetLeafAtStem(stem []byte, resolver NodeResolverFn) ([][]byte, error) {
+func (n *InternalNode) GetValuesAtStem(stem []byte, resolver NodeResolverFn) ([][]byte, error) {
 	nchild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
 	switch child := n.children[nchild].(type) {
 	case UnknownNode:
@@ -534,7 +534,7 @@ func (n *InternalNode) GetLeafAtStem(stem []byte, resolver NodeResolverFn) ([][]
 		n.children[nchild] = resolved
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.GetLeafAtStem(stem, resolver)
+		return n.GetValuesAtStem(stem, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
 			// We can't return the values since it's a POA leaf node, so we know nothing
@@ -546,7 +546,7 @@ func (n *InternalNode) GetLeafAtStem(stem []byte, resolver NodeResolverFn) ([][]
 		}
 		return nil, nil
 	case *InternalNode:
-		return child.GetLeafAtStem(stem, resolver)
+		return child.GetValuesAtStem(stem, resolver)
 	default:
 		return nil, errUnknownNodeType
 	}
@@ -664,7 +664,7 @@ func (n *InternalNode) Get(key []byte, resolver NodeResolverFn) ([]byte, error) 
 	if len(key) != StemSize+1 {
 		return nil, fmt.Errorf("invalid key length, expected %d, got %d", StemSize+1, len(key))
 	}
-	stemValues, err := n.GetLeafAtStem(key[:StemSize], resolver)
+	stemValues, err := n.GetValuesAtStem(key[:StemSize], resolver)
 	if err != nil {
 		return nil, err
 	}

--- a/tree.go
+++ b/tree.go
@@ -350,10 +350,10 @@ func (n *InternalNode) cowChild(index byte) {
 func (n *InternalNode) Insert(key []byte, value []byte, resolver NodeResolverFn) error {
 	values := make([][]byte, NodeWidth)
 	values[key[31]] = value
-	return n.InsertStem(key[:31], values, resolver)
+	return n.InsertLeafAtStem(key[:31], values, resolver)
 }
 
-func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
+func (n *InternalNode) InsertLeafAtStem(stem []byte, values [][]byte, resolver NodeResolverFn) error {
 	nChild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
 
 	switch child := n.children[nChild].(type) {
@@ -383,7 +383,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 		n.cowChild(nChild)
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.InsertStem(stem, values, resolver)
+		return n.InsertLeafAtStem(stem, values, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
 			// We can't insert any values into a POA leaf node.
@@ -407,7 +407,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 
 		nextWordInInsertedKey := offset2key(stem, n.depth+1)
 		if nextWordInInsertedKey == nextWordInExistingKey {
-			return newBranch.InsertStem(stem, values, resolver)
+			return newBranch.InsertLeafAtStem(stem, values, resolver)
 		}
 
 		// Next word differs, so this was the last level.
@@ -421,7 +421,7 @@ func (n *InternalNode) InsertStem(stem []byte, values [][]byte, resolver NodeRes
 		newBranch.children[nextWordInInsertedKey] = leaf
 	case *InternalNode:
 		n.cowChild(nChild)
-		return child.InsertStem(stem, values, resolver)
+		return child.InsertLeafAtStem(stem, values, resolver)
 	default: // It should be an UknownNode.
 		return errUnknownNodeType
 	}
@@ -509,10 +509,10 @@ func (n *InternalNode) CreatePath(path []byte, stemInfo stemInfo, comms []*Point
 	return child.CreatePath(path[1:], stemInfo, comms, values)
 }
 
-// GetStem returns the all NodeWidth values of the stem.
+// GetLeafAtStem returns the all NodeWidth values of the stem.
 // The returned slice is internal to the tree, so it *must* be considered readonly
 // for callers.
-func (n *InternalNode) GetStem(stem []byte, resolver NodeResolverFn) ([][]byte, error) {
+func (n *InternalNode) GetLeafAtStem(stem []byte, resolver NodeResolverFn) ([][]byte, error) {
 	nchild := offset2key(stem, n.depth) // index of the child pointed by the next byte in the key
 	switch child := n.children[nchild].(type) {
 	case UnknownNode:
@@ -534,7 +534,7 @@ func (n *InternalNode) GetStem(stem []byte, resolver NodeResolverFn) ([][]byte, 
 		n.children[nchild] = resolved
 		// recurse to handle the case of a LeafNode child that
 		// splits.
-		return n.GetStem(stem, resolver)
+		return n.GetLeafAtStem(stem, resolver)
 	case *LeafNode:
 		if equalPaths(child.stem, stem) {
 			// We can't return the values since it's a POA leaf node, so we know nothing
@@ -546,7 +546,7 @@ func (n *InternalNode) GetStem(stem []byte, resolver NodeResolverFn) ([][]byte, 
 		}
 		return nil, nil
 	case *InternalNode:
-		return child.GetStem(stem, resolver)
+		return child.GetLeafAtStem(stem, resolver)
 	default:
 		return nil, errUnknownNodeType
 	}
@@ -664,7 +664,7 @@ func (n *InternalNode) Get(key []byte, resolver NodeResolverFn) ([]byte, error) 
 	if len(key) != StemSize+1 {
 		return nil, fmt.Errorf("invalid key length, expected %d, got %d", StemSize+1, len(key))
 	}
-	stemValues, err := n.GetStem(key[:StemSize], resolver)
+	stemValues, err := n.GetLeafAtStem(key[:StemSize], resolver)
 	if err != nil {
 		return nil, err
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1101,7 +1101,7 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	if err := root1.(*InternalNode).InsertLeafAtStem(fourtyKeyTest[:31], values, nil); err != nil {
+	if err := root1.(*InternalNode).InsertValuesAtStem(fourtyKeyTest[:31], values, nil); err != nil {
 		t.Fatalf("error inserting: %s", err)
 	}
 	r1c := root1.Commit()
@@ -1149,7 +1149,7 @@ func TestInsertStemTouchingBothHalves(t *testing.T) {
 	newValues := make([][]byte, NodeWidth)
 	newValues[1] = testValue
 	newValues[NodeWidth-2] = testValue
-	if err := root.(*InternalNode).InsertLeafAtStem(zeroKeyTest[:StemSize], newValues, nil); err != nil {
+	if err := root.(*InternalNode).InsertValuesAtStem(zeroKeyTest[:StemSize], newValues, nil); err != nil {
 		t.Fatalf("error inserting stem: %v", err)
 	}
 	root.Commit()

--- a/tree_test.go
+++ b/tree_test.go
@@ -1101,7 +1101,7 @@ func TestInsertStem(t *testing.T) {
 	values[5] = zeroKeyTest
 	values[192] = fourtyKeyTest
 
-	if err := root1.(*InternalNode).InsertStem(fourtyKeyTest[:31], values, nil); err != nil {
+	if err := root1.(*InternalNode).InsertLeafAtStem(fourtyKeyTest[:31], values, nil); err != nil {
 		t.Fatalf("error inserting: %s", err)
 	}
 	r1c := root1.Commit()
@@ -1149,7 +1149,7 @@ func TestInsertStemTouchingBothHalves(t *testing.T) {
 	newValues := make([][]byte, NodeWidth)
 	newValues[1] = testValue
 	newValues[NodeWidth-2] = testValue
-	if err := root.(*InternalNode).InsertStem(zeroKeyTest[:StemSize], newValues, nil); err != nil {
+	if err := root.(*InternalNode).InsertLeafAtStem(zeroKeyTest[:StemSize], newValues, nil); err != nil {
 		t.Fatalf("error inserting stem: %v", err)
 	}
 	root.Commit()


### PR DESCRIPTION
The names `InsertStem` and `GetStem` are confusing, they imply that we are getting the stem, when we are getting the _values_ at that stem.