### PR TITLE
[wip] SSZ-optimize proof (type 1)

### DIFF
--- a/proof_json.go
+++ b/proof_json.go
@@ -183,32 +183,38 @@ func (vp *VerkleProof) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// TODO use gencodec if that works
 type stemStateDiffMarshaller struct {
-	Stem        string           `json:"stem"`
-	SuffixDiffs SuffixStateDiffs `json:"suffixDiffs"`
+	Stem     string   `json:"stem"`
+	Suffixes string   `json:"suffixes"`
+	Current  []string `json:"current"`
+	New      []string `json:"new"`
 }
 
 func (ssd StemStateDiff) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&stemStateDiffMarshaller{
-		Stem:        HexToPrefixedString(ssd.Stem[:]),
-		SuffixDiffs: ssd.SuffixDiffs,
+		Stem:     HexToPrefixedString(ssd.Stem[:]),
+		Suffixes: HexToPrefixedString(ssd.Suffixes),
+		// Current:
+		// TODO implement if it makes sense.
 	})
 }
 
 func (ssd *StemStateDiff) UnmarshalJSON(data []byte) error {
-	var aux stemStateDiffMarshaller
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("stemdiff unmarshal error: %w", err)
-	}
+	// var aux stemStateDiffMarshaller
+	// if err := json.Unmarshal(data, &aux); err != nil {
+	// 	return fmt.Errorf("stemdiff unmarshal error: %w", err)
+	// }
 
-	stem, err := PrefixedHexStringToBytes(aux.Stem)
-	if err != nil {
-		return fmt.Errorf("invalid hex string for stem: %w", err)
-	}
-	*ssd = StemStateDiff{
-		SuffixDiffs: aux.SuffixDiffs,
-	}
-	copy(ssd.Stem[:], stem)
+	// stem, err := PrefixedHexStringToBytes(aux.Stem)
+	// if err != nil {
+	// 	return fmt.Errorf("invalid hex string for stem: %w", err)
+	// }
+	// *ssd = StemStateDiff{
+	// 	SuffixDiffs: aux.SuffixDiffs,
+	// }
+	// copy(ssd.Stem[:], stem)
+	// TODO implement if it makes sense
 	return nil
 }
 
@@ -216,59 +222,4 @@ type suffixStateDiffMarshaller struct {
 	Suffix       byte    `json:"suffix"`
 	CurrentValue *string `json:"currentValue"`
 	NewValue     *string `json:"newValue"`
-}
-
-func (ssd SuffixStateDiff) MarshalJSON() ([]byte, error) {
-	var cvstr, nvstr *string
-	if ssd.CurrentValue != nil {
-		tempstr := HexToPrefixedString(ssd.CurrentValue[:])
-		cvstr = &tempstr
-	}
-	if ssd.NewValue != nil {
-		tempstr := HexToPrefixedString(ssd.NewValue[:])
-		nvstr = &tempstr
-	}
-	return json.Marshal(&suffixStateDiffMarshaller{
-		Suffix:       ssd.Suffix,
-		CurrentValue: cvstr,
-		NewValue:     nvstr,
-	})
-}
-
-func (ssd *SuffixStateDiff) UnmarshalJSON(data []byte) error {
-	aux := &suffixStateDiffMarshaller{}
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("suffix diff unmarshal error: %w", err)
-	}
-
-	if aux.CurrentValue != nil && len(*aux.CurrentValue) != 64 && len(*aux.CurrentValue) != 0 && len(*aux.CurrentValue) != 66 {
-		return fmt.Errorf("invalid hex string for current value: %s", *aux.CurrentValue)
-	}
-
-	*ssd = SuffixStateDiff{
-		Suffix: aux.Suffix,
-	}
-
-	if aux.CurrentValue != nil && len(*aux.CurrentValue) != 0 {
-		currentValueBytes, err := PrefixedHexStringToBytes(*aux.CurrentValue)
-		if err != nil {
-			return fmt.Errorf("error decoding hex string for current value: %v", err)
-		}
-
-		ssd.CurrentValue = &[32]byte{}
-		copy(ssd.CurrentValue[:], currentValueBytes)
-	}
-
-	if aux.NewValue != nil && len(*aux.NewValue) != 0 {
-		newValueBytes, err := PrefixedHexStringToBytes(*aux.NewValue)
-		if err != nil {
-			return fmt.Errorf("error decoding hex string for current value: %v", err)
-		}
-
-		ssd.NewValue = &[32]byte{}
-		copy(ssd.NewValue[:], newValueBytes)
-	}
-
-	return nil
 }

