### PR TITLE
Fixed error handling, removed some typos, and optimized performance by little bit

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -32,12 +32,15 @@ var (
 	errDeleteHash             = errors.New("trying to delete from a hashed subtree")
 	errDeleteMissing          = errors.New("trying to delete a missing group")
 	errDeleteUnknown          = errors.New("trying to delete an out-of-view node")
+	errDeleteEmpty            = errors.New("can't delete an empty node")
 	errReadFromInvalid        = errors.New("trying to read from an invalid child")
 	errSerializeHashedNode    = errors.New("trying to serialize a hashed internal node")
+	errSerializeUnknownNode   = errors.New("trying to serialize a subtree missing from the stateless view")
 	errInsertIntoOtherStem    = errors.New("insert splits a stem where it should not happen")
 	errUnknownNodeType        = errors.New("unknown node type detected")
 	errMissingNodeInStateless = errors.New("trying to access a node that is missing from the stateless view")
 	errIsPOAStub              = errors.New("trying to read/write a proof of absence leaf node")
+	errGetProofItemsUnknownNode = errors.New("can't generate proof items for unknown node")
 )
 
 const (

--- a/empty.go
+++ b/empty.go
@@ -36,7 +36,7 @@ func (Empty) Insert([]byte, []byte, NodeResolverFn) error {
 }
 
 func (Empty) Delete([]byte, NodeResolverFn) (bool, error) {
-	return false, errors.New("cant delete an empty node")
+	return false, errDeleteEmpty
 }
 
 func (Empty) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/hashednode.go
+++ b/hashednode.go
@@ -37,7 +37,7 @@ func (HashedNode) Insert([]byte, []byte, NodeResolverFn) error {
 }
 
 func (HashedNode) Delete([]byte, NodeResolverFn) (bool, error) {
-	return false, errors.New("cant delete a hashed node in-place")
+	return false, errDeleteHash
 }
 
 func (HashedNode) Get([]byte, NodeResolverFn) ([]byte, error) {

--- a/unknown.go
+++ b/unknown.go
@@ -25,8 +25,6 @@
 
 package verkle
 
-import "errors"
-
 type UnknownNode struct{}
 
 func (UnknownNode) Insert([]byte, []byte, NodeResolverFn) error {
@@ -34,7 +32,7 @@ func (UnknownNode) Insert([]byte, []byte, NodeResolverFn) error {
 }
 
 func (UnknownNode) Delete([]byte, NodeResolverFn) (bool, error) {
-	return false, errors.New("cant delete in a subtree missing form a stateless view")
+	return false, errDeleteUnknown
 }
 
 func (UnknownNode) Get([]byte, NodeResolverFn) ([]byte, error) {
@@ -52,11 +50,11 @@ func (UnknownNode) Commitment() *Point {
 }
 
 func (UnknownNode) GetProofItems(Keylist, NodeResolverFn) (*ProofElements, []byte, []Stem, error) {
-	return nil, nil, nil, errors.New("can't generate proof items for unknown node")
+	return nil, nil, nil, errGetProofItemsUnknownNode
 }
 
 func (UnknownNode) Serialize() ([]byte, error) {
-	return nil, errors.New("trying to serialize a subtree missing from the statless view")
+	return nil, errSerializeUnknownNode
 }
 
 func (UnknownNode) Copy() VerkleNode {


### PR DESCRIPTION
This PR addresses three separate issues:

1. Fixed typos in error messages:
   - Changed "cant" to "can't" 
   - Fixed "form a stateless view" to "from a stateless view"
   - Fixed "statless" to "stateless"



2. improved error handling:
   - Added missing sentinel error variables to doc.go
   - Modified implementations to use these central error variables
   - Enables proper error checking with errors.Is() throughout the codebase

3. Fixed O(N²) DoS vulnerability in proof_ipa.go:
   - Added keyStemIndex map for efficient lookups
   - Replaced linear scans with map lookups in 3 locations for optimizing performance
   - Changed performance from O(N²) to O(N) for large proofs(it will prevent DOS)
<img width="788" alt="image" src="https://github.com/user-attachments/assets/68b7647a-e857-415c-adec-3ebb6ed55c06" />


