### PR TITLE
Fix global mutation issue

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -145,7 +145,8 @@ func parseEoAccountNode(serialized []byte, depth byte) (VerkleNode, error) {
 	if err := ln.c1.SetBytesUncompressed(serialized[leafStemOffset+StemSize:leafStemOffset+StemSize+banderwagon.UncompressedSize], true); err != nil {
 		return nil, fmt.Errorf("error setting leaf C1 commitment: %w", err)
 	}
-	ln.c2 = &banderwagon.Identity
+	ln.c2 = new(Point)
+	*ln.c2 = banderwagon.Identity
 	ln.commitment = new(Point)
 	if err := ln.commitment.SetBytesUncompressed(serialized[leafStemOffset+StemSize+banderwagon.UncompressedSize:leafStemOffset+StemSize+banderwagon.UncompressedSize*2], true); err != nil {
 		return nil, fmt.Errorf("error setting leaf root commitment: %w", err)
@@ -171,13 +172,15 @@ func parseSingleSlotNode(serialized []byte, depth byte) (VerkleNode, error) {
 		if err := ln.c1.SetBytesUncompressed(cnCommBytes, true); err != nil {
 			return nil, fmt.Errorf("error setting leaf C1 commitment: %w", err)
 		}
-		ln.c2 = &banderwagon.Identity
+		ln.c2 = new(Point)
+		*ln.c2 = banderwagon.Identity
 	} else {
 		ln.c2 = new(Point)
 		if err := ln.c2.SetBytesUncompressed(cnCommBytes, true); err != nil {
 			return nil, fmt.Errorf("error setting leaf C2 commitment: %w", err)
 		}
-		ln.c1 = &banderwagon.Identity
+		ln.c1 = new(Point)
+		*ln.c1 = banderwagon.Identity
 	}
 	ln.commitment = new(Point)
 	if err := ln.commitment.SetBytesUncompressed(rootCommBytes, true); err != nil {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -231,3 +231,9 @@ func TestLeaf_FirstC2Write_DoesNotMutate_GlobalIdentity(t *testing.T) {
 		t.Fatalf("BUG: first c2 write mutated global banderwagon.Identity")
 	}
 }
+
+func word32(tag byte) []byte {
+	b := make([]byte, 32)
+	b[31] = tag
+	return b
+}


### PR DESCRIPTION
I have been chasing a strange bug that started with nodes getting out of sync when executing a contract (while trying out the pathdb of geth).

It turned out that it only happened if the contract had an array of just the right size to start filling the second half of a verkle node's children. 
After more investigation, it turned out the reason is this global Identity mutation.

I added a test to replicate the issue.