--- a/proof_test.go
+++ b/proof_test.go
@@ -568,113 +568,113 @@ func TestProofOfAbsenceNoneMultipleStems(t *testing.T) {
 	}
 }
 
-func TestSuffixStateDiffJSONMarshalUn(t *testing.T) {
-	t.Parallel()
+// func TestSuffixStateDiffJSONMarshalUn(t *testing.T) {
+// 	t.Parallel()
 
-	ssd := SuffixStateDiff{
-		Suffix: 0x41,
-		CurrentValue: &[32]byte{
-			0x10, 0x20, 0x30, 0x40,
-			0x50, 0x60, 0x70, 0x80,
-			0x90, 0xA0, 0xB0, 0xC0,
-			0xD0, 0xE0, 0xF0, 0x00,
-			0x11, 0x22, 0x33, 0x44,
-			0x55, 0x66, 0x77, 0x88,
-			0x99, 0xAA, 0xBB, 0xCC,
-			0xDD, 0xEE, 0xFF, 0x00,
-		},
-	}
+// 	ssd := SuffixStateDiff{
+// 		Suffix: 0x41,
+// 		CurrentValue: &[32]byte{
+// 			0x10, 0x20, 0x30, 0x40,
+// 			0x50, 0x60, 0x70, 0x80,
+// 			0x90, 0xA0, 0xB0, 0xC0,
+// 			0xD0, 0xE0, 0xF0, 0x00,
+// 			0x11, 0x22, 0x33, 0x44,
+// 			0x55, 0x66, 0x77, 0x88,
+// 			0x99, 0xAA, 0xBB, 0xCC,
+// 			0xDD, 0xEE, 0xFF, 0x00,
+// 		},
+// 	}
 
-	expectedJSON := `{"suffix":65,"currentValue":"0x102030405060708090a0b0c0d0e0f000112233445566778899aabbccddeeff00","newValue":null}`
-	actualJSON, err := json.Marshal(ssd)
-	if err != nil {
-		t.Errorf("error marshalling SuffixStateDiff to JSON: %v", err)
-	}
+// 	expectedJSON := `{"suffix":65,"currentValue":"0x102030405060708090a0b0c0d0e0f000112233445566778899aabbccddeeff00","newValue":null}`
+// 	actualJSON, err := json.Marshal(ssd)
+// 	if err != nil {
+// 		t.Errorf("error marshalling SuffixStateDiff to JSON: %v", err)
+// 	}
 
-	if string(actualJSON) != expectedJSON {
-		t.Errorf("JSON output doesn't match expected value.\nExpected: %s\nActual: %s", expectedJSON, string(actualJSON))
-	}
+// 	if string(actualJSON) != expectedJSON {
+// 		t.Errorf("JSON output doesn't match expected value.\nExpected: %s\nActual: %s", expectedJSON, string(actualJSON))
+// 	}
 
-	var actualSSD SuffixStateDiff
-	err = json.Unmarshal(actualJSON, &actualSSD)
-	if err != nil {
-		t.Errorf("error unmarshalling JSON to SuffixStateDiff: %v", err)
-	}
+// 	var actualSSD SuffixStateDiff
+// 	err = json.Unmarshal(actualJSON, &actualSSD)
+// 	if err != nil {
+// 		t.Errorf("error unmarshalling JSON to SuffixStateDiff: %v", err)
+// 	}
 
-	if !reflect.DeepEqual(actualSSD, ssd) {
-		t.Errorf("SuffixStateDiff doesn't match expected value.\nExpected: %+v\nActual: %+v", ssd, actualSSD)
-	}
-}
+// 	if !reflect.DeepEqual(actualSSD, ssd) {
+// 		t.Errorf("SuffixStateDiff doesn't match expected value.\nExpected: %+v\nActual: %+v", ssd, actualSSD)
+// 	}
+// }
 
