### PR TITLE
Proof of absence and presence for the same path with nil proof of presence value

### DIFF
--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -412,12 +412,12 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 		return nil, fmt.Errorf("proof of absence stems are not sorted")
 	}
 
-	// We build a cache of stems that have a presence extension status.
-	stemsWithExtPresent := map[string]struct{}{}
+	// We build a cache of paths that have a presence extension status.
+	pathsWithExtPresent := map[string]struct{}{}
 	i := 0
 	for _, es := range proof.ExtStatus {
 		if es&3 == extStatusPresent {
-			stemsWithExtPresent[string(stems[i])] = struct{}{}
+			pathsWithExtPresent[string(stems[i][:es>>3])] = struct{}{}
 		}
 		i++
 	}
@@ -446,14 +446,14 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 			// If that is the case, we don't have to do anything since the corresponding leaf will be
 			// constructed by that extension status (already processed or to be processed).
 			// In other case, we should get the stem from the list of proof of absence stems.
-			if _, ok := stemsWithExtPresent[string(path)]; !ok {
+			if _, ok := pathsWithExtPresent[string(path)]; !ok {
 				si.stem = poas[0]
 				poas = poas[1:]
 			}
 			// All keys that are part of a proof of absence, must contain empty
 			// prestate values. If that isn't the case, the proof is invalid.
 			for i, k := range proof.Keys { // TODO: DoS risk, use map or binary search.
-				if bytes.HasPrefix(k, si.stem) {
+				if bytes.HasPrefix(k, stems[stemIndex]) {
 					if proof.PreValues[i] != nil {
 						return nil, fmt.Errorf("proof of absence (other) stem %x has a value", si.stem)
 					}

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -459,7 +459,7 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 					}
 				}
 			}
-		default:
+		case extStatusPresent:
 			si.values = map[byte][]byte{}
 			si.stem = stems[stemIndex]
 			for i, k := range proof.Keys { // TODO: DoS risk, use map or binary search.
@@ -474,6 +474,8 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 			if si.stem == nil {
 				return nil, fmt.Errorf("no stem found for path %x", path)
 			}
+		default:
+			return nil, fmt.Errorf("invalid extension status: %d", si.stemType)
 		}
 		info[string(path)] = si
 		paths = append(paths, path)
@@ -488,6 +490,9 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 				break
 			}
 		}