-func TestStemStateDiffJSONMarshalUn(t *testing.T) {
-	t.Parallel()
+// func TestStemStateDiffJSONMarshalUn(t *testing.T) {
+// 	t.Parallel()
 
-	ssd := StemStateDiff{
-		Stem: [StemSize]byte{10},
-		SuffixDiffs: []SuffixStateDiff{{
-			Suffix: 0x41,
-			CurrentValue: &[32]byte{
-				0x10, 0x20, 0x30, 0x40,
-				0x50, 0x60, 0x70, 0x80,
-				0x90, 0xA0, 0xB0, 0xC0,
-				0xD0, 0xE0, 0xF0, 0x00,
-				0x11, 0x22, 0x33, 0x44,
-				0x55, 0x66, 0x77, 0x88,
-				0x99, 0xAA, 0xBB, 0xCC,
-				0xDD, 0xEE, 0xFF, 0x00,
-			},
-		}},
-	}
+// 	ssd := StemStateDiff{
+// 		Stem: [StemSize]byte{10},
+// 		SuffixDiffs: []SuffixStateDiff{{
+// 			Suffix: 0x41,
+// 			CurrentValue: &[32]byte{
+// 				0x10, 0x20, 0x30, 0x40,
+// 				0x50, 0x60, 0x70, 0x80,
+// 				0x90, 0xA0, 0xB0, 0xC0,
+// 				0xD0, 0xE0, 0xF0, 0x00,
+// 				0x11, 0x22, 0x33, 0x44,
+// 				0x55, 0x66, 0x77, 0x88,
+// 				0x99, 0xAA, 0xBB, 0xCC,
+// 				0xDD, 0xEE, 0xFF, 0x00,
+// 			},
+// 		}},
+// 	}
 
-	expectedJSON := `{"stem":"0x0a000000000000000000000000000000000000000000000000000000000000","suffixDiffs":[{"suffix":65,"currentValue":"0x102030405060708090a0b0c0d0e0f000112233445566778899aabbccddeeff00","newValue":null}]}`
-	actualJSON, err := json.Marshal(ssd)
-	if err != nil {
-		t.Errorf("error marshalling SuffixStateDiff to JSON: %v", err)
-	}
+// 	expectedJSON := `{"stem":"0x0a000000000000000000000000000000000000000000000000000000000000","suffixDiffs":[{"suffix":65,"currentValue":"0x102030405060708090a0b0c0d0e0f000112233445566778899aabbccddeeff00","newValue":null}]}`
+// 	actualJSON, err := json.Marshal(ssd)
+// 	if err != nil {
+// 		t.Errorf("error marshalling SuffixStateDiff to JSON: %v", err)
+// 	}
 
-	if string(actualJSON) != expectedJSON {
-		t.Errorf("JSON output doesn't match expected value.\nExpected: %s\nActual: %s", expectedJSON, string(actualJSON))
-	}
+// 	if string(actualJSON) != expectedJSON {
+// 		t.Errorf("JSON output doesn't match expected value.\nExpected: %s\nActual: %s", expectedJSON, string(actualJSON))
+// 	}
 
-	var actualSSD StemStateDiff
-	err = json.Unmarshal(actualJSON, &actualSSD)
-	if err != nil {
-		t.Errorf("error unmarshalling JSON to StemStateDiff: %v", err)
-	}
+// 	var actualSSD StemStateDiff
+// 	err = json.Unmarshal(actualJSON, &actualSSD)
+// 	if err != nil {
+// 		t.Errorf("error unmarshalling JSON to StemStateDiff: %v", err)
+// 	}
 
-	if !reflect.DeepEqual(actualSSD, ssd) {
-		t.Errorf("SuffixStateDiff doesn't match expected value.\nExpected: %+v\nActual: %+v", ssd, actualSSD)
-	}
-}
+// 	if !reflect.DeepEqual(actualSSD, ssd) {
+// 		t.Errorf("SuffixStateDiff doesn't match expected value.\nExpected: %+v\nActual: %+v", ssd, actualSSD)
+// 	}
+// }
 