+	}
+	if stemIndex != len(stems) {
+		return nil, fmt.Errorf("not all stems were used: %d", len(stems))
 	}
 
 	if len(poas) != 0 {

--- a/proof_ipa.go
+++ b/proof_ipa.go
@@ -401,8 +401,6 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 	if len(stems) != len(proof.ExtStatus) {
 		return nil, fmt.Errorf("invalid number of stems and extension statuses: %d != %d", len(stems), len(proof.ExtStatus))
 	}
-	// stemIndex := 0
-
 	var (
 		info  = map[string]stemInfo{}
 		paths [][]byte
@@ -482,21 +480,7 @@ func PreStateTreeFromProof(proof *Proof, rootC *Point) (VerkleNode, error) { // 
 		}
 		info[string(path)] = si
 		paths = append(paths, path)
-
-		// // Skip over all the stems that share the same path
-		// // to the extension tree. This happens e.g. if two
-		// // stems have the same path, but one is a proof of
-		// // absence and the other one is present.
-		// stemIndex++
-		// for ; stemIndex < len(stems); stemIndex++ {
-		// 	if !bytes.Equal(stems[stemIndex][:depth], path) {
-		// 		break
-		// 	}
-		// }
 	}
-	// if stemIndex != len(stems) {
-	// 	return nil, fmt.Errorf("not all stems were used: %d", len(stems))
-	// }
 
 	if len(poas) != 0 {
 		return nil, fmt.Errorf("not all proof of absence stems were used: %d", len(poas))

--- a/proof_test.go
+++ b/proof_test.go
@@ -1212,10 +1212,8 @@ func TestDoubleProofOfAbsence(t *testing.T) {
 		t.Fatalf("invalid number of proof-of-absence stems: %d", len(proof.PoaStems))
 	}
 
-	// Despite we have two steams proved absent, we only need one extension status.
-	// A single extension status can already regenerate this branch, so the second stem
-	// can identify this branch was recreated.
-	if len(proof.ExtStatus) != 1 {
+	// We need one extension status for each stem.
+	if len(proof.ExtStatus) != 2 {
 		t.Fatalf("invalid number of proof-of-absence stems: %d", len(proof.PoaStems))
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -1464,33 +1464,37 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 		pe.Fis = append(pe.Fis, poly[:])
 	}
 
+	addedAbsentStems := map[string]struct{}{}
+
 	// Second pass: add the cn-level elements
 	for _, key := range keys {
 		pe.ByPath[string(key[:n.depth])] = n.commitment
 
 		// Proof of absence: case of a differing stem.
-		// Add an unopened stem-level node.
 		if !equalPaths(n.stem, key) {
-			// Corner case: don't add the poa stem if it's
-			// already present as a proof-of-absence for a
-			// different key, or for the same key (case of
-			// multiple missing keys being absent).
-			// The list of extension statuses has to be of
-			// length 1 at this level, so skip otherwise.
+			// If this is the first extension status added for this path,
+			// add the proof of absence stem (only once). If later we detect a proof of
+			// presence, we'll clear the list since that proof of presence
+			// will be enough to provide the stem.
 			if len(esses) == 0 {
-				esses = append(esses, extStatusAbsentOther|(n.depth<<3))
 				poass = append(poass, n.stem)
+			}
+			// Add an extension status absent other for this stem.
+			// Note we keep a cache to avoid adding the same stem twice (or more) if
+			// there're multiple keys with the same stem.
+			if _, ok := addedAbsentStems[string(key[:StemSize])]; !ok {
+				esses = append(esses, extStatusAbsentOther|(n.depth<<3))
+				addedAbsentStems[string(key[:StemSize])] = struct{}{}
 			}
 			pe.Vals = append(pe.Vals, nil)
 			continue
 		}
 
-		// corner case (see previous corner case): if a proof-of-absence
-		// stem was found, and it now turns out the same stem is used as
-		// a proof of presence, clear the proof-of-absence list to avoid
-		// redundancy. Note that we don't delete the extension statuses
-		// since that is needed to figure out which is the correct
-		// stem for this path.
+		// As mentioned above, if a proof-of-absence stem was found, and
+		// it now turns out the same stem is used as a proof of presence,
+		// clear the proof-of-absence list to avoid redundancy. Note that
+		// we don't delete the extension statuse since that is needed to
+		// figure out which is the correct stem for this path.
 		if len(poass) > 0 {
 			poass = nil
 		}

--- a/tree.go
+++ b/tree.go
@@ -1488,10 +1488,11 @@ func (n *LeafNode) GetProofItems(keys keylist, _ NodeResolverFn) (*ProofElements
 		// corner case (see previous corner case): if a proof-of-absence
 		// stem was found, and it now turns out the same stem is used as
 		// a proof of presence, clear the proof-of-absence list to avoid
-		// redundancy.
+		// redundancy. Note that we don't delete the extension statuses
+		// since that is needed to figure out which is the correct
+		// stem for this path.
 		if len(poass) > 0 {
 			poass = nil
-			esses = nil
 		}
 
 		var (

--- a/tree_test.go
+++ b/tree_test.go
@@ -1050,8 +1050,8 @@ func TestGetProofItemsNoPoaIfStemPresent(t *testing.T) {
 	if len(poas) != 0 {
 		t.Fatalf("returned %d poas instead of 0", len(poas))
 	}
-	if len(esses) != 1 {
-		t.Fatalf("returned %d extension statuses instead of the expected 1", len(esses))
+	if len(esses) != 2 {
+		t.Fatalf("returned %d extension statuses instead of the expected 2", len(esses))
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1050,8 +1050,8 @@ func TestGetProofItemsNoPoaIfStemPresent(t *testing.T) {
 	if len(poas) != 0 {
 		t.Fatalf("returned %d poas instead of 0", len(poas))
 	}
-	if len(esses) != 2 {
-		t.Fatalf("returned %d extension statuses instead of the expected 2", len(esses))
+	if len(esses) != 3 {
+		t.Fatalf("returned %d extension statuses instead of the expected 3", len(esses))
 	}
 }
 


### PR DESCRIPTION
This is a proposed fix to https://github.com/gballet/go-verkle/pull/413.

At the end of the day, it's almost aligned with the ultra-original Python implementation, which _probably_ did this for the same reason I found #413 problematic. 