-func TestSuffixStateDiffJSONMarshalUnCurrentValueNil(t *testing.T) {
-	t.Parallel()
+// func TestSuffixStateDiffJSONMarshalUnCurrentValueNil(t *testing.T) {
+// 	t.Parallel()
 
-	ssd := SuffixStateDiff{
-		Suffix:       0x41,
-		CurrentValue: nil,
-	}
+// 	ssd := SuffixStateDiff{
+// 		Suffix:       0x41,
+// 		CurrentValue: nil,
+// 	}
 
-	expectedJSON := `{"suffix":65,"currentValue":null,"newValue":null}`
-	actualJSON, err := json.Marshal(ssd)
-	if err != nil {
-		t.Errorf("error marshalling SuffixStateDiff to JSON: %v", err)
-	}
+// 	expectedJSON := `{"suffix":65,"currentValue":null,"newValue":null}`
+// 	actualJSON, err := json.Marshal(ssd)
+// 	if err != nil {
+// 		t.Errorf("error marshalling SuffixStateDiff to JSON: %v", err)
+// 	}
 
-	if string(actualJSON) != expectedJSON {
-		t.Errorf("JSON output doesn't match expected value.\nExpected: %s\nActual: %s", expectedJSON, string(actualJSON))
-	}
+// 	if string(actualJSON) != expectedJSON {
+// 		t.Errorf("JSON output doesn't match expected value.\nExpected: %s\nActual: %s", expectedJSON, string(actualJSON))
+// 	}
 
-	var actualSSD SuffixStateDiff
-	err = json.Unmarshal(actualJSON, &actualSSD)
-	if err != nil {
-		t.Errorf("error unmarshalling JSON to SuffixStateDiff: %v", err)
-	}
+// 	var actualSSD SuffixStateDiff
+// 	err = json.Unmarshal(actualJSON, &actualSSD)
+// 	if err != nil {
+// 		t.Errorf("error unmarshalling JSON to SuffixStateDiff: %v", err)
+// 	}
 
-	if !reflect.DeepEqual(actualSSD, ssd) {
-		t.Errorf("SuffixStateDiff doesn't match expected value.\nExpected: %+v\nActual: %+v", ssd, actualSSD)
-	}
-}
+// 	if !reflect.DeepEqual(actualSSD, ssd) {
+// 		t.Errorf("SuffixStateDiff doesn't match expected value.\nExpected: %+v\nActual: %+v", ssd, actualSSD)
+// 	}
+// }
 
 func TestIPAProofMarshalUnmarshalJSON(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This is the first suggestion by Péter, it replaces the proposed suffix diff format with:

```go
type StemStateDiff struct {
	Stem     [StemSize]byte `json:"stem"`
	SuffixDiffs SuffixStateDiffs `json:"suffixDiffs"`
	Suffixes []byte         `json:"suffixes"`
	Current  [][]byte       `json:"current"`
	New      [][]byte       `json:"new"`
}
```

The size improvement compared to the currently proposed method, is significant:

![image](https://github.com/user-attachments/assets/c3ccc5fd-5c3b-46e6-a665-457db919fb3d)

The comparison is a bit unfair, since the library doesn't support optionals and so the encoding for the default method is greatly inflated. But one could argue that if optionals can not be implemented, then this is the correct size of the witness.